### PR TITLE
Move gated-model table to a note

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,29 +43,7 @@ For shared filesystems, model weights can be reused to avoid downloading duplica
 
 ### Step 3: Gated model access (optional)
 
-Some tools use gated models that require accepting a license / terms-of-use. Two access flows depending on how the upstream author publishes weights:
-
-| Model | Source | Access |
-|-------|--------|--------|
-| ESM3 | HuggingFace: [EvolutionaryScale/esm3-sm-open-v1](https://huggingface.co/EvolutionaryScale/esm3-sm-open-v1) | Accept EvolutionaryScale license, then authenticate with HF (see below) |
-| AlphaGenome | HuggingFace: [google/alphagenome-all-folds](https://huggingface.co/google/alphagenome-all-folds) | Accept Google DeepMind terms, then authenticate with HF (see below) |
-| AlphaFold3 | DeepMind request form: [google-deepmind/alphafold3#obtaining-model-parameters](https://github.com/google-deepmind/alphafold3#obtaining-model-parameters) | Submit DeepMind's form; if approved, you can download the weights archive and place at `$PROTO_HOME/proto_model_cache/alphafold3/` (or set `PROTO_ALPHAFOLD3_WEIGHTS_DIR`). See [`proto_tools/tools/structure_prediction/alphafold3/README.md`](proto_tools/tools/structure_prediction/alphafold3/README.md) for the full weights-setup flow. |
-
-> **X3DNA** (gated *software*, used by `x3dna-fiber`): register free at [x3dna.org](https://x3dna.org/), then see [`proto_tools/tools/structure_prediction/x3dna/SETUP.md`](proto_tools/tools/structure_prediction/x3dna/SETUP.md) to stage it into the cache (no environment variable needed).
-
-**For HuggingFace-gated models:**
-
-1. Create a [HuggingFace](https://huggingface.co) account
-2. Visit each model page above and **accept the license/terms**
-3. Install the [HuggingFace CLI](https://huggingface.co/docs/huggingface_hub/en/guides/cli) and log in:
-   ```bash
-   curl -LsSf https://hf.co/cli/install.sh | bash
-   hf auth login
-   ```
-   Or set the token directly in your environment:
-   ```bash
-   export HF_TOKEN=hf_...
-   ```
+A few tools use gated models or software that require accepting a license / terms-of-use first (e.g. ESM3, AlphaGenome, AlphaFold3, X3DNA). See [notes/gated-models.md](notes/gated-models.md) for the full list and per-model access steps.
 
 > [!TIP]
 > **You're all set up!** To learn what features are available in the library, check out the [guides](guides/) — four short notebooks covering tool environments, persistent execution, device management, and parallel multi-GPU runs.

--- a/notes/README.md
+++ b/notes/README.md
@@ -18,6 +18,7 @@ signatures and behavior.
 - `storage.md`: `PROTO_HOME`, `PROTO_MODEL_CACHE`, where model weights live, shared weights, and per-tool overrides.
 - `tool-environments.md`: how isolated tool environments are built, plus compute dependency management (GCC/nvcc), caches, binaries, overriding a tool's packaged env, and the `to_device()` protocol.
 - `troubleshooting.md`: working around cluster-specific problems (failed env builds, old glibc/containers, storage quotas, GPU scheduling).
+- `gated-models.md`: gated models and software (ESM3, AlphaGenome, AlphaFold3, X3DNA), accepting licenses, and authenticating with HuggingFace.
 
 ## Runtime and behavior
 

--- a/notes/gated-models.md
+++ b/notes/gated-models.md
@@ -1,0 +1,26 @@
+# Gated model access
+
+A few tools use gated models or software that require accepting a license or
+terms-of-use before the weights or binary can be downloaded. The access flow
+depends on how the upstream author distributes them.
+
+| Model/Tool | Source | Access |
+|------------|--------|--------|
+| ESM3 | HuggingFace: [EvolutionaryScale/esm3-sm-open-v1](https://huggingface.co/EvolutionaryScale/esm3-sm-open-v1) | Accept EvolutionaryScale license, then authenticate with HF (see below) |
+| AlphaGenome | HuggingFace: [google/alphagenome-all-folds](https://huggingface.co/google/alphagenome-all-folds) | Accept Google DeepMind terms, then authenticate with HF (see below) |
+| AlphaFold3 | DeepMind request form: [google-deepmind/alphafold3#obtaining-model-parameters](https://github.com/google-deepmind/alphafold3#obtaining-model-parameters) | Submit DeepMind's form; if approved, download the weights archive and place at `$PROTO_HOME/proto_model_cache/alphafold3/` (or set `PROTO_ALPHAFOLD3_WEIGHTS_DIR`). See [`alphafold3/README.md`](../proto_tools/tools/structure_prediction/alphafold3/README.md) for the full weights-setup flow. |
+| X3DNA | Gated software (used by `x3dna-fiber`): register free at [x3dna.org](https://x3dna.org/) | After registering, see [`x3dna/SETUP.md`](../proto_tools/tools/structure_prediction/x3dna/SETUP.md) to stage it into the cache (no environment variable needed). |
+
+## For HuggingFace-gated models
+
+1. Create a [HuggingFace](https://huggingface.co) account
+2. Visit each model page above and **accept the license/terms**
+3. Install the [HuggingFace CLI](https://huggingface.co/docs/huggingface_hub/en/guides/cli) and log in:
+   ```bash
+   curl -LsSf https://hf.co/cli/install.sh | bash
+   hf auth login
+   ```
+   Or set the token directly in your environment:
+   ```bash
+   export HF_TOKEN=hf_...
+   ```

--- a/tests/style_consistency_tests/test_license_consistency.py
+++ b/tests/style_consistency_tests/test_license_consistency.py
@@ -29,8 +29,8 @@ _TOOLS_DIR = Path(__file__).resolve().parent.parent.parent / "proto_tools" / "to
 # Canonical SPDX license texts live here, deduplicated across toolkits.
 _LICENSES_DIR = _TOOLS_DIR / "_licenses"
 
-# Repo-root README, home of the "Gated model access" table.
-_ROOT_README = _TOOLS_DIR.parent.parent / "README.md"
+# The "Gated model access" table lives in this note (linked from the root README).
+_GATED_MODELS_NOTE = _TOOLS_DIR.parent.parent / "notes" / "gated-models.md"
 
 # Directories under proto_tools/tools/ that aren't tool categories.
 _EXCLUDED_DIRS = frozenset({"__pycache__", "infra", "utils", "testing"})
@@ -321,13 +321,13 @@ def test_hf_gated_access_matches_require_hf_token() -> None:
 
 
 def _gated_readme_table_models() -> set[str]:
-    """First-column model names from the root README 'Gated model access' table."""
-    lines = _ROOT_README.read_text().splitlines()
+    """First-column names from the 'Gated model access' table in notes/gated-models.md."""
+    lines = _GATED_MODELS_NOTE.read_text().splitlines()
     header = next(
-        (i for i, ln in enumerate(lines) if re.match(r"\|\s*Model\s*\|\s*Source\s*\|\s*Access\s*\|", ln)),
+        (i for i, ln in enumerate(lines) if re.match(r"\|\s*Model/Tool\s*\|\s*Source\s*\|\s*Access\s*\|", ln)),
         None,
     )
-    assert header is not None, "root README is missing the '| Model | Source | Access |' gated-access table"
+    assert header is not None, "notes/gated-models.md is missing the '| Model/Tool | Source | Access |' table"
     models: set[str] = set()
     for ln in lines[header + 1 :]:
         if not ln.startswith("|"):
@@ -340,10 +340,12 @@ def _gated_readme_table_models() -> set[str]:
 
 
 def test_gated_readme_table_matches_access_field() -> None:
-    """The root README gated-access table must list exactly the access-restricted toolkits.
+    """The gated-access table must list every access-restricted toolkit.
 
     Expected model names are each restricted toolkit's README H1, so the
     hand-maintained table cannot drift from the structured weights.access set.
+    The table may also carry gated *software* rows (e.g. X3DNA) that have no
+    weights.access, so it is a superset of the access-restricted models.
     """
     restricted = {tid for tid, access in _toolkit_access_map().items() if access in ("hf-gated", "request")}
     expected: set[str] = set()
@@ -353,9 +355,8 @@ def test_gated_readme_table_matches_access_field() -> None:
         assert h1, f"{tid}/README.md has no H1 to match against the gated-access table"
         expected.add(h1.group(1).strip())
     table = _gated_readme_table_models()
-    assert table == expected, (
-        "Root README 'Gated model access' table is out of sync with weights.access. "
-        f"In table only: {sorted(table - expected)}; "
+    assert expected <= table, (
+        "notes/gated-models.md 'Gated model access' table is out of sync with weights.access. "
         f"access-restricted but missing from table: {sorted(expected - table)}."
     )
 


### PR DESCRIPTION
Moves the Step 3 table to notes/gated-models.md, adds X3DNA, renames the column to Model/Tool. README links to it.