### PR TITLE
fix(structure): idempotent construction for nested Structure objects (feedback#25)

### DIFF
--- a/proto_tools/entities/structures/structure.py
+++ b/proto_tools/entities/structures/structure.py
@@ -281,6 +281,27 @@ class Structure(BaseModel):
 
         structure_value = data.get("structure")
 
+        # A nested Structure instance under the ``structure`` key — i.e.
+        # ``Structure(structure=<Structure>)`` or ``Structure(**{"structure": <Structure>, ...})``.
+        # This happens when a serialized Structure dict round-trips, or when the API gateway
+        # substitutes a synthetic ``Structure`` for an uploaded asset reference nested inside the
+        # documented ``Structure.model_dump()`` envelope. Unwrap to the inner content and carry its
+        # metadata (outer-provided keys win) so construction is idempotent instead of calling the
+        # str-only helpers below on a ``Structure`` object.
+        if isinstance(structure_value, Structure):
+            inner = structure_value
+            data["structure"] = inner.structure
+            if not data.get("structure_format"):
+                data["structure_format"] = inner.structure_format
+            if not data.get("source"):
+                data["source"] = inner.source
+            current_bft = data.get("b_factor_type")
+            if current_bft in (None, BFactorType.UNSPECIFIED, "unspecified"):
+                data["b_factor_type"] = inner.b_factor_type
+            if data.get("metrics") is None:
+                data["metrics"] = inner.metrics
+            structure_value = data["structure"]
+
         # If structure is an http(s) URL, fetch its content transparently (mirrors the path branch).
         if looks_like_url(structure_value):
             data["structure"] = _fetch_structure_url(structure_value)

--- a/proto_tools/entities/structures/structure.py
+++ b/proto_tools/entities/structures/structure.py
@@ -281,13 +281,8 @@ class Structure(BaseModel):
 
         structure_value = data.get("structure")
 
-        # A nested Structure instance under the ``structure`` key — i.e.
-        # ``Structure(structure=<Structure>)`` or ``Structure(**{"structure": <Structure>, ...})``.
-        # This happens when a serialized Structure dict round-trips, or when the API gateway
-        # substitutes a synthetic ``Structure`` for an uploaded asset reference nested inside the
-        # documented ``Structure.model_dump()`` envelope. Unwrap to the inner content and carry its
-        # metadata (outer-provided keys win) so construction is idempotent instead of calling the
-        # str-only helpers below on a ``Structure`` object.
+        # "structure" already holds a built Structure (a round-trip or re-construction): unwrap to its
+        # inner content and inherit its metadata (outer-provided keys win) so re-construction is idempotent.
         if isinstance(structure_value, Structure):
             inner = structure_value
             data["structure"] = inner.structure

--- a/tests/structure_tests/test_structure.py
+++ b/tests/structure_tests/test_structure.py
@@ -149,6 +149,47 @@ def test_nested_field_typed_structure_accepts_bare_string(test_pdb_file_content)
     assert p.structure.structure == test_pdb_file_content
 
 
+def test_init_accepts_nested_structure_instance(test_pdb_file_content):
+    """Structure(structure=<Structure>) is idempotent rather than crashing.
+
+    Regression for proto-bio/feedback#25: the API gateway substitutes a synthetic
+    ``Structure`` for an uploaded (>1MB) asset ref nested inside the documented
+    ``{"structure": <ref>, ...}`` envelope. Before this fix, the before-validator
+    ran the str-only ``detect_structure_format`` on the ``Structure`` object and
+    raised ``AttributeError: 'Structure' object has no attribute 'split'`` — an
+    unhandled 500 on the tool dispatch path.
+    """
+    inner = Structure(structure=test_pdb_file_content, source="orig.pdb")
+
+    wrapped = Structure(structure=inner)
+    assert wrapped.structure == test_pdb_file_content
+    assert wrapped.structure_format == "pdb"
+    assert wrapped.source == "orig.pdb"  # inner metadata carried over
+
+    # The exact gateway shape: an envelope dict whose ``structure`` is a Structure
+    # object and whose ``structure_format`` is absent (the trigger for detection).
+    from_envelope = Structure.model_validate({"structure": inner})
+    assert from_envelope.structure == test_pdb_file_content
+    assert from_envelope.structure_format == "pdb"
+
+
+def test_nested_field_typed_structure_accepts_structure_instance_envelope(test_pdb_file_content):
+    """A StructureInputBase-style field tolerates the gateway's ``{structure: <Structure>}`` envelope.
+
+    Mirrors how ``proteinmpnn-sample`` / ``esm-if1-*`` / ``dssp`` inputs receive a
+    synthetic ``Structure`` after the >1MB upload's asset ref is swapped in place.
+    """
+
+    class _Pair(BaseModel):
+        sequence: str
+        structure: Structure
+
+    inner = Structure(structure=test_pdb_file_content)
+    p = _Pair.model_validate({"sequence": "MKTL", "structure": {"structure": inner}})
+    assert p.structure.structure_format == "pdb"
+    assert p.structure.structure == test_pdb_file_content
+
+
 # ── Format conversion ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Real user (severity **blocking**) hit `Internal Server Error` running **proteinmpnn-sample** with an uploaded structure. Diagnosed to an unhandled exception on the tools-api dispatch path:

```
File "proto_tools/entities/structures/utils.py", in detect_structure_format
  lines = [line.strip() for line in structure_content.split("\n") ...]
AttributeError: 'Structure' object has no attribute 'split'
```

`Structure._handle_construction` calls the **str-only** `detect_structure_format()` on whatever sits under the `structure` key. When that value is itself a `Structure` object — i.e. `Structure(structure=<Structure>)` / `Structure(**{"structure": <Structure>})` — it crashes. Because it's a raw `AttributeError` (not `ValidationError`/`HTTPException`), FastAPI returns a bare **500** and the gateway refunds the dispatch credit.

### How a `Structure` ends up nested
For a structure **upload >1 MB**, proto-ui sends the asset in the documented `Structure.model_dump()` envelope `{structure: <AssetRef>, ...}`. The tools-api gateway resolves the ref and **substitutes a synthetic `Structure` object** in place → `{structure: <Structure object>}` → `Structure(**that)` → boom.

≤1 MB uploads (sent inline as a content string) and pasted text take a different path and work — which is why it only reproduces with large structures and slipped past the e2e sweep / small test PDBs.

**Scope:** every `StructureInputBase` tool — inverse_folding (`proteinmpnn-*`, `esm-if1-*`, `ligandmpnn-*`, `fampnn-*`), `dssp-secondary-structure`, `pyrosetta-*`.

## Fix

Unwrap a nested `Structure` at the top of `_handle_construction` to its inner content + metadata (outer-provided keys win), before the str-only helpers run. `Structure(structure=<Structure>)` is now idempotent; any residual type mismatch degrades to a clean 422 instead of a 500.

## Tests

- `test_init_accepts_nested_structure_instance` — bare + enveloped nested-Structure shapes, metadata carry-over.
- `test_nested_field_typed_structure_accepts_structure_instance_envelope` — the exact gateway `{structure: <Structure>}` shape on a `StructureInputBase`-style field.
- Full `tests/structure_tests/` (155 passed) + `tests/style_consistency_tests/` (6533 passed) + ruff + mypy green.
- Verified the exact reporter repro (synthetic-swap → `InverseFoldingStructureInput.model_validate`) now passes.

## Follow-up
Requires a submodule pin bump in **proto-tools-api** after merge (its `submodule-check` CI requires pin == proto-tools `main` HEAD). proto-ui ships a complementary defense-in-depth fix (collapse `{structure: <AssetRef>}` → bare ref at submit).