### PR TITLE
Sync proto-bio/main: 1-indexed residue positions + LigandMPNN multi-GPU device pin

### DIFF
--- a/proto_tools/entities/structures/selection.py
+++ b/proto_tools/entities/structures/selection.py
@@ -241,15 +241,19 @@ class ResidueSelection(BaseModel):
         return self.chains[chain_id]
 
     def validate_against(self, structure: Structure, label: str = "selection") -> None:
-        """Raise if any selected chain or position is missing from ``structure``.
+        """Raise if any selected chain is missing or any position is out of range.
+
+        Positions are 1-indexed over each chain's residues (position 1 = the first
+        residue), so a valid position lies in ``1..N`` where ``N`` is the chain's
+        residue count. Construction already rejects positions ``< 1``.
 
         Args:
             structure (Structure): The structure to check against.
             label (str): Prefix for error messages, typically the parent field name.
 
         Raises:
-            ValueError: If any selected chain is absent from the structure, or
-                any selected position is not a real residue in its chain.
+            ValueError: If any selected chain is absent from the structure, or any
+                selected position exceeds its chain's residue count.
         """
         available = set(structure.get_chain_ids())
         for chain_id, positions in self.chains.items():
@@ -257,12 +261,32 @@ class ResidueSelection(BaseModel):
                 raise ValueError(
                     f"{label}: chain {chain_id!r} not in structure (available: {sorted(available)})",
                 )
-            valid = set(structure.get_chain_positions(chain_id))
-            invalid = set(positions) - valid
+            length = len(structure.get_chain_positions(chain_id))
+            invalid = sorted(p for p in positions if p > length)
             if invalid:
                 raise ValueError(
-                    f"{label}: invalid positions {sorted(invalid)} for chain {chain_id!r}",
+                    f"{label}: invalid positions {invalid} for chain {chain_id!r} (chain has {length} residues)",
                 )
+
+    def to_residue_numbers(self, structure: Structure) -> dict[str, list[int]]:
+        """Resolve each chain's 1-indexed positions to its residue numbers.
+
+        Position ``i`` maps to the residue number of the ``i``-th residue in the chain
+        (``get_chain_positions(chain)[i - 1]``), so a selection is independent of how the
+        structure numbers or gaps its residues. Positions must already be validated with
+        :meth:`validate_against` (position ``i`` requires the chain to have ``>= i`` residues).
+
+        Args:
+            structure (Structure): The structure whose residue numbering to resolve against.
+
+        Returns:
+            dict[str, list[int]]: Per-chain lists of residue numbers.
+        """
+        resolved: dict[str, list[int]] = {}
+        for chain_id, positions in self.chains.items():
+            numbering = structure.get_chain_positions(chain_id)
+            resolved[chain_id] = [numbering[position - 1] for position in positions]
+        return resolved
 
 
 class StructureInputBase(BaseModel):

--- a/proto_tools/tools/inverse_folding/esm_if1/esm_if1_sample.py
+++ b/proto_tools/tools/inverse_folding/esm_if1/esm_if1_sample.py
@@ -229,7 +229,11 @@ def run_esm_if1_sample(
                     "device": config.device,
                     "weights_variant": config.weights_variant,
                     "verbose": config.verbose,
-                    "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
+                    "fixed_positions": (
+                        inp.fixed_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_positions is not None
+                        else None
+                    ),
                 }
                 result = ToolInstance.dispatch(
                     "esm_if1",

--- a/proto_tools/tools/inverse_folding/fampnn/fampnn_pack.py
+++ b/proto_tools/tools/inverse_folding/fampnn/fampnn_pack.py
@@ -214,9 +214,15 @@ def run_fampnn_pack(
                     "model_variant": config.model_variant,
                     "device": config.device,
                     "verbose": config.verbose,
-                    "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
+                    "fixed_positions": (
+                        inp.fixed_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_positions is not None
+                        else None
+                    ),
                     "fixed_sidechain_positions": (
-                        inp.fixed_sidechain_positions.chains if inp.fixed_sidechain_positions is not None else None
+                        inp.fixed_sidechain_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_sidechain_positions is not None
+                        else None
                     ),
                 }
                 result = ToolInstance.dispatch(

--- a/proto_tools/tools/inverse_folding/fampnn/fampnn_sample.py
+++ b/proto_tools/tools/inverse_folding/fampnn/fampnn_sample.py
@@ -317,9 +317,15 @@ def run_fampnn_sample(
                     "model_variant": config.model_variant,
                     "device": config.device,
                     "verbose": config.verbose,
-                    "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
+                    "fixed_positions": (
+                        inp.fixed_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_positions is not None
+                        else None
+                    ),
                     "fixed_sidechain_positions": (
-                        inp.fixed_sidechain_positions.chains if inp.fixed_sidechain_positions is not None else None
+                        inp.fixed_sidechain_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_sidechain_positions is not None
+                        else None
                     ),
                 }
                 result = ToolInstance.dispatch(

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_sample.py
@@ -251,7 +251,7 @@ def _fixed_positions_cover_structure(inp: InverseFoldingStructureInput) -> bool:
     """Return whether fixed_positions cover every residue in every structure chain."""
     if inp.fixed_positions is None:
         return False
-    fixed = inp.fixed_positions.chains
+    fixed = inp.fixed_positions.to_residue_numbers(inp.structure)
     for chain_id in inp.structure.get_chain_ids():
         if set(fixed.get(chain_id, [])) != set(inp.structure.get_chain_positions(chain_id)):
             return False
@@ -335,7 +335,11 @@ def run_ligandmpnn_sample(
                     "chains_explicitly_set": inp.chains_to_redesign is not None and not all_positions_fixed,
                     "batch_size": chunk,
                     "temperature": config.temperature,
-                    "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
+                    "fixed_positions": (
+                        inp.fixed_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_positions is not None
+                        else None
+                    ),
                     "excluded_amino_acids": config.excluded_amino_acids,
                     "seed": base_seed + dispatch_idx,
                     "device": config.device,

--- a/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/ligandmpnn_score.py
@@ -152,7 +152,11 @@ def run_ligandmpnn_score(
                     "chain_ids": pair.structure.get_chain_ids(),
                     "sequence": pair.sequence,
                     "seed": seed,
-                    "fixed_positions": (pair.fixed_positions.chains if pair.fixed_positions is not None else None),
+                    "fixed_positions": (
+                        pair.fixed_positions.to_residue_numbers(pair.structure)
+                        if pair.fixed_positions is not None
+                        else None
+                    ),
                     "device": config.device,
                     "return_logits": config.return_logits,
                     "verbose": config.verbose,

--- a/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/ligandmpnn/standalone/inference.py
@@ -412,6 +412,17 @@ def _set_legacy_seed(seed: int | None) -> None:
     torch.backends.cudnn.benchmark = False
 
 
+def _pin_active_cuda_device(device: str) -> None:
+    """Pin the process's active CUDA device to ``device``.
+
+    The original LigandMPNN code builds some tensors on the default CUDA device (``cuda:0``)
+    rather than the one threaded through, which fails under multi-GPU dispatch when a worker
+    runs on ``cuda:1``. Setting the active device makes those default-device ops land correctly.
+    """
+    if device.startswith("cuda") and torch.cuda.is_available():
+        torch.cuda.set_device(device)
+
+
 def _is_legacy_package_path(path: Path) -> bool:
     required = ("ligandmpnn.py", "model_utils.py", "data_utils.py", "pdb_utils.py", "sc_utils.py")
     return all((path / filename).is_file() for filename in required)
@@ -672,6 +683,7 @@ class LegacyCompatibleLigandMPNNModel:
         **_: Any,
     ) -> dict[str, Any]:
         """Sample fixed-backbone sequences and packed full-atom structures."""
+        _pin_active_cuda_device(device)
         self.load(device)
         self.load_packer(device)
         _set_legacy_seed(seed)
@@ -743,6 +755,7 @@ class LegacyCompatibleLigandMPNNModel:
         **_: Any,
     ) -> dict[str, Any]:
         """Score a sequence against a structure with original-compatible semantics."""
+        _pin_active_cuda_device(device)
         self.load(device)
         _set_legacy_seed(seed)
         args = self._args(

--- a/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_gradient.py
+++ b/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_gradient.py
@@ -205,7 +205,11 @@ def run_proteinmpnn_gradient(
                 "temperature": inputs.temperature,
                 "use_ste": config.use_ste,
                 "compute_gradient": config.compute_gradient,
-                "fixed_positions": inputs.fixed_positions.chains if inputs.fixed_positions is not None else None,
+                "fixed_positions": (
+                    inputs.fixed_positions.to_residue_numbers(inputs.structure)
+                    if inputs.fixed_positions is not None
+                    else None
+                ),
                 "model_choice": config.model_choice,
                 "seed": seed,
                 "device": config.device,

--- a/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_sample.py
+++ b/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_sample.py
@@ -238,7 +238,11 @@ def run_proteinmpnn_sample(
                     "chain_ids": inp.chain_ids_to_redesign,
                     "batch_size": chunk,
                     "temperature": config.temperature,
-                    "fixed_positions": inp.fixed_positions.chains if inp.fixed_positions is not None else None,
+                    "fixed_positions": (
+                        inp.fixed_positions.to_residue_numbers(inp.structure)
+                        if inp.fixed_positions is not None
+                        else None
+                    ),
                     "excluded_amino_acids": config.excluded_amino_acids,
                     "seed": seed_rng.randint(0, 2**31 - 1),
                     "device": config.device,

--- a/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_score.py
+++ b/proto_tools/tools/inverse_folding/proteinmpnn/proteinmpnn_score.py
@@ -198,7 +198,7 @@ def run_proteinmpnn_score(
                 "sequence": sequence_structure_pair.sequence,
                 "seed": seed,
                 "fixed_positions": (
-                    sequence_structure_pair.fixed_positions.chains
+                    sequence_structure_pair.fixed_positions.to_residue_numbers(sequence_structure_pair.structure)
                     if sequence_structure_pair.fixed_positions is not None
                     else None
                 ),

--- a/tests/inverse_folding_tests/test_if_schemas.py
+++ b/tests/inverse_folding_tests/test_if_schemas.py
@@ -62,6 +62,41 @@ def test_structure_with_fixed():
     assert structure.fixed_positions.chains == {"A": [1, 2, 3]}
 
 
+def _offset_multichain_pdb() -> str:
+    """Two chains whose residues are numbered off 1 with gaps: A = 27,28,29,35,36; B = 10,11,12."""
+
+    def residue(chain: str, num: int, base_id: int) -> str:
+        return "".join(
+            f"ATOM  {base_id + k:>5}  {atom:<3} MET {chain}{num:>4}      "
+            f"27.340  24.430   2.614  1.00  9.67           {atom[0]}\n"
+            for k, atom in enumerate(["N", "CA", "C", "O"], start=1)
+        )
+
+    lines, base_id = "", 0
+    for chain, nums in (("A", [27, 28, 29, 35, 36]), ("B", [10, 11, 12])):
+        for num in nums:
+            lines += residue(chain, num, base_id)
+            base_id += 4
+    return lines + "END\n"
+
+
+def test_structure_with_fixed_positions_1indexed_on_offset_numbering():
+    """1-indexed fixed positions across chains validate on offset/gapped numbering and resolve to residue numbers."""
+    structure = InverseFoldingStructureInput(
+        structure=_offset_multichain_pdb(),
+        fixed_positions={"A": [1, 2, 4], "B": [1, 3]},
+    )
+    assert structure.fixed_positions is not None
+    # Position i targets the i-th residue: A[4] skips the 30-34 gap to residue 35; B is offset at 10.
+    assert structure.fixed_positions.to_residue_numbers(structure.structure) == {"A": [27, 28, 35], "B": [10, 12]}
+
+
+def test_structure_rejects_fixed_position_past_chain_length():
+    """A fixed position beyond the chain's residue count is rejected."""
+    with pytest.raises(ValueError, match="invalid positions"):
+        InverseFoldingStructureInput(structure=_offset_multichain_pdb(), fixed_positions={"A": [6]})
+
+
 def test_structure_rejects_invalid_pdb_content():
     with pytest.raises(ValueError):
         InverseFoldingStructureInput(structure="not a pdb file")

--- a/tests/structure_tests/test_selection.py
+++ b/tests/structure_tests/test_selection.py
@@ -216,6 +216,46 @@ def test_residue_selection_validate_against_bad_position(structure: Structure) -
         ResidueSelection(chains={"A": [9999]}).validate_against(structure)
 
 
+def _offset_gapped_structure() -> Structure:
+    """Chain A numbered 27, 28, 29, 35, 36 (author offset plus an internal 30-34 gap)."""
+
+    def residue(num: int, base_id: int) -> str:
+        return (
+            f"ATOM  {base_id + 1:>5}  N   MET A{num:>4}      27.340  24.430   2.614  1.00  9.67           N\n"
+            f"ATOM  {base_id + 2:>5}  CA  MET A{num:>4}      26.266  25.413   2.842  1.00 10.38           C\n"
+            f"ATOM  {base_id + 3:>5}  C   MET A{num:>4}      26.913  26.639   3.531  1.00  9.62           C\n"
+            f"ATOM  {base_id + 4:>5}  O   MET A{num:>4}      27.886  26.463   4.263  1.00  9.62           O\n"
+        )
+
+    pdb = "".join(residue(num, i * 4) for i, num in enumerate([27, 28, 29, 35, 36])) + "END\n"
+    return Structure(structure=pdb)
+
+
+def test_residue_selection_validate_against_1indexed_offset_numbering() -> None:
+    """Positions are 1-indexed over residues, so 1..N is valid even when the file numbers from 27."""
+    structure = _offset_gapped_structure()  # chain A has 5 residues: 27, 28, 29, 35, 36
+    ResidueSelection(chains={"A": [1, 2, 3, 4, 5]}).validate_against(structure)
+
+
+def test_residue_selection_validate_against_rejects_out_of_range() -> None:
+    """A position past the chain's residue count is rejected."""
+    structure = _offset_gapped_structure()  # 5 residues
+    with pytest.raises(ValueError, match="invalid positions"):
+        ResidueSelection(chains={"A": [6]}).validate_against(structure)
+
+
+def test_residue_selection_to_residue_numbers_maps_offset_and_gaps() -> None:
+    """Position i resolves to the i-th residue's number, skipping unmodeled gaps."""
+    structure = _offset_gapped_structure()
+    resolved = ResidueSelection(chains={"A": [1, 4, 5]}).to_residue_numbers(structure)
+    assert resolved == {"A": [27, 35, 36]}  # position 4 skips the 30-34 gap to residue 35
+
+
+def test_residue_selection_to_residue_numbers_identity_when_numbered_from_one(structure: Structure) -> None:
+    """When a chain is numbered 1..N, resolution is the identity map."""
+    assert ResidueSelection(chains={"A": [1, 2, 3]}).to_residue_numbers(structure) == {"A": [1, 2, 3]}
+
+
 # ============================================================================
 # SingleChainSelection
 # ============================================================================


### PR DESCRIPTION
Brings `proto-bio/proto-tools:main` up to date on top of `evo-design/proto-tools:main` (ahead by 7 commits, behind by 0 — merges cleanly). Two substantive changes, plus intervening `Merge 'evo-design:main' into main` sync commits.

## Honor 1-indexed residue positions in ResidueSelection (proto-bio#12)

`ResidueSelection` documents its positions as **1-indexed** (position 1 = the first residue), and that is how `fixed_positions` / `fixed_sidechain_positions` are described across the inverse-folding tools. But the implementation used **author residue numbers**: `validate_against` checked against `Structure.get_chain_positions` (author `seqid.num`), and the tools forwarded positions verbatim to the models, which resolve `"{chain}{number}"` by author numbering. These coincide only for structures numbered `1..N` with no gaps (all test fixtures), so CI never caught the divergence — but for a structure starting at, say, 27 with gaps, a valid 1-indexed selection was rejected, or silently fixed the wrong residue.

- `ResidueSelection.validate_against` now bounds positions to `1..N` (the chain's residue count).
- New `ResidueSelection.to_residue_numbers(structure)` maps each 1-indexed position to the corresponding residue's number via `get_chain_positions(chain)[i - 1]`.
- All inverse-folding tools (`proteinmpnn` / `ligandmpnn` / `esm-if` / `fampnn` — sample, score, gradient, pack) resolve `fixed_positions` and `fixed_sidechain_positions` through it before building model inputs, so validation and model application stay in the same space. Also corrects `_fixed_positions_cover_structure`, which previously never matched on offset-numbered structures.
- Tests: an offset + gapped fixture (chain A = 27, 28, 29, 35, 36) proving position 1 → residue 27, position 4 → residue 35 (skips the gap), position 6 rejected; existing `1..N` fixtures are unchanged (identity map).

## Pin active CUDA device in original LigandMPNN path for multi-GPU dispatch (proto-bio#11)

Pins the active CUDA device in the original LigandMPNN code path so multi-GPU dispatch targets the assigned device.

## Verification

`tests/structure_tests/test_selection.py`, `tests/inverse_folding_tests/test_if_schemas.py`, the full `tests/style_consistency_tests/` suite, and the non-GPU inverse-folding tests all pass; ruff + mypy clean. GPU sampling tests are unaffected (fixtures are numbered `1..N`).
