### PR TITLE
Fix metal3d env build: bump moleculekit 1.14.8 → 1.15.3

### DIFF
--- a/proto_tools/tools/structure_scoring/metal3d/standalone/requirements.txt
+++ b/proto_tools/tools/structure_scoring/metal3d/standalone/requirements.txt
@@ -1,4 +1,4 @@
 numpy
-moleculekit==1.14.8
+moleculekit==1.15.3
 scipy
 scikit-learn


### PR DESCRIPTION
## What

Bump metal3d's `moleculekit` pin: `1.14.8` → `1.15.3` (the current release).

## Why

`moleculekit==1.14.8` was yanked from PyPI, so metal3d's standalone env can no longer resolve its dependencies:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of moleculekit==1.14.8 … your requirements are unsatisfiable.
```

That fails `setup.sh` (exit 1) → the metal3d Modal image build fails. It surfaced when a full all-apps redeploy re-attempted metal3d's build (it hadn't been rebuilt recently, so the yank went unnoticed).

`1.14.8` and `1.14.7` are both gone from PyPI; `1.15.3` is the current release. The two APIs metal3d uses — `moleculekit.molecule.Molecule` and `moleculekit.tools.voxeldescriptors.getVoxelDescriptors` — are unchanged.

## Testing (local, macOS / Python 3.10)

- `moleculekit==1.15.3` installs cleanly on the pinned Python 3.10; metal3d's imports work against it.
- metal3d unit test passes; GPU inference tests skip (no CUDA locally) — those + the Linux/CUDA image build validate in CI/deploy.
- `tests/style_consistency_tests/` pass, except one **pre-existing, unrelated** failure (`colabfold_search` missing `python_version.txt`, already failing on `main`).

Note: 1.15.3 pulls numpy 2.x transitively (vs the old stack's numpy 1.x) — worth confirming in the metal3d deploy build.
