### PR TITLE
Drop ligand_mpnn_ prefix from LigandMPNN config fields

### DIFF
--- a/proto_tools/tools/inverse_folding/ligandmpnn/README.md
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/README.md
@@ -35,8 +35,8 @@ Use this to design or redesign binding sites, enzyme active sites, nucleic-acid-
 
 #### Usage Tips
 
-- **Keep `ligand_mpnn_use_atom_context` enabled.** It defaults to `True` and is the whole point of LigandMPNN: it encodes the surrounding ligand, nucleotide, and metal atoms. Turning it off makes the model effectively ligand-blind, close to plain ProteinMPNN.
-- **Set `ligand_mpnn_use_side_chain_context` to `True` to honor a fixed motif.** It conditions on the sidechain atoms of fixed residues, which helps when redesigning around a preserved catalytic or binding motif. It defaults to `False`.
+- **Keep `use_atom_context` enabled.** It defaults to `True` and is the whole point of LigandMPNN: it encodes the surrounding ligand, nucleotide, and metal atoms. Turning it off makes the model effectively ligand-blind, close to plain ProteinMPNN.
+- **Set `use_side_chain_context` to `True` to honor a fixed motif.** It conditions on the sidechain atoms of fixed residues, which helps when redesigning around a preserved catalytic or binding motif. It defaults to `False`.
 - **`fixed_positions` is counted from 1, not 0**, to match biological residue selection conventions. Listed positions keep their input residue, and chains or atoms you do not redesign still act as context rather than being removed.
 
 ### LigandMPNN Scoring (`ligandmpnn-score`)

--- a/proto_tools/tools/inverse_folding/ligandmpnn/examples/example.ipynb
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/examples/example.ipynb
@@ -275,9 +275,9 @@
        "| <code>batch_size</code> | <code>int &#124; None</code> | <code>None</code> | Number of sequences to process simultaneously on GPU. Defaults to num_sequences_per_structure. |\n",
        "| <code>temperature</code> | <code>float</code> | <code>0.1</code> | Sampling temperature; lower = greedier, higher = more diverse |\n",
        "| <code>model_type</code> | <code>Literal['ligand_mpnn']</code> | <code>'ligand_mpnn'</code> | LigandMPNN model variant (ligand-aware weights). |\n",
-       "| <code>ligand_mpnn_use_atom_context</code> | <code>bool</code> | <code>True</code> | Encode ligand atom context in the message-passing graph |\n",
-       "| <code>ligand_mpnn_use_side_chain_context</code> | <code>bool</code> | <code>False</code> | Condition on sidechain atoms of fixed residues |\n",
-       "| <code>ligand_mpnn_cutoff_for_score</code> | <code>float</code> | <code>8.0</code> | Ligand-residue distance cutoff (A) for interface recovery score |\n",
+       "| <code>use_atom_context</code> | <code>bool</code> | <code>True</code> | Encode ligand atom context in the message-passing graph |\n",
+       "| <code>use_side_chain_context</code> | <code>bool</code> | <code>False</code> | Condition on sidechain atoms of fixed residues |\n",
+       "| <code>cutoff_for_score</code> | <code>float</code> | <code>8.0</code> | Ligand-residue distance cutoff (A) for interface recovery score |\n",
        "| <code>excluded_amino_acids</code> | <code>list[Literal['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y']] &#124; None</code> | <code>None</code> | Single-letter codes of amino acids to exclude (e.g. ['C'] to forbid cysteine) |"
       ],
       "text/plain": [

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
@@ -65,9 +65,9 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
             reference ``ligandmpnn`` Python package when ``backend="reference"``.
         packer_checkpoint_path (str | None): Side-chain packer checkpoint used
             by the reference backend to emit sequence-consistent PDB structures.
-        ligand_mpnn_use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
-        ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
-        ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å) for the ligand-interface
+        use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
+        use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
+        cutoff_for_score (float): Ligand-residue distance cutoff (Å) for the ligand-interface
             recovery score.
         sc_num_denoising_steps (int): Number of side-chain denoising steps for the reference packer.
         sc_num_samples (int): Number of side-chain samples for the reference packer.
@@ -79,7 +79,7 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         description="LigandMPNN model variant (ligand-aware weights).",
         reload_on_change=True,
     )
-    ligand_mpnn_use_atom_context: bool = ConfigField(
+    use_atom_context: bool = ConfigField(
         title="Use Ligand Atom Context",
         default=True,
         description="Encode ligand atom context in the message-passing graph",
@@ -108,12 +108,12 @@ class LigandMPNNSampleConfig(InverseFoldingConfig):
         description="Optional side-chain packer checkpoint path for the reference backend.",
         reload_on_change=True,
     )
-    ligand_mpnn_use_side_chain_context: bool = ConfigField(
+    use_side_chain_context: bool = ConfigField(
         title="Use Sidechain Context",
         default=False,
         description="Condition on sidechain atoms of fixed residues",
     )
-    ligand_mpnn_cutoff_for_score: float = ConfigField(
+    cutoff_for_score: float = ConfigField(
         title="Ligand Cutoff for Score",
         default=8.0,
         gt=0.0,
@@ -337,9 +337,9 @@ def run_ligandmpnn_sample(
                     "checkpoint_path": config.checkpoint_path,
                     "reference_backend_path": config.reference_backend_path,
                     "packer_checkpoint_path": config.packer_checkpoint_path,
-                    "ligand_mpnn_use_atom_context": config.ligand_mpnn_use_atom_context,
-                    "ligand_mpnn_use_side_chain_context": config.ligand_mpnn_use_side_chain_context,
-                    "ligand_mpnn_cutoff_for_score": config.ligand_mpnn_cutoff_for_score,
+                    "ligand_mpnn_use_atom_context": config.use_atom_context,
+                    "ligand_mpnn_use_side_chain_context": config.use_side_chain_context,
+                    "ligand_mpnn_cutoff_for_score": config.cutoff_for_score,
                     "sc_num_denoising_steps": config.sc_num_denoising_steps,
                     "sc_num_samples": config.sc_num_samples,
                 }

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
@@ -52,9 +52,9 @@ class LigandMPNNScoringConfig(BaseConfig):
         checkpoint_path (str | None): Optional explicit LigandMPNN checkpoint path.
         reference_backend_path (str | None): Path to a checkout containing the
             reference ``ligandmpnn`` Python package when ``backend="reference"``.
-        ligand_mpnn_use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
-        ligand_mpnn_use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
-        ligand_mpnn_cutoff_for_score (float): Ligand-residue distance cutoff (Å).
+        use_atom_context (bool): Whether ligand-aware variants encode ligand atom context.
+        use_side_chain_context (bool): Whether to condition on fixed-residue sidechain atoms.
+        cutoff_for_score (float): Ligand-residue distance cutoff (Å).
     """
 
     device: str = ConfigField(
@@ -92,17 +92,17 @@ class LigandMPNNScoringConfig(BaseConfig):
         description="Path to a local reference LigandMPNN checkout when backend='reference'.",
         reload_on_change=True,
     )
-    ligand_mpnn_use_atom_context: bool = ConfigField(
+    use_atom_context: bool = ConfigField(
         title="Use Ligand Atom Context",
         default=True,
         description="Encode ligand atom context in the message-passing graph.",
     )
-    ligand_mpnn_use_side_chain_context: bool = ConfigField(
+    use_side_chain_context: bool = ConfigField(
         title="Use Sidechain Context",
         default=False,
         description="Condition on sidechain atoms of fixed residues.",
     )
-    ligand_mpnn_cutoff_for_score: float = ConfigField(
+    cutoff_for_score: float = ConfigField(
         title="Ligand Cutoff for Score",
         default=8.0,
         gt=0.0,
@@ -169,9 +169,9 @@ def run_ligandmpnn_score(
                     "checkpoint_path": config.checkpoint_path,
                     "reference_backend_path": config.reference_backend_path,
                     "scoring_mode": config.scoring_mode,
-                    "ligand_mpnn_use_atom_context": config.ligand_mpnn_use_atom_context,
-                    "ligand_mpnn_use_side_chain_context": config.ligand_mpnn_use_side_chain_context,
-                    "ligand_mpnn_cutoff_for_score": config.ligand_mpnn_cutoff_for_score,
+                    "ligand_mpnn_use_atom_context": config.use_atom_context,
+                    "ligand_mpnn_use_side_chain_context": config.use_side_chain_context,
+                    "ligand_mpnn_cutoff_for_score": config.cutoff_for_score,
                 },
                 instance=instance,
                 config=config,


### PR DESCRIPTION
Follow-up to #16, addressing my review comment: the LigandMPNN config exposed `ligand_mpnn_`-prefixed fields that no other tool carries. That prefix exists on the model's native arguments, not on our public config surface.

## Change
Renames the public config fields on both `LigandMPNNScoringConfig` and `LigandMPNNSampleConfig`:
- `ligand_mpnn_use_atom_context` → `use_atom_context`
- `ligand_mpnn_use_side_chain_context` → `use_side_chain_context`
- `ligand_mpnn_cutoff_for_score` → `cutoff_for_score`

The model-facing keys in the dispatch payload and the `standalone/inference.py` internals keep their native `ligand_mpnn_*` names (that's what the underlying LigandMPNN model expects); the tools now map the renamed config fields onto those keys. Docstrings, the toolkit README, and the example notebook table are updated to match.

Scope deliberately limited to the field rename. My other two comments on #16 (whether `reference_backend_path` is needed, and collapsing `backend` into a `reference_backend_path` toggle) are left for a separate discussion.

Note: proto-language forwards these fields with guarded kwargs, so the downstream rename there is a coordinated follow-up.

## Testing
- `tests/style_consistency_tests/` — 6594 passed
- `tests/inverse_folding_tests/test_ligandmpnn.py -m "not slow"` — 8 passed on H100 (real model load/score/sample)
- Direct config check: new names accepted, old prefixed names rejected