### PR TITLE
fix(germinal): put tool env /lib on LD_LIBRARY_PATH so DAlphaBall loads libgfortran

### DIFF
--- a/proto_tools/tools/binder_design/germinal/standalone/env_vars.txt
+++ b/proto_tools/tools/binder_design/germinal/standalone/env_vars.txt
@@ -3,5 +3,5 @@ HF_TOKEN
 PROTO_GERMINAL_WEIGHTS_DIR
 
 [set]
-LD_LIBRARY_PATH=${VENV_PATH}/cuda_env/lib
+LD_LIBRARY_PATH=${VENV_PATH}/lib:${VENV_PATH}/cuda_env/lib
 XLA_FLAGS=--xla_gpu_cuda_data_dir=${VENV_PATH}/cuda_env

--- a/proto_tools/utils/persistent_worker.py
+++ b/proto_tools/utils/persistent_worker.py
@@ -520,7 +520,7 @@ def _build_subprocess_env(
         env["CONDA_PREFIX"] = str(Path(tool_env_path))
         env["VIRTUAL_ENV"] = str(Path(tool_env_path))
 
-    # Build LD_LIBRARY_PATH: tool [set] > parent LD > conda/lib
+    # Build LD_LIBRARY_PATH: tool [set] > tool env /lib > parent LD > conda/lib
     # (parent LD and conda /lib are skipped if LD_LIBRARY_PATH is in [no_passthrough];
     # in that case just the host driver-lib dir is appended so libcuda.so.1 still resolves)
     ld_parts: list[str] = []
@@ -530,6 +530,18 @@ def _build_subprocess_env(
     existing_ld = env.get("LD_LIBRARY_PATH", "")
     if existing_ld:
         ld_parts.extend(existing_ld.split(":"))
+
+    # The tool env's own lib dir, where conda packages installed into the tool
+    # env (libgfortran, libgomp, etc.) live. Always included — these are the
+    # tool's own shared libs, not host/parent libs gated by [no_passthrough].
+    # The parent conda/lib appended below is the *outer* env (CONDA_PREFIX is
+    # read before being repointed at the tool env), so without this the tool
+    # env's own libs never reach the loader. Required by germinal's DAlphaBall
+    # binary, which dynamically links libgfortran.so.5 from this dir.
+    if tool_env_path:
+        tool_env_lib = str(Path(tool_env_path) / "lib")
+        if tool_env_lib not in ld_parts:
+            ld_parts.append(tool_env_lib)
 
     if not ld_no_passthrough:
         # Parent LD_LIBRARY_PATH (NVIDIA driver, CUDA, module-loaded libs, MKL, etc.)

--- a/proto_tools/utils/persistent_worker.py
+++ b/proto_tools/utils/persistent_worker.py
@@ -531,13 +531,9 @@ def _build_subprocess_env(
     if existing_ld:
         ld_parts.extend(existing_ld.split(":"))
 
-    # The tool env's own lib dir, where conda packages installed into the tool
-    # env (libgfortran, libgomp, etc.) live. Always included — these are the
-    # tool's own shared libs, not host/parent libs gated by [no_passthrough].
-    # The parent conda/lib appended below is the *outer* env (CONDA_PREFIX is
-    # read before being repointed at the tool env), so without this the tool
-    # env's own libs never reach the loader. Required by germinal's DAlphaBall
-    # binary, which dynamically links libgfortran.so.5 from this dir.
+    # The conda/lib appended below is the *outer* env (CONDA_PREFIX is read
+    # before it's repointed at the tool env), so the tool's own shared libs
+    # (libgfortran, libgomp) only reach the loader if we add its /lib here.
     if tool_env_path:
         tool_env_lib = str(Path(tool_env_path) / "lib")
         if tool_env_lib not in ld_parts:

--- a/tests/tool_infra_tests/test_persistent_worker.py
+++ b/tests/tool_infra_tests/test_persistent_worker.py
@@ -994,6 +994,43 @@ def test_ld_library_path_via_set_directive(monkeypatch, tmp_path: Path, conda_pr
     assert ("/opt/conda/lib" in ld_parts) == expect_conda_lib
 
 
+def test_ld_library_path_includes_tool_env_lib(monkeypatch, tmp_path: Path):
+    """The tool env's own /lib (libgfortran, libgomp, …) is on LD_LIBRARY_PATH.
+
+    Regression for germinal's DAlphaBall binary, which dynamically links
+    libgfortran.so.5 installed into the tool env. The auto-appended conda lib
+    is the *outer* CONDA_PREFIX (read before being repointed at the tool env),
+    so without an explicit tool-env entry the tool env's own libs never reach
+    the loader and the binary fails with "libgfortran.so.5: cannot open ...".
+    """
+    monkeypatch.setenv("CONDA_PREFIX", "/opt/conda")
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    env = _build_subprocess_env(device="cpu", tool_env_path=tmp_path)
+
+    ld_parts = env["LD_LIBRARY_PATH"].split(":")
+    tool_env_lib = str(tmp_path / "lib")
+    assert tool_env_lib in ld_parts
+    # Tool env lib precedes the outer conda lib so the tool's own libs win.
+    assert ld_parts.index(tool_env_lib) < ld_parts.index("/opt/conda/lib")
+
+
+def test_ld_library_path_tool_env_lib_present_under_no_passthrough(monkeypatch, tmp_path: Path):
+    """[no_passthrough] strips host LD libs but keeps the tool env's own /lib."""
+    from proto_tools.utils.persistent_worker import _find_driver_lib_dir
+
+    _find_driver_lib_dir.cache_clear()
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/local/cuda/lib64")
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    tool_env_vars = {"passthrough": [], "set": [], "no_passthrough": ["LD_LIBRARY_PATH"]}
+
+    env = _build_subprocess_env(device="cpu", tool_env_path=tmp_path, tool_env_vars=tool_env_vars)
+
+    ld_parts = env.get("LD_LIBRARY_PATH", "").split(":")
+    assert str(tmp_path / "lib") in ld_parts
+    assert "/usr/local/cuda/lib64" not in ld_parts
+
+
 def test_no_passthrough_blocks_whitelisted_var(monkeypatch):
     """[no_passthrough] also blocks whitelisted vars (e.g. HTTP_PROXY) from parent."""
     monkeypatch.setenv("HTTP_PROXY", "http://proxy:8080")

--- a/tests/tool_infra_tests/test_persistent_worker.py
+++ b/tests/tool_infra_tests/test_persistent_worker.py
@@ -995,13 +995,10 @@ def test_ld_library_path_via_set_directive(monkeypatch, tmp_path: Path, conda_pr
 
 
 def test_ld_library_path_includes_tool_env_lib(monkeypatch, tmp_path: Path):
-    """The tool env's own /lib (libgfortran, libgomp, …) is on LD_LIBRARY_PATH.
+    """Tool env's own /lib is on LD_LIBRARY_PATH, ahead of the outer conda lib.
 
-    Regression for germinal's DAlphaBall binary, which dynamically links
-    libgfortran.so.5 installed into the tool env. The auto-appended conda lib
-    is the *outer* CONDA_PREFIX (read before being repointed at the tool env),
-    so without an explicit tool-env entry the tool env's own libs never reach
-    the loader and the binary fails with "libgfortran.so.5: cannot open ...".
+    The auto-appended conda lib is the outer CONDA_PREFIX, not the tool env, so
+    the tool's own libs (libgfortran, libgomp) reach the loader only via this.
     """
     monkeypatch.setenv("CONDA_PREFIX", "/opt/conda")
     monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)


### PR DESCRIPTION
## Problem

`germinal-design` jobs fail in prod with what *looks* like a structure-prediction error, but the real crash is downstream in the **PyRosetta interface-filtering** stage (Modal call `fc-01KVVBPQK5PF6C6SCEA8377EA2`). The chai structure model finishes cleanly; the job dies here:

```
params/DAlphaBall.gcc: error while loading shared libraries:
    libgfortran.so.5: cannot open shared object file: No such file or directory
WARNING!! DALPHABALL output nan at index 18446744073709551488
ERROR:: Exit from: .../core/scoring/packing/surf_vol.cc line: 164  [UtilityExitException]
  run_germinal.py:144 → filter_utils.run_filters → pyrosetta_utils.score_interface:171
  → buns_filter.report_sm(pose)
```

`score_interface` runs Rosetta's `BuriedUnsatHbonds` filter with `dalphaball_sasa="1"`, which shells out to the `DAlphaBall.gcc` binary. That binary is dynamically linked against `libgfortran.so.5` → loader can't find it → returns garbage → fatal `UtilityExitException` → whole `run_germinal.py` subprocess exits 1 → job fails.

## Root cause

`setup.sh` builds `DAlphaBall.gcc` by installing conda-forge `gfortran` into the tool env, so `libgfortran.so.5` lives in **`$VENV_PATH/lib`**. But that dir never reaches the subprocess loader path:

- `env_vars.txt` `[set] LD_LIBRARY_PATH=${VENV_PATH}/cuda_env/lib` overwrites the path to the CUDA sub-prefix only.
- `_build_subprocess_env` then appends `parent_conda_prefix/lib` — but `parent_conda_prefix` is read **before** `CONDA_PREFIX` is repointed at the tool env, so it's the *outer* env's lib, **never the tool env's own `$VENV_PATH/lib`**.

This isn't target-specific — it fires on every design that reaches scoring, so `germinal-design` is broken for all real jobs (and it's one of the three starter examples).

## Fix (two layers)

1. **General** — `_build_subprocess_env` now always includes `{tool_env_path}/lib` on `LD_LIBRARY_PATH` (the tool's own shared libs: libgfortran, libgomp, …), positioned after the tool `[set]` entries and before parent/outer-conda libs. Closes this class of bug for any standalone tool that installs shared libs into its own env and overrides `LD_LIBRARY_PATH`.
2. **Tool-local** — germinal `env_vars.txt` prepends `${VENV_PATH}/lib` to the `[set]` `LD_LIBRARY_PATH` as belt-and-suspenders.

## Tests

Added two regression tests (verified RED before the fix → GREEN after): tool env `/lib` is present on `LD_LIBRARY_PATH` (incl. under `[no_passthrough]`) and ordered before the outer conda lib.

- `tests/tool_infra_tests/test_persistent_worker.py`: 94 passed
- `tests/style_consistency_tests/`: 6533 passed
- `ruff check`: clean

## Verification note

This fixes the env-construction logic + unit-level proof. Full confirmation requires a live germinal-design run on Modal after the env rebuilds (the env hash changes since `env_vars.txt` changed, forcing a rebuild). Recommend a smoke run post-merge/deploy.