### PR TITLE
Expose LigandMPNN packed structures and scoring options

### DIFF
--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
@@ -69,6 +69,8 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
         ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å) for the ligand-interface
             recovery score.
+        sc_num_denoising_steps (int): Number of side-chain denoising steps for the reference packer.
+        sc_num_samples (int): Number of side-chain samples for the reference packer.
     """
 
     model_type: LigandMPNNModelType = ConfigField(

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
@@ -12,6 +12,7 @@ from pydantic import Field
 
 from proto_tools.entities.complex import Chain
 from proto_tools.entities.ligands import Fragment
+from proto_tools.entities.structures import Structure
 from proto_tools.tools.inverse_folding.shared_data_models import (
     DesignedComplex,
     DesignSet,
@@ -97,7 +98,7 @@ class LigandMPNNDesignMetrics(Metrics):
     Metrics documented in ``metric_spec``:
         sequence_recovery (float): Fraction of chains_to_redesign residues
             matching the input structure's reference sequence (0.0-1.0).
-            Always present.
+            Present when at least one redesigned residue is scored.
         ligand_interface_sequence_recovery (float): Recovery restricted to
             ligand-interface residues (0.0-1.0). Present only when a ligand
             interface is present; ``NaN`` or absent when the input structure
@@ -106,7 +107,7 @@ class LigandMPNNDesignMetrics(Metrics):
 
     metric_spec: ClassVar[dict[str, MetricSpec]] = {
         "sequence_recovery": {
-            "availability": "always",
+            "availability": "when at least one redesigned residue is scored",
             "type": "float",
             "min": 0.0,
             "max": 1.0,
@@ -146,6 +147,11 @@ class LigandMPNNDesign(DesignedComplex):
         title="Metrics",
         description="Per-design recovery metrics for this complex.",
     )
+    structure: Structure | None = Field(
+        default=None,
+        title="Designed Structure",
+        description="Optional LigandMPNN full-atom structure for this design.",
+    )
 
 
 class LigandMPNNDesignSet(DesignSet):
@@ -174,6 +180,17 @@ class LigandMPNNSampleOutput(InverseFoldingOutput):
         title="Design Sets",
         description="One LigandMPNNDesignSet per input structure, in input order.",
     )
+
+
+def _fixed_positions_cover_structure(inp: InverseFoldingStructureInput) -> bool:
+    """Return whether fixed_positions cover every residue in every structure chain."""
+    if inp.fixed_positions is None:
+        return False
+    fixed = inp.fixed_positions.chains
+    for chain_id in inp.structure.get_chain_ids():
+        if set(fixed.get(chain_id, [])) != set(inp.structure.get_chain_positions(chain_id)):
+            return False
+    return True
 
 
 # ============================================================================
@@ -238,16 +255,18 @@ def run_ligandmpnn_sample(
         all_chain_sequences: list[list[dict[str, str]]] = []
         all_recovery: list[float] = []
         all_interface_recovery: list[float] = []
+        all_pdb_strings: list[str | None] = []
         remaining = config.num_sequences_per_structure
         # Materialize the Structure to a tempfile once per input — reused across chunks.
         with inp.structure.temp_file() as pdb_path:
             while remaining > 0:
                 chunk = min(config.batch_size, remaining)  # type: ignore[type-var]
+                all_positions_fixed = _fixed_positions_cover_structure(inp)
                 input_dict = {
                     "operation": "sample",
                     "pdb_path": str(pdb_path),
                     "chain_ids": inp.chain_ids_to_redesign,
-                    "chains_explicitly_set": inp.chains_to_redesign is not None,
+                    "chains_explicitly_set": inp.chains_to_redesign is not None and not all_positions_fixed,
                     "batch_size": chunk,
                     "temperature": config.temperature,
                     "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
@@ -269,15 +288,16 @@ def run_ligandmpnn_sample(
                 all_chain_sequences.extend(result["chain_sequences"])
                 all_recovery.extend(m["sequence_recovery"] for m in result["metrics"])
                 all_interface_recovery.extend(m["ligand_interface_sequence_recovery"] for m in result["metrics"])
+                all_pdb_strings.extend(result.get("pdb_strings", [None] * len(result["chain_sequences"])))
                 dispatch_idx += 1
                 remaining -= chunk  # type: ignore[operator]
 
         # The standalone emits ordered per-chain (chain_id, sequence) pairs.
-        redesigned_ids = set(inp.chain_ids_to_redesign)
+        redesigned_ids = set() if _fixed_positions_cover_structure(inp) else set(inp.chain_ids_to_redesign)
 
         complexes: list[LigandMPNNDesign] = []
-        for chain_seqs, recovery, interface_recovery in zip(
-            all_chain_sequences, all_recovery, all_interface_recovery, strict=True
+        for chain_seqs, recovery, interface_recovery, pdb_string in zip(
+            all_chain_sequences, all_recovery, all_interface_recovery, all_pdb_strings, strict=True
         ):
             chains: list[Chain | Fragment] = [Chain(id=entry["id"], sequence=entry["sequence"]) for entry in chain_seqs]
             designed: list[bool] = [entry["id"] in redesigned_ids for entry in chain_seqs]
@@ -286,11 +306,16 @@ def run_ligandmpnn_sample(
                     chains=chains,
                     designed=designed,
                     metrics=LigandMPNNDesignMetrics(
-                        sequence_recovery=recovery,
+                        sequence_recovery=(recovery if math.isfinite(recovery) else None),
                         # Foundry returns NaN when no ligand interface; route to None so the conditional key is dropped.
                         ligand_interface_sequence_recovery=(
                             interface_recovery if math.isfinite(interface_recovery) else None
                         ),
+                    ),
+                    structure=(
+                        Structure(structure=pdb_string, structure_format="pdb", source="ligandmpnn-sample")
+                        if pdb_string
+                        else None
                     ),
                 )
             )

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
@@ -34,6 +34,7 @@ LigandMPNNModelType = Literal[
     # "per_residue_label_membrane_mpnn",
     # "global_label_membrane_mpnn",
 ]
+LigandMPNNBackend = Literal["foundry", "reference"]
 
 
 # ============================================================================
@@ -56,6 +57,14 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         excluded_amino_acids (list[AminoAcid] | None): One-letter codes of amino acids to exclude.
         seed (int): Random seed to use for sampling.
         model_type (LigandMPNNModelType): LigandMPNN variant to load.
+        backend (LigandMPNNBackend): Inference backend. ``"foundry"`` uses the
+            managed Foundry LigandMPNN implementation; ``"reference"`` uses a
+            local reference LigandMPNN checkout for compatibility experiments.
+        checkpoint_path (str | None): Optional explicit LigandMPNN checkpoint path.
+        reference_backend_path (str | None): Path to a checkout containing the
+            reference ``ligandmpnn`` Python package when ``backend="reference"``.
+        packer_checkpoint_path (str | None): Side-chain packer checkpoint used
+            by the reference backend to emit sequence-consistent PDB structures.
         ligand_mpnn_use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
         ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
         ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å) for the ligand-interface
@@ -72,6 +81,30 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         title="Use Ligand Atom Context",
         default=True,
         description="Encode ligand atom context in the message-passing graph",
+    )
+    backend: LigandMPNNBackend = ConfigField(
+        title="Backend",
+        default="foundry",
+        description="Inference backend: managed Foundry implementation or local reference implementation.",
+        reload_on_change=True,
+    )
+    checkpoint_path: str | None = ConfigField(
+        title="Checkpoint Path",
+        default=None,
+        description="Optional explicit LigandMPNN checkpoint path.",
+        reload_on_change=True,
+    )
+    reference_backend_path: str | None = ConfigField(
+        title="Reference Backend Path",
+        default=None,
+        description="Path to a local reference LigandMPNN checkout when backend='reference'.",
+        reload_on_change=True,
+    )
+    packer_checkpoint_path: str | None = ConfigField(
+        title="Packer Checkpoint Path",
+        default=None,
+        description="Optional side-chain packer checkpoint path for the reference backend.",
+        reload_on_change=True,
     )
     ligand_mpnn_use_side_chain_context: bool = ConfigField(
         title="Use Sidechain Context",
@@ -90,6 +123,18 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         description="Single-letter codes of amino acids to exclude (e.g. ['C'] to forbid cysteine)",
         examples=[["C"]],
     )
+    sc_num_denoising_steps: int = ConfigField(
+        title="Sidechain Denoising Steps",
+        default=8,
+        ge=1,
+        description="Number of side-chain denoising steps for the reference backend packer.",
+    )
+    sc_num_samples: int = ConfigField(
+        title="Sidechain Samples",
+        default=1,
+        ge=1,
+        description="Number of side-chain samples for the reference backend packer.",
+    )
 
 
 class LigandMPNNDesignMetrics(Metrics):
@@ -103,6 +148,9 @@ class LigandMPNNDesignMetrics(Metrics):
             ligand-interface residues (0.0-1.0). Present only when a ligand
             interface is present; ``NaN`` or absent when the input structure
             has no ligand interface.
+        pmpnn (float): Mean sequence probability reported by compatible
+            LigandMPNN backends. Higher values indicate higher model
+            probability for the emitted sequence.
     """
 
     metric_spec: ClassVar[dict[str, MetricSpec]] = {
@@ -115,6 +163,13 @@ class LigandMPNNDesignMetrics(Metrics):
         },
         "ligand_interface_sequence_recovery": {
             "availability": "when a ligand interface is present",
+            "type": "float",
+            "min": 0.0,
+            "max": 1.0,
+            "better_values_are": "higher",
+        },
+        "pmpnn": {
+            "availability": "when emitted by the selected backend",
             "type": "float",
             "min": 0.0,
             "max": 1.0,
@@ -255,6 +310,7 @@ def run_ligandmpnn_sample(
         all_chain_sequences: list[list[dict[str, str]]] = []
         all_recovery: list[float] = []
         all_interface_recovery: list[float] = []
+        all_pmpnn: list[float | None] = []
         all_pdb_strings: list[str | None] = []
         remaining = config.num_sequences_per_structure
         # Materialize the Structure to a tempfile once per input — reused across chunks.
@@ -275,9 +331,15 @@ def run_ligandmpnn_sample(
                     "device": config.device,
                     "verbose": config.verbose,
                     "model_type": config.model_type,
+                    "backend": config.backend,
+                    "checkpoint_path": config.checkpoint_path,
+                    "reference_backend_path": config.reference_backend_path,
+                    "packer_checkpoint_path": config.packer_checkpoint_path,
                     "ligand_mpnn_use_atom_context": config.ligand_mpnn_use_atom_context,
                     "ligand_mpnn_use_side_chain_context": config.ligand_mpnn_use_side_chain_context,
                     "ligand_mpnn_cutoff_for_score": config.ligand_mpnn_cutoff_for_score,
+                    "sc_num_denoising_steps": config.sc_num_denoising_steps,
+                    "sc_num_samples": config.sc_num_samples,
                 }
                 result = ToolInstance.dispatch(
                     "ligandmpnn",
@@ -287,7 +349,10 @@ def run_ligandmpnn_sample(
                 )
                 all_chain_sequences.extend(result["chain_sequences"])
                 all_recovery.extend(m["sequence_recovery"] for m in result["metrics"])
-                all_interface_recovery.extend(m["ligand_interface_sequence_recovery"] for m in result["metrics"])
+                all_interface_recovery.extend(
+                    m.get("ligand_interface_sequence_recovery", math.nan) for m in result["metrics"]
+                )
+                all_pmpnn.extend(m.get("pmpnn") for m in result["metrics"])
                 all_pdb_strings.extend(result.get("pdb_strings", [None] * len(result["chain_sequences"])))
                 dispatch_idx += 1
                 remaining -= chunk  # type: ignore[operator]
@@ -296,8 +361,8 @@ def run_ligandmpnn_sample(
         redesigned_ids = set() if _fixed_positions_cover_structure(inp) else set(inp.chain_ids_to_redesign)
 
         complexes: list[LigandMPNNDesign] = []
-        for chain_seqs, recovery, interface_recovery, pdb_string in zip(
-            all_chain_sequences, all_recovery, all_interface_recovery, all_pdb_strings, strict=True
+        for chain_seqs, recovery, interface_recovery, pmpnn, pdb_string in zip(
+            all_chain_sequences, all_recovery, all_interface_recovery, all_pmpnn, all_pdb_strings, strict=True
         ):
             chains: list[Chain | Fragment] = [Chain(id=entry["id"], sequence=entry["sequence"]) for entry in chain_seqs]
             designed: list[bool] = [entry["id"] in redesigned_ids for entry in chain_seqs]
@@ -311,6 +376,7 @@ def run_ligandmpnn_sample(
                         ligand_interface_sequence_recovery=(
                             interface_recovery if math.isfinite(interface_recovery) else None
                         ),
+                        pmpnn=(pmpnn if pmpnn is not None and math.isfinite(pmpnn) else None),
                     ),
                     structure=(
                         Structure(structure=pdb_string, structure_format="pdb", source="ligandmpnn-sample")

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
@@ -45,6 +45,9 @@ class LigandMPNNScoringConfig(BaseConfig):
         device (str): Device to run the model on.
         return_logits (bool): Whether to include per-position logits.
         scoring_mode (LigandMPNNScoringMode): Single-position or autoregressive scoring mode.
+        ligand_mpnn_use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
+        ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
+        ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å).
     """
 
     device: str = ConfigField(
@@ -63,6 +66,22 @@ class LigandMPNNScoringConfig(BaseConfig):
         title="Scoring Mode",
         default="single_aa",
         description="Use single-position probabilities or one seed-determined autoregressive order.",
+    )
+    ligand_mpnn_use_atom_context: bool = ConfigField(
+        title="Use Ligand Atom Context",
+        default=True,
+        description="Encode ligand atom context in the message-passing graph.",
+    )
+    ligand_mpnn_use_side_chain_context: bool = ConfigField(
+        title="Use Sidechain Context",
+        default=False,
+        description="Condition on sidechain atoms of fixed residues.",
+    )
+    ligand_mpnn_cutoff_for_score: float = ConfigField(
+        title="Ligand Cutoff for Score",
+        default=8.0,
+        gt=0.0,
+        description="Ligand-residue distance cutoff (Å).",
     )
 
 
@@ -122,6 +141,9 @@ def run_ligandmpnn_score(
                     "verbose": config.verbose,
                     "model_type": "ligand_mpnn",
                     "scoring_mode": config.scoring_mode,
+                    "ligand_mpnn_use_atom_context": config.ligand_mpnn_use_atom_context,
+                    "ligand_mpnn_use_side_chain_context": config.ligand_mpnn_use_side_chain_context,
+                    "ligand_mpnn_cutoff_for_score": config.ligand_mpnn_cutoff_for_score,
                 },
                 instance=instance,
                 config=config,

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
@@ -19,6 +19,7 @@ from proto_tools.utils import (
 from proto_tools.utils.progress import progress_bar
 
 LigandMPNNScoringMode = Literal["single_aa", "autoregressive"]
+LigandMPNNBackend = Literal["foundry", "reference"]
 
 
 class LigandMPNNScoringInput(BaseToolInput):
@@ -45,6 +46,12 @@ class LigandMPNNScoringConfig(BaseConfig):
         device (str): Device to run the model on.
         return_logits (bool): Whether to include per-position logits.
         scoring_mode (LigandMPNNScoringMode): Single-position or autoregressive scoring mode.
+        backend (LigandMPNNBackend): Inference backend. ``"foundry"`` uses the
+            managed Foundry implementation; ``"reference"`` uses a local
+            reference LigandMPNN checkout for compatibility experiments.
+        checkpoint_path (str | None): Optional explicit LigandMPNN checkpoint path.
+        reference_backend_path (str | None): Path to a checkout containing the
+            reference ``ligandmpnn`` Python package when ``backend="reference"``.
         ligand_mpnn_use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
         ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
         ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å).
@@ -66,6 +73,24 @@ class LigandMPNNScoringConfig(BaseConfig):
         title="Scoring Mode",
         default="single_aa",
         description="Use single-position probabilities or one seed-determined autoregressive order.",
+    )
+    backend: LigandMPNNBackend = ConfigField(
+        title="Backend",
+        default="foundry",
+        description="Inference backend: managed Foundry implementation or local reference implementation.",
+        reload_on_change=True,
+    )
+    checkpoint_path: str | None = ConfigField(
+        title="Checkpoint Path",
+        default=None,
+        description="Optional explicit LigandMPNN checkpoint path.",
+        reload_on_change=True,
+    )
+    reference_backend_path: str | None = ConfigField(
+        title="Reference Backend Path",
+        default=None,
+        description="Path to a local reference LigandMPNN checkout when backend='reference'.",
+        reload_on_change=True,
     )
     ligand_mpnn_use_atom_context: bool = ConfigField(
         title="Use Ligand Atom Context",
@@ -140,6 +165,9 @@ def run_ligandmpnn_score(
                     "return_logits": config.return_logits,
                     "verbose": config.verbose,
                     "model_type": "ligand_mpnn",
+                    "backend": config.backend,
+                    "checkpoint_path": config.checkpoint_path,
+                    "reference_backend_path": config.reference_backend_path,
                     "scoring_mode": config.scoring_mode,
                     "ligand_mpnn_use_atom_context": config.ligand_mpnn_use_atom_context,
                     "ligand_mpnn_use_side_chain_context": config.ligand_mpnn_use_side_chain_context,

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
@@ -10,7 +10,7 @@ import tempfile
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -501,11 +501,14 @@ def _run_reference_ligandmpnn(
         array = np.asarray(x)
         if array.size == 1:
             x = array.reshape(()).item()
-        return original_format_float_positional(x, *args_, **kwargs)
+        return str(original_format_float_positional(x, *args_, **kwargs))
 
     ligandmpnn_module.np.format_float_positional = format_float_positional_compat
     try:
-        return ligandmpnn_module.run_ligandmpnn(args, protein_dict, feature_dict, model, device=device)
+        return cast(
+            "dict[str, Any]",
+            ligandmpnn_module.run_ligandmpnn(args, protein_dict, feature_dict, model, device=device),
+        )
     finally:
         ligandmpnn_module.np.format_float_positional = original_format_float_positional
 
@@ -698,7 +701,7 @@ class ReferenceLigandMPNNModel:
             verbose=verbose,
             seed=seed,
         )
-        protein_dict, _, _, feature_dict = self._prepare(pdb_path, args, device)
+        protein_dict, _other_atoms, _icodes, feature_dict = self._prepare(pdb_path, args, device)
         data_utils = self._modules["data_utils"]
         token_ids = [data_utils.restype_str_to_int[aa] for aa in sequence]
         if len(token_ids) != int(feature_dict["mask"].shape[1]):

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
@@ -856,24 +856,26 @@ def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
     pdb_path = input_dict["pdb_path"]
     operation = input_dict["operation"]
     if operation == "sample":
-        return _model.sample(
-            pdb_path=pdb_path,
-            chain_ids=input_dict["chain_ids"],
-            chains_explicitly_set=input_dict.get("chains_explicitly_set", False),
-            batch_size=input_dict["batch_size"],
-            temperature=input_dict["temperature"],
-            fixed_positions=input_dict.get("fixed_positions"),
-            excluded_amino_acids=input_dict.get("excluded_amino_acids"),
-            seed=input_dict["seed"],
-            device=input_dict["device"],
-            verbose=input_dict["verbose"],
-            model_type=input_dict["model_type"],
-            ligand_mpnn_use_atom_context=input_dict["ligand_mpnn_use_atom_context"],
-            ligand_mpnn_use_side_chain_context=input_dict["ligand_mpnn_use_side_chain_context"],
-            ligand_mpnn_cutoff_for_score=input_dict["ligand_mpnn_cutoff_for_score"],
-            sc_num_denoising_steps=input_dict.get("sc_num_denoising_steps", 8),
-            sc_num_samples=input_dict.get("sc_num_samples", 1),
-        )
+        sample_kwargs = {
+            "pdb_path": pdb_path,
+            "chain_ids": input_dict["chain_ids"],
+            "chains_explicitly_set": input_dict.get("chains_explicitly_set", False),
+            "batch_size": input_dict["batch_size"],
+            "temperature": input_dict["temperature"],
+            "fixed_positions": input_dict.get("fixed_positions"),
+            "excluded_amino_acids": input_dict.get("excluded_amino_acids"),
+            "seed": input_dict["seed"],
+            "device": input_dict["device"],
+            "verbose": input_dict["verbose"],
+            "model_type": input_dict["model_type"],
+            "ligand_mpnn_use_atom_context": input_dict["ligand_mpnn_use_atom_context"],
+            "ligand_mpnn_use_side_chain_context": input_dict["ligand_mpnn_use_side_chain_context"],
+            "ligand_mpnn_cutoff_for_score": input_dict["ligand_mpnn_cutoff_for_score"],
+        }
+        if backend == "reference":
+            sample_kwargs["sc_num_denoising_steps"] = input_dict.get("sc_num_denoising_steps", 8)
+            sample_kwargs["sc_num_samples"] = input_dict.get("sc_num_samples", 1)
+        return _model.sample(**sample_kwargs)
     if operation == "score":
         return _model.score(
             pdb_path=pdb_path,

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
@@ -4,6 +4,7 @@ import gc
 import json
 import os
 import sys
+from io import StringIO
 from typing import Any
 
 import numpy as np
@@ -36,6 +37,21 @@ def _sequence_tokens(sequence: str) -> tuple[list[str], list[int]]:
         return vocab, [token_by_letter[aa] for aa in sequence]
     except KeyError as exc:
         raise ValueError(f"ligandmpnn: unsupported residue {exc.args[0]!r}") from exc
+
+
+def _atom_array_to_pdb(atom_array: Any) -> str:
+    """Serialize a Foundry/Biotite atom array to a PDB string."""
+    from biotite.structure.io.pdb import PDBFile
+
+    finite_atoms = np.isfinite(np.asarray(atom_array.coord)).all(axis=-1)
+    atom_array = atom_array[finite_atoms]
+    if len(atom_array) == 0:
+        raise ValueError("ligandmpnn: sampled structure contains no finite-coordinate atoms.")
+    pdb_file = PDBFile()
+    pdb_file.set_structure(atom_array)
+    buffer = StringIO()
+    pdb_file.write(buffer)
+    return buffer.getvalue()
 
 
 class LigandMPNNModel:
@@ -142,6 +158,7 @@ class LigandMPNNModel:
         # Split designed_sequence by the non-atomized token level (1:1 with it).
         chain_sequences: list[list[dict[str, str]]] = []
         metrics: list[dict[str, Any]] = []
+        pdb_strings: list[str] = []
         for output in results:
             arr = output.atom_array
             # Drop atomized residues; retained backbone atoms cover every non-atomized residue.
@@ -171,9 +188,10 @@ class LigandMPNNModel:
                 groups.append({"id": current_chain, "sequence": "".join(buffer)})
             chain_sequences.append(groups)
             metrics.append(output.output_dict)
+            pdb_strings.append(_atom_array_to_pdb(arr))
 
         self.unload()
-        return {"chain_sequences": chain_sequences, "metrics": metrics}
+        return {"chain_sequences": chain_sequences, "metrics": metrics, "pdb_strings": pdb_strings}
 
     def score(
         self,
@@ -187,6 +205,9 @@ class LigandMPNNModel:
         model_type: str = "ligand_mpnn",
         return_logits: bool = False,
         scoring_mode: str = "single_aa",
+        ligand_mpnn_use_atom_context: bool = True,
+        ligand_mpnn_use_side_chain_context: bool = False,
+        ligand_mpnn_cutoff_for_score: float = 8.0,
     ) -> dict[str, Any]:
         """Score a sequence against a structure."""
         from mpnn.collate.feature_collator import FeatureCollator
@@ -218,6 +239,9 @@ class LigandMPNNModel:
             "decode_type": "teacher_forcing",
             "causality_pattern": SCORING_CAUSALITY[scoring_mode],
             "initialize_sequence_embedding_with_ground_truth": True,
+            "ligand_mpnn_use_atom_context": int(ligand_mpnn_use_atom_context),
+            "ligand_mpnn_use_side_chain_context": int(ligand_mpnn_use_side_chain_context),
+            "ligand_mpnn_cutoff_for_score": ligand_mpnn_cutoff_for_score,
             "features_to_return": {
                 "input_features": ["S", "mask_for_loss"],
                 "decoder_features": ["logits", "log_probs"],
@@ -231,11 +255,19 @@ class LigandMPNNModel:
 
         inference_input = MPNNInferenceInput.from_atom_array_and_dict(input_dict=input_dict)
         input_dict = inference_input.input_dict
+        pipeline_args = {}
+        if input_dict["occupancy_threshold_sidechain"] is not None:
+            pipeline_args["occupancy_threshold_sidechain"] = input_dict["occupancy_threshold_sidechain"]
+        if input_dict["occupancy_threshold_backbone"] is not None:
+            pipeline_args["occupancy_threshold_backbone"] = input_dict["occupancy_threshold_backbone"]
+        if input_dict["undesired_res_names"] is not None:
+            pipeline_args["undesired_res_names"] = input_dict["undesired_res_names"]
         pipeline = build_mpnn_transform_pipeline(
             model_type=self._engine.model_type,
             is_inference=True,
             minimal_return=True,
             device=self._engine.device,
+            **pipeline_args,
         )
         network_input = FeatureCollator()(
             [
@@ -391,6 +423,9 @@ def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
             model_type=input_dict["model_type"],
             return_logits=input_dict["return_logits"],
             scoring_mode=input_dict["scoring_mode"],
+            ligand_mpnn_use_atom_context=input_dict.get("ligand_mpnn_use_atom_context", True),
+            ligand_mpnn_use_side_chain_context=input_dict.get("ligand_mpnn_use_side_chain_context", False),
+            ligand_mpnn_cutoff_for_score=input_dict.get("ligand_mpnn_cutoff_for_score", 8.0),
         )
     raise ValueError(f"ligandmpnn: unknown operation {operation!r}; valid: ['sample', 'score']")
 

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
@@ -1,10 +1,15 @@
 """LigandMPNN inference implementation using Foundry."""
 
 import gc
+import importlib
 import json
 import os
+import random
 import sys
+import tempfile
 from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -378,19 +383,475 @@ class LigandMPNNModel:
             torch.cuda.empty_cache()
 
 
+def _set_reference_seed(seed: int | None) -> None:
+    if seed is None:
+        return
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.enabled = False
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def _reference_package_path(reference_backend_path: str | None) -> Path:
+    if reference_backend_path is None:
+        raise ValueError("ligandmpnn reference backend requires reference_backend_path")
+    root = Path(reference_backend_path).expanduser().resolve()
+    candidates = [
+        root / "models" / "ligandmpnn",
+        root / "ligandmpnn",
+        root,
+    ]
+    for candidate in candidates:
+        if (candidate / "ligandmpnn.py").is_file() and (candidate / "model_utils.py").is_file():
+            return candidate
+    raise ValueError(
+        "ligandmpnn reference backend path must contain ligandmpnn.py and model_utils.py "
+        f"(checked {', '.join(str(path) for path in candidates)})"
+    )
+
+
+def _load_reference_modules(reference_backend_path: str | None) -> dict[str, Any]:
+    package_path = _reference_package_path(reference_backend_path)
+    parent = str(package_path.parent)
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+    package = package_path.name
+    for module_name, module in list(sys.modules.items()):
+        if module_name != package and not module_name.startswith(f"{package}."):
+            continue
+        module_file = getattr(module, "__file__", None)
+        if module_file is not None and not Path(module_file).resolve().is_relative_to(package_path):
+            del sys.modules[module_name]
+    return {
+        "ligandmpnn": importlib.import_module(f"{package}.ligandmpnn"),
+        "pdb_utils": importlib.import_module(f"{package}.pdb_utils"),
+        "sc_utils": importlib.import_module(f"{package}.sc_utils"),
+        "model_utils": importlib.import_module(f"{package}.model_utils"),
+        "data_utils": importlib.import_module(f"{package}.data_utils"),
+        "package_path": package_path,
+    }
+
+
+def _reference_checkpoint_path(
+    reference_backend_path: str | None,
+    checkpoint_path: str | None,
+    filename: str,
+) -> str:
+    if checkpoint_path is not None:
+        return checkpoint_path
+    package_path = _reference_package_path(reference_backend_path)
+    root_candidates = [package_path, package_path.parent, package_path.parent.parent]
+    for root in root_candidates:
+        candidate = root / "model_params" / filename
+        if candidate.is_file():
+            return str(candidate)
+        candidate = root / "models" / "ligandmpnn" / "model_params" / filename
+        if candidate.is_file():
+            return str(candidate)
+    raise ValueError(f"ligandmpnn reference backend could not locate {filename}; pass an explicit checkpoint path")
+
+
+def _fixed_residue_strings(fixed_positions: dict[str, list[int]] | None) -> list[str]:
+    if not fixed_positions:
+        return []
+    return [f"{chain}{position}" for chain, positions in fixed_positions.items() for position in positions]
+
+
+def _chain_sequences_from_reference(protein_dict: dict[str, Any], sequence: str) -> list[dict[str, str]]:
+    groups: list[dict[str, str]] = []
+    current_chain: str | None = None
+    buffer: list[str] = []
+    for chain_id, aa in zip([str(chain) for chain in protein_dict["chain_letters"]], sequence, strict=True):
+        if chain_id != current_chain:
+            if current_chain is not None:
+                groups.append({"id": current_chain, "sequence": "".join(buffer)})
+            current_chain = chain_id
+            buffer = []
+        buffer.append(aa)
+    if current_chain is not None:
+        groups.append({"id": current_chain, "sequence": "".join(buffer)})
+    return groups
+
+
+def _reference_sequence_recovery(output_dict: dict[str, Any]) -> float:
+    native = output_dict["native_sequence"].detach().cpu().numpy()
+    generated = torch.transpose(output_dict["generated_sequence"], 1, 2)[0].squeeze().detach().cpu().numpy()
+    mask = (output_dict["mask"] * output_dict["chain_mask"]).detach().cpu().numpy().astype(bool)
+    if not np.any(mask):
+        return float("nan")
+    return float(np.mean(native[mask] == generated[mask]))
+
+
+def _run_reference_ligandmpnn(
+    ligandmpnn_module: Any,
+    args: Any,
+    protein_dict: dict[str, Any],
+    feature_dict: dict[str, Any],
+    model: Any,
+    *,
+    device: str,
+) -> dict[str, Any]:
+    original_format_float_positional = ligandmpnn_module.np.format_float_positional
+
+    def format_float_positional_compat(x: Any, *args_: Any, **kwargs: Any) -> str:
+        array = np.asarray(x)
+        if array.size == 1:
+            x = array.reshape(()).item()
+        return original_format_float_positional(x, *args_, **kwargs)
+
+    ligandmpnn_module.np.format_float_positional = format_float_positional_compat
+    try:
+        return ligandmpnn_module.run_ligandmpnn(args, protein_dict, feature_dict, model, device=device)
+    finally:
+        ligandmpnn_module.np.format_float_positional = original_format_float_positional
+
+
+class ReferenceLigandMPNNModel:
+    """Reference LigandMPNN backend used for compatibility experiments."""
+
+    def __init__(
+        self,
+        reference_backend_path: str | None,
+        checkpoint_path: str | None = None,
+        packer_checkpoint_path: str | None = None,
+    ) -> None:
+        """Initialize reference backend paths and lazy model state."""
+        self.reference_backend_path = reference_backend_path
+        self.checkpoint_path = _reference_checkpoint_path(
+            reference_backend_path,
+            checkpoint_path,
+            "ligandmpnn_v_32_020_25.pt",
+        )
+        self.packer_checkpoint_path = _reference_checkpoint_path(
+            reference_backend_path,
+            packer_checkpoint_path,
+            "ligandmpnn_sc_v_32_002_16.pt",
+        )
+        self._modules = _load_reference_modules(reference_backend_path)
+        self._loaded = False
+        self.device: str | None = None
+        self.model: Any = None
+        self.packer: Any = None
+        self.atom_context_num: int = 16
+
+    def load(self, device: str) -> None:
+        """Load the reference LigandMPNN sequence model and side-chain packer."""
+        if self._loaded and self.device == device:
+            return
+        if self._loaded:
+            self.unload()
+
+        checkpoint = torch.load(self.checkpoint_path, map_location=device)
+        self.atom_context_num = int(checkpoint["atom_context_num"])
+        k_neighbors = checkpoint["num_edges"]
+        protein_mpnn = self._modules["model_utils"].ProteinMPNN
+        self.model = protein_mpnn(
+            node_features=128,
+            edge_features=128,
+            hidden_dim=128,
+            num_encoder_layers=3,
+            num_decoder_layers=3,
+            k_neighbors=k_neighbors,
+            device=device,
+            atom_context_num=self.atom_context_num,
+            model_type="ligand_mpnn",
+            ligand_mpnn_use_side_chain_context=True,
+        )
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.model.eval()
+        self.model.to(device)
+
+        checkpoint_packer = torch.load(self.packer_checkpoint_path, map_location=device)
+        packer_cls = self._modules["sc_utils"].Packer
+        self.packer = packer_cls(
+            node_features=128,
+            edge_features=128,
+            num_positional_embeddings=16,
+            num_chain_embeddings=16,
+            num_rbf=16,
+            hidden_dim=128,
+            num_encoder_layers=3,
+            num_decoder_layers=3,
+            atom_context_num=16,
+            lower_bound=0.0,
+            upper_bound=20.0,
+            top_k=32,
+            dropout=0.0,
+            augment_eps=0.0,
+            atom37_order=False,
+            device=device,
+            num_mix=3,
+        )
+        self.packer.load_state_dict(checkpoint_packer["model_state_dict"])
+        self.packer.eval()
+        self.packer.to(device)
+
+        self.device = device
+        self._loaded = True
+
+    def to_device(self, device: str) -> None:
+        """Reload the reference models on a different device."""
+        if not self._loaded:
+            raise ValueError("ligandmpnn reference backend cannot move an unloaded model; call load() first")
+        if self.device != device:
+            self.unload()
+            self.load(device)
+
+    def sample(
+        self,
+        pdb_path: str,
+        chain_ids: list[str],
+        batch_size: int,
+        temperature: float = DEFAULT_TEMPERATURE,
+        fixed_positions: dict[str, list[int]] | None = None,
+        excluded_amino_acids: list[str] | None = None,
+        seed: int | None = None,
+        device: str = "cuda",
+        verbose: bool = False,
+        ligand_mpnn_cutoff_for_score: float = 20.0,
+        sc_num_denoising_steps: int = 8,
+        sc_num_samples: int = 1,
+        **_: Any,
+    ) -> dict[str, Any]:
+        """Sample fixed-backbone sequences and packed structures with the reference backend."""
+        self.load(device)
+        _set_reference_seed(seed)
+        args = self._args(
+            chain_ids=chain_ids,
+            fixed_positions=fixed_positions,
+            excluded_amino_acids=excluded_amino_acids,
+            temperature=temperature,
+            ligand_mpnn_cutoff_for_score=ligand_mpnn_cutoff_for_score,
+            sc_num_denoising_steps=sc_num_denoising_steps,
+            sc_num_samples=sc_num_samples,
+            verbose=verbose,
+            seed=seed,
+        )
+        protein_dict, other_atoms, icodes, feature_dict = self._prepare(pdb_path, args, device)
+
+        chain_sequences: list[list[dict[str, str]]] = []
+        metrics: list[dict[str, Any]] = []
+        pdb_strings: list[str] = []
+        with tempfile.TemporaryDirectory(prefix="ligandmpnn_reference_") as tmpdir:
+            for index in range(batch_size):
+                feature_dict["randn"] = torch.randn([1, feature_dict["mask"].shape[1]], device=device)
+                output_dict = _run_reference_ligandmpnn(
+                    self._modules["ligandmpnn"],
+                    args,
+                    protein_dict,
+                    feature_dict,
+                    self.model,
+                    device=device,
+                )
+                sequence = output_dict["generated_sequence_str"]
+                outfile = os.path.join(tmpdir, f"reference_{index}.pdb")
+                self._modules["pdb_utils"].pack_sc(
+                    args,
+                    self.packer,
+                    protein_dict,
+                    output_dict["generated_sequence"],
+                    other_atoms,
+                    icodes,
+                    outfile=outfile,
+                    device=device,
+                )
+                chain_sequences.append(_chain_sequences_from_reference(protein_dict, sequence))
+                metrics.append(
+                    {
+                        "sequence_recovery": _reference_sequence_recovery(output_dict),
+                        "ligand_interface_sequence_recovery": float("nan"),
+                        "pmpnn": float(output_dict["loss_np"]),
+                    }
+                )
+                pdb_strings.append(Path(outfile).read_text())
+        return {"chain_sequences": chain_sequences, "metrics": metrics, "pdb_strings": pdb_strings}
+
+    def score(
+        self,
+        pdb_path: str,
+        chain_ids: list[str],
+        sequence: str,
+        fixed_positions: dict[str, list[int]] | None = None,
+        seed: int | None = None,
+        device: str = "cuda",
+        verbose: bool = False,
+        return_logits: bool = False,
+        scoring_mode: str = "single_aa",
+        ligand_mpnn_cutoff_for_score: float = 20.0,
+        **_: Any,
+    ) -> dict[str, Any]:
+        """Score a sequence against a structure with the reference backend."""
+        self.load(device)
+        _set_reference_seed(seed)
+        args = self._args(
+            chain_ids=chain_ids,
+            fixed_positions=fixed_positions,
+            excluded_amino_acids=None,
+            temperature=1.0,
+            ligand_mpnn_cutoff_for_score=ligand_mpnn_cutoff_for_score,
+            sc_num_denoising_steps=8,
+            sc_num_samples=1,
+            verbose=verbose,
+            seed=seed,
+        )
+        protein_dict, _, _, feature_dict = self._prepare(pdb_path, args, device)
+        data_utils = self._modules["data_utils"]
+        token_ids = [data_utils.restype_str_to_int[aa] for aa in sequence]
+        if len(token_ids) != int(feature_dict["mask"].shape[1]):
+            raise ValueError(
+                f"Sequence length {len(token_ids)} does not match structure ({int(feature_dict['mask'].shape[1])} residues)."
+            )
+        feature_dict["S"] = torch.tensor([token_ids], device=device, dtype=torch.int32)
+        with torch.inference_mode():
+            if scoring_mode == "single_aa":
+                score_dict = self.model.single_aa_score(feature_dict, use_sequence=1)
+            else:
+                score_dict = self.model.score(feature_dict, use_sequence=1)
+
+        probs_2d = torch.mean(torch.exp(score_dict["log_probs"]), 0)
+        seq_tensor = feature_dict["S"].squeeze()
+        selected = probs_2d[torch.arange(len(token_ids), device=device), seq_tensor].detach().cpu().numpy()
+        chain_mask = protein_dict["chain_mask"].detach().cpu().numpy().astype(bool)
+        selected_masked = selected[chain_mask]
+        if selected_masked.size == 0:
+            raise ValueError("ligandmpnn reference score found no residues available to score")
+        avg_log_likelihood = float(np.mean(np.log(np.maximum(selected_masked, 1e-12))))
+        logits = None
+        if return_logits:
+            logits = np.log(np.maximum(probs_2d.detach().cpu().numpy(), 1e-12)).tolist()
+        return {
+            "logits": logits,
+            "metrics": {
+                **log_likelihood_metrics(avg_log_likelihood, int(selected_masked.size)),
+                "mean_current_probability": float(np.mean(selected_masked)),
+            },
+            "vocab": [data_utils.restype_int_to_str[idx] for idx in range(len(data_utils.restype_int_to_str))],
+        }
+
+    def _args(
+        self,
+        *,
+        chain_ids: list[str],
+        fixed_positions: dict[str, list[int]] | None,
+        excluded_amino_acids: list[str] | None,
+        temperature: float,
+        ligand_mpnn_cutoff_for_score: float,
+        sc_num_denoising_steps: int,
+        sc_num_samples: int,
+        verbose: bool,
+        seed: int | None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            seq_model="ligandmpnn",
+            seed=seed,
+            model_path=self.checkpoint_path,
+            packer_path=self.packer_checkpoint_path,
+            var_residues="",
+            fixed_residues=" ".join(_fixed_residue_strings(fixed_positions)),
+            bias_AA="",
+            bias_AA_per_residue="",
+            omit_AA="".join(excluded_amino_acids or []),
+            omit_AA_per_residue="",
+            symmetry_residues="",
+            symmetry_weights="",
+            homo_oligomer=0,
+            sc_num_denoising_steps=sc_num_denoising_steps,
+            sc_num_samples=sc_num_samples,
+            ligand_mpnn_cutoff_for_score=ligand_mpnn_cutoff_for_score,
+            temperature=temperature,
+            zero_indexed=0,
+            autoregressive_score=0,
+            single_aa_score=1,
+            chains_to_design=",".join(chain_ids),
+            parse_these_chains_only="",
+            parse_atoms_with_zero_occupancy=0,
+            verbose=verbose,
+        )
+
+    def _prepare(
+        self,
+        pdb_path: str,
+        args: SimpleNamespace,
+        device: str,
+    ) -> tuple[dict[str, Any], Any, list[str], dict[str, Any]]:
+        ligandmpnn = self._modules["ligandmpnn"]
+        protein_dict, _, other_atoms, icodes, _ = self._modules["data_utils"].parse_PDB(
+            pdb_path,
+            device=device,
+            chains=[],
+            parse_all_atoms=True,
+            parse_atoms_with_zero_occupancy=args.parse_atoms_with_zero_occupancy,
+        )
+        encoded_residues, encoded_residue_dict, _ = ligandmpnn.get_encoded_residues(protein_dict, icodes)
+        design_params = {
+            "var_residues": ligandmpnn.get_var_residues(args, pdb_path),
+            "fixed_residues": ligandmpnn.get_fixed_residues(args, pdb_path),
+            "bias_AA": ligandmpnn.get_bias_aa(args, pdb_path, device)[0],
+            "bias_AA_per_residue": {},
+            "omit_AA": ligandmpnn.get_omit_aa(args, pdb_path, device)[0],
+            "omit_AA_per_residue": {},
+            "parse_these_chains_only_list": [],
+        }
+        protein_dict, feature_dict = ligandmpnn.prepare_ligandmpnn(
+            args,
+            protein_dict,
+            icodes,
+            design_params,
+            self.atom_context_num,
+            device=device,
+        )
+        omit_per_residue = ligandmpnn.omit_aa(args, encoded_residues, encoded_residue_dict, {}, device)
+        feature_dict["bias"] = feature_dict["bias"] - 1e8 * omit_per_residue[None]
+        return protein_dict, other_atoms, icodes, feature_dict
+
+    def unload(self) -> None:
+        """Unload reference models and clear cached GPU memory."""
+        self.model = None
+        self.packer = None
+        self._loaded = False
+        self.device = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+
 # ============================================================================
 # Dispatch
 # ============================================================================
-_model: LigandMPNNModel | None = None
+_model: Any | None = None
+_model_key: tuple[Any, ...] | None = None
 
 
 def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
     """Entry point for both persistent-worker and one-shot execution."""
-    global _model
+    global _model, _model_key
+    backend = input_dict.get("backend", "foundry")
+    checkpoint_path = input_dict.get("checkpoint_path")
+    reference_backend_path = input_dict.get("reference_backend_path")
+    packer_checkpoint_path = input_dict.get("packer_checkpoint_path")
+    model_key = (backend, checkpoint_path, reference_backend_path, packer_checkpoint_path)
+    if _model is not None and _model_key != model_key:
+        _model.unload()
+        _model = None
+        _model_key = None
     if _model is None:
-        _model = LigandMPNNModel(
-            checkpoint_path=input_dict.get("checkpoint_path"),
-        )
+        if backend == "reference":
+            _model = ReferenceLigandMPNNModel(
+                reference_backend_path=reference_backend_path,
+                checkpoint_path=checkpoint_path,
+                packer_checkpoint_path=packer_checkpoint_path,
+            )
+        elif backend == "foundry":
+            _model = LigandMPNNModel(
+                checkpoint_path=checkpoint_path,
+            )
+        else:
+            raise ValueError("ligandmpnn backend must be 'foundry' or 'reference'")
+        _model_key = model_key
 
     pdb_path = input_dict["pdb_path"]
     operation = input_dict["operation"]
@@ -410,6 +871,8 @@ def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
             ligand_mpnn_use_atom_context=input_dict["ligand_mpnn_use_atom_context"],
             ligand_mpnn_use_side_chain_context=input_dict["ligand_mpnn_use_side_chain_context"],
             ligand_mpnn_cutoff_for_score=input_dict["ligand_mpnn_cutoff_for_score"],
+            sc_num_denoising_steps=input_dict.get("sc_num_denoising_steps", 8),
+            sc_num_samples=input_dict.get("sc_num_samples", 1),
         )
     if operation == "score":
         return _model.score(

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/requirements.txt
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/requirements.txt
@@ -1,1 +1,3 @@
 rc-foundry[all]==0.2.0
+biopython>=1.84
+ml-collections>=0.1.1


### PR DESCRIPTION
## Summary

Adds the LigandMPNN tool support needed for dEVA-style structure-aware design workflows:

- returns optional full-atom packed structures and optional `pmpnn` metrics from LigandMPNN sampling
- exposes LigandMPNN scoring/sample backend, checkpoint, side-chain context, ligand cutoff, and reference-backend options
- adds a local reference LigandMPNN backend for compatibility experiments against Gina's dEVA implementation
- supports fixed-sequence side-chain packing through the reference backend while preserving Foundry sampling compatibility

## Related PR

Supports evo-design/proto-language#9.

## Validation

- `python -m compileall proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py`
- `ruff check proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py`
- `ruff format --check proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py`
- `git diff --check`
- `pytest tests/inverse_folding_tests/test_ligandmpnn.py -q --tb=short` (8 passed, 2 skipped)
- exercised through the local CUDA proto-language dEVA Metal3D smoke, which achieved sequence parity with the reference dEVA run for the one-generation 2VVB setup