### PR TITLE
fix(germinal): install dssp from conda-forge + symlink it in place

### DIFF
--- a/proto_tools/tools/binder_design/germinal/standalone/setup.sh
+++ b/proto_tools/tools/binder_design/germinal/standalone/setup.sh
@@ -92,15 +92,14 @@ elif ! ls "$WEIGHTS_DIR/params"/*.npz >/dev/null 2>&1; then
         | tar x -C "$WEIGHTS_DIR/params"
 fi
 
-# DSSP (secondary-structure assignment) — non-fatal if install fails.
-if [ ! -f "$WEIGHTS_DIR/binaries/dssp" ]; then
-    "$MAMBA_BIN" install -y -p "$VENV_PATH" -c salilab -c conda-forge dssp 2>/dev/null || true
-    if [ -f "$VENV_PATH/bin/mkdssp" ]; then
-        cp "$VENV_PATH/bin/mkdssp" "$WEIGHTS_DIR/binaries/dssp"
-        chmod +x "$WEIGHTS_DIR/binaries/dssp"
-    else
-        echo "WARNING: DSSP install failed; secondary-structure-dependent filters may be skipped."
-    fi
+# DSSP from conda-forge (salilab is dead + linked an unavailable boost 1.73). Symlink in place —
+# copying to $WEIGHTS_DIR breaks RPATH — and always reinstall so its libs stay in the env.
+"$MAMBA_BIN" install -y -p "$VENV_PATH" -c conda-forge dssp 2>/dev/null || true
+mkdir -p "$GERMINAL_DIR/params"
+if [ -f "$VENV_PATH/bin/mkdssp" ]; then
+    ln -sf "$VENV_PATH/bin/mkdssp" "$GERMINAL_DIR/params/dssp"
+else
+    echo "WARNING: DSSP install failed; secondary-structure-dependent filters may be skipped."
 fi
 
 # DAlphaBall (buried-unsat-hbond computation) — compiled from source, non-fatal.
@@ -121,10 +120,9 @@ if [ ! -f "$WEIGHTS_DIR/binaries/DAlphaBall.gcc" ]; then
     ) || echo "WARNING: DAlphaBall build pipeline failed; continuing without it."
 fi
 
-# Symlink binaries so Germinal's relative `params/dssp` / `params/DAlphaBall.gcc` resolve at runtime
-# (inference.py spawns run_germinal.py with cwd=$GERMINAL_DIR).
+# Symlink DAlphaBall so Germinal's relative `params/DAlphaBall.gcc` resolves at runtime
+# (inference.py spawns run_germinal.py with cwd=$GERMINAL_DIR; dssp is symlinked above).
 mkdir -p "$GERMINAL_DIR/params"
-[ -f "$WEIGHTS_DIR/binaries/dssp" ] && ln -sf "$WEIGHTS_DIR/binaries/dssp" "$GERMINAL_DIR/params/dssp"
 [ -f "$WEIGHTS_DIR/binaries/DAlphaBall.gcc" ] && \
     ln -sf "$WEIGHTS_DIR/binaries/DAlphaBall.gcc" "$GERMINAL_DIR/params/DAlphaBall.gcc"
 


### PR DESCRIPTION
## Summary

Fixes [proto-bio/feedback#29](https://github.com/proto-bio/feedback/issues/29) — a `germinal-design` job that died with only tqdm progress bars visible. I recovered the full stored result from Modal (`FunctionCall.from_id("fc-01KW0VG7Z5677Q50345WQYSQDC").get()`); the real traceback was buried at the tail:

```
params/dssp: error while loading shared libraries:
libboost_thread.so.1.73.0: cannot open shared object file: No such file or directory
...
  File ".../germinal/filters/filter_utils.py", line 161, in run_filters
    ss_content = utils.calc_ss_percentage(...)
subprocess.CalledProcessError: Command '['params/dssp', '--version']' returned non-zero exit status 127.
```

The trajectory ran fine; it died in the **post-design secondary-structure filter**, when Germinal shells out to its bundled `params/dssp`. **Every campaign reaching the SS filter fails — the tool can't complete a run today.**

## Root cause (two compounding bugs, both reproduced)

**1. Channel rot — the boost the binary needs no longer exists.** The salilab `dssp` build links `libboost_thread.so.1.73.0`, but conda-forge now resolves boost to **1.91**, so that SONAME is never installed — no search-path trick can find a library that isn't there. `-c salilab` doesn't even solve anymore.

**2. Binary copied out of its env.** `setup.sh` copied conda `mkdssp` from `$VENV_PATH` into the persistent `$WEIGHTS_DIR` (`/weights`) volume, which detaches it from its libs (RPATH `$ORIGIN/../lib`), and the `if [ ! -f .../dssp ]` cache guard then skipped reinstalling on every later env rebuild.

### Why the earlier `LD_LIBRARY_PATH` fix (#8) didn't help
#8 added `${VENV_PATH}/lib` to `LD_LIBRARY_PATH` and **was already deployed to `main`** (proto-tools-api v0.0.16 / v26, 2026-06-24, pinning `a358e263f`). The issue job ran 2026-06-26 **on that image** and still failed — proof the matching boost simply isn't present to be found.

## Fix

```bash
# DSSP from conda-forge (salilab is dead + linked an unavailable boost 1.73). Symlink in place —
# copying to $WEIGHTS_DIR breaks RPATH — and always reinstall so its libs stay in the env.
"$MAMBA_BIN" install -y -p "$VENV_PATH" -c conda-forge dssp 2>/dev/null || true
mkdir -p "$GERMINAL_DIR/params"
if [ -f "$VENV_PATH/bin/mkdssp" ]; then
    ln -sf "$VENV_PATH/bin/mkdssp" "$GERMINAL_DIR/params/dssp"
else
    echo "WARNING: DSSP install failed; secondary-structure-dependent filters may be skipped."
fi
```

- **conda-forge channel** → `mkdssp 4.6.1` with a matched boost (1.90), `ldd` clean. (salilab was already a v4-era mkdssp, so this stays in the same DSSP v4 family.)
- **Symlink in place** to `$VENV_PATH/bin/mkdssp` so `$ORIGIN/../lib` resolves the env libs via RPATH — no reliance on `LD_LIBRARY_PATH`.
- **Always reinstall** (drop the `$WEIGHTS_DIR` cache guard) so the matched libs land in the freshly-rebuilt env every time.

**Not changed:** DAlphaBall keeps its `$WEIGHTS_DIR` staging (expensive source compile; its libs come via other packages + #8's `LD_LIBRARY_PATH`). Flagged for an `ldd` audit at deploy.

## Verification — reproduced the bug and the fix on Linux/conda

Ran an isolated Modal repro (debian + micromamba), mirroring setup.sh's layout (`mkdssp` in env `bin`, boost in env `lib`, RPATH `$ORIGIN/../lib`):

| Install | `ldd mkdssp` | `mkdssp --version` |
|---|---|---|
| `-c salilab -c conda-forge dssp` (old) | `libboost_thread.so.1.73.0 => not found` | exit 127 |
| `-c conda-forge dssp`, **copied out** to `/weights` | env libs not found | exit 127 |
| `-c conda-forge dssp`, **symlinked in place** (this PR) | clean | **exit 0 → `mkdssp version 4.6.1`** |

- [x] `pytest tests/binder_design_tests/test_germinal_design.py` → 9 passed, 3 skipped (GPU/slow)
- [x] `pytest tests/style_consistency_tests/` → 6533 passed (CI gate)
- [x] `bash -n setup.sh` clean
- [ ] **Deploy-time (GPU):** rebuild `proto-tools-germinal` on staging off this commit, confirm a minimal `germinal-design` clears the SS filter; `ldd` DAlphaBall to see if it needs the same channel/symlink treatment.

## Follow-up (not in this PR)

- Bump the `proto-tools` submodule in proto-tools-api to this commit, then manually redeploy `proto-tools-germinal` to `staging` then `main` (the broken `/weights/binaries/dssp` becomes inert).

https://claude.ai/code/session_01JPWFtbX3uzUzx2EQRYzoyD