### PR TITLE
feat(remote): add managed multi-node execution

### DIFF
--- a/proto_tools/cli.py
+++ b/proto_tools/cli.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import shlex
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -23,6 +25,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from proto_tools.tools.tool_registry import ToolRegistry, ToolSpec
+from proto_tools.utils import remote_execution as remote_exec
 from proto_tools.utils.tool_instance import ToolInstance
 
 logger = logging.getLogger(__name__)
@@ -36,7 +39,7 @@ logger = logging.getLogger(__name__)
 def _dump_json(value: Any) -> str:
     """Render any value as pretty-printed JSON."""
     if isinstance(value, BaseModel):
-        return value.model_dump_json(indent=2)
+        return str(value.model_dump_json(indent=2))
     if isinstance(value, list) and value and isinstance(value[0], BaseModel):
         return json.dumps([v.model_dump() for v in value], indent=2, default=str)
     if isinstance(value, dict) and value and isinstance(next(iter(value.values()), None), list):
@@ -319,6 +322,602 @@ def _cmd_agent_context(_args: argparse.Namespace) -> int:
     return 0
 
 
+def _remote_nodes_from_args(args: argparse.Namespace) -> list[remote_exec.RemoteNode]:
+    """Load and optionally filter remote nodes for CLI commands."""
+    nodes = remote_exec.load_remote_nodes_json(args.profile)
+    node_names = getattr(args, "node", None)
+    if not node_names:
+        return nodes
+    requested = set(node_names)
+    filtered = [node for node in nodes if node.name in requested]
+    missing = sorted(requested - {node.name for node in filtered})
+    if missing:
+        raise ValueError(f"Remote node(s) not found in {args.profile}: {', '.join(missing)}")
+    return filtered
+
+
+def _existing_remote_command_node_from_args(args: argparse.Namespace) -> remote_exec.ExistingRemoteCommandNode:
+    """Load one existing-command node for direct wrapper execution."""
+    nodes = remote_exec.load_existing_remote_command_nodes_json(args.profile)
+    return remote_exec.select_existing_remote_command_node(nodes, args.node)
+
+
+def _raise_for_remote_profile_errors(nodes: list[remote_exec.RemoteNode]) -> None:
+    """Raise before SSH commands when a remote profile has static errors."""
+    profile_errors = [issue for issue in remote_exec.validate_remote_nodes(nodes) if issue.level == "error"]
+    if profile_errors:
+        first = profile_errors[0]
+        raise ValueError(f"Invalid remote profile: {first.node_name or '-'} {first.field}: {first.message}")
+
+
+def _validated_remote_nodes_from_args(args: argparse.Namespace) -> list[remote_exec.RemoteNode]:
+    """Load remote nodes and reject static profile errors."""
+    nodes = _remote_nodes_from_args(args)
+    _raise_for_remote_profile_errors(nodes)
+    return nodes
+
+
+def _parse_remote_scaffold_node(raw: str) -> tuple[str, str | None, str]:
+    """Parse ``NAME[@HOST]=HOME`` for profile scaffolding."""
+    if "=" not in raw:
+        raise ValueError(f"Remote profile node must use NAME[@HOST]=HOME: {raw!r}")
+    left, home_dir = raw.split("=", 1)
+    if not left or not home_dir:
+        raise ValueError(f"Remote profile node must use NAME[@HOST]=HOME: {raw!r}")
+    if "@" in left:
+        name, host = left.split("@", 1)
+    else:
+        name, host = left, None
+    if not name or host == "":
+        raise ValueError(f"Remote profile node must use NAME[@HOST]=HOME: {raw!r}")
+    return name, host, home_dir
+
+
+def _print_remote_mapping(args: argparse.Namespace, payload: dict[str, Any]) -> int:
+    """Print per-node remote command results."""
+    if getattr(args, "json", False):
+        print(_dump_json(payload))
+        return 0
+    for name, value in payload.items():
+        rendered = json.dumps(value, sort_keys=True) if isinstance(value, dict | list) else str(value)
+        print(f"{name}\t{rendered}")
+    return 0
+
+
+def _remote_timeout_kwargs(args: argparse.Namespace) -> dict[str, float]:
+    """Return optional timeout kwargs without disturbing narrow test fakes."""
+    timeout_sec = getattr(args, "timeout_sec", None)
+    return {} if timeout_sec is None else {"timeout_sec": timeout_sec}
+
+
+def _cmd_remote_profile_scaffold(args: argparse.Namespace) -> int:
+    """``proto-tools remote profile scaffold``."""
+    if not args.direct and not args.slurm:
+        raise ValueError("remote profile scaffold requires at least one --direct or --slurm node")
+    nodes: list[remote_exec.RemoteNode] = []
+    for raw in args.direct:
+        name, host, home_dir = _parse_remote_scaffold_node(raw)
+        nodes.append(
+            remote_exec.scaffold_remote_node(
+                name,
+                home_dir,
+                host=host,
+                scheduler="direct",
+                repo_name=args.repo_name,
+                work_name=args.work_name_template or args.work_name,
+                bootstrap_python=args.bootstrap_python,
+                weight=args.direct_weight,
+                max_concurrent_buckets=args.direct_max_concurrent_buckets,
+                worker_device=args.direct_worker_device,
+            )
+        )
+    for raw in args.slurm:
+        name, host, home_dir = _parse_remote_scaffold_node(raw)
+        nodes.append(
+            remote_exec.scaffold_remote_node(
+                name,
+                home_dir,
+                host=host,
+                scheduler="slurm",
+                repo_name=args.repo_name,
+                work_name=args.work_name_template or args.work_name,
+                bootstrap_python=args.bootstrap_python,
+                weight=args.slurm_weight,
+                max_concurrent_buckets=args.slurm_max_concurrent_buckets,
+                max_active_slurm_jobs=args.slurm_max_active_jobs,
+                worker_device=args.slurm_worker_device,
+                sbatch_args=tuple(args.slurm_sbatch_arg),
+            )
+        )
+
+    issues = remote_exec.validate_remote_nodes(nodes)
+    errors = [issue for issue in issues if issue.level == "error"]
+    if errors:
+        first = errors[0]
+        raise ValueError(f"generated remote profile is invalid: {first.node_name or '-'} {first.field}: {first.message}")
+
+    remote_exec.write_remote_nodes_json(nodes, args.output, overwrite=args.overwrite)
+    summary = {
+        "output": str(args.output),
+        "nodes": [node.to_dict() for node in nodes],
+        "issues": [issue.to_dict() for issue in issues],
+    }
+    if args.json:
+        print(_dump_json(summary))
+    else:
+        print(f"profile\t{args.output}")
+        for node in nodes:
+            print(f"node\t{node.name}\t{node.host}\t{node.scheduler}\twork_dir={node.work_dir}")
+        for issue in issues:
+            print(f"{issue.level}\t{issue.node_name or '-'}\t{issue.field}\t{issue.message}")
+    return 0
+
+
+def _cmd_remote_profile_list(args: argparse.Namespace) -> int:
+    """``proto-tools remote profile list``."""
+    nodes = _remote_nodes_from_args(args)
+    if args.json:
+        print(_dump_json([node.to_dict() for node in nodes]))
+        return 0
+    for node in nodes:
+        print(
+            f"{node.name}\t{node.host}\t{node.scheduler}\t"
+            f"weight={node.weight}\tmax_concurrent_buckets={node.max_concurrent_buckets}"
+        )
+    return 0
+
+
+def _cmd_remote_profile_validate(args: argparse.Namespace) -> int:
+    """``proto-tools remote profile validate``."""
+    nodes = _remote_nodes_from_args(args)
+    issues = remote_exec.validate_remote_nodes(nodes)
+    has_errors = any(issue.level == "error" for issue in issues)
+    payload = {
+        "ok": not has_errors,
+        "node_count": len(nodes),
+        "issues": [issue.to_dict() for issue in issues],
+    }
+    if args.json:
+        print(_dump_json(payload))
+    elif not issues:
+        print("ok")
+    else:
+        for issue in issues:
+            print(f"{issue.level}\t{issue.node_name or '-'}\t{issue.field}\t{issue.message}")
+    return 1 if has_errors else 0
+
+
+def _cmd_remote_manager_start(args: argparse.Namespace) -> int:
+    """``proto-tools remote manager-start``."""
+    nodes = _validated_remote_nodes_from_args(args)
+    client = remote_exec.RemoteManagerClient()
+    timeout_kwargs = _remote_timeout_kwargs(args)
+    payload = {
+        node.name: client.start_node(
+            node,
+            poll_interval=args.poll_interval,
+            slurm_group_size=args.slurm_group_size,
+            **timeout_kwargs,
+        )
+        for node in nodes
+    }
+    return _print_remote_mapping(args, payload)
+
+
+def _cmd_remote_manager_status(args: argparse.Namespace) -> int:
+    """``proto-tools remote manager-status``."""
+    nodes = _validated_remote_nodes_from_args(args)
+    client = remote_exec.RemoteManagerClient()
+    timeout_kwargs = _remote_timeout_kwargs(args)
+    payload = {node.name: client.status_node(node, **timeout_kwargs) for node in nodes}
+    return _print_remote_mapping(args, payload)
+
+
+def _cmd_remote_manager_preflight(args: argparse.Namespace) -> int:
+    """``proto-tools remote manager-preflight``."""
+    nodes = _validated_remote_nodes_from_args(args)
+    client = remote_exec.RemoteManagerClient()
+    timeout_kwargs = _remote_timeout_kwargs(args)
+    payload = {node.name: client.preflight_node(node, **timeout_kwargs) for node in nodes}
+    return _print_remote_mapping(args, payload)
+
+
+def _cmd_remote_manager_diagnostics(args: argparse.Namespace) -> int:
+    """``proto-tools remote manager-diagnostics``."""
+    nodes = _validated_remote_nodes_from_args(args)
+    client = remote_exec.RemoteManagerClient()
+    timeout_kwargs = _remote_timeout_kwargs(args)
+    payload = {node.name: client.diagnostics_node(node, **timeout_kwargs) for node in nodes}
+    return _print_remote_mapping(args, payload)
+
+
+def _cmd_remote_smoke(args: argparse.Namespace) -> int:
+    """``proto-tools remote smoke``."""
+    report = remote_exec.smoke_remote_nodes(
+        _remote_nodes_from_args(args),
+        local_results_dir=args.local_results_dir,
+        timeout_sec=args.timeout_sec,
+    )
+    if args.json:
+        print(_dump_json(report.to_dict()))
+    else:
+        print("ok" if report.ok else "failed")
+        for issue in report.profile_issues:
+            print(f"{issue.level}\t{issue.node_name or '-'}\t{issue.field}\t{issue.message}")
+        for name, payload in report.preflight.items():
+            if not payload.get("ok"):
+                print(f"preflight-failed\t{name}\t{json.dumps(payload, sort_keys=True)}")
+        for name, status in report.manager_status.items():
+            if status.startswith("check-failed:"):
+                print(f"manager-status-failed\t{name}\t{status}")
+        for name, payload in report.diagnostics.items():
+            if isinstance(payload, dict) and payload.get("ok") is False:
+                print(f"diagnostics-failed\t{name}\t{json.dumps(payload, sort_keys=True)}")
+    return 0 if report.ok else 1
+
+
+def _cmd_remote_existing_plan(args: argparse.Namespace) -> int:
+    """``proto-tools remote existing plan``."""
+    node = _existing_remote_command_node_from_args(args)
+    plan = remote_exec.plan_existing_remote_command(
+        node,
+        local_input_path=args.input,
+        run_id=args.run_id,
+        local_collect_dir=args.local_collect_dir,
+    )
+    payload = plan.to_dict()
+    if args.json:
+        print(_dump_json(payload))
+    else:
+        for step, command in payload["commands"].items():
+            print(f"existing-command\t{plan.node_name}\t{step}\t{shlex.join(command)}")
+    return 0
+
+
+def _cmd_remote_existing_run(args: argparse.Namespace) -> int:
+    """``proto-tools remote existing run``."""
+    node = _existing_remote_command_node_from_args(args)
+    result = remote_exec.run_existing_remote_command(
+        node,
+        local_input_path=args.input,
+        run_id=args.run_id,
+        local_collect_dir=args.local_collect_dir,
+        timeout_sec=args.timeout_sec,
+    )
+    if args.json:
+        print(_dump_json(result.to_dict()))
+    else:
+        print(f"completed\t{result.plan.node_name}\t{result.plan.run_id}")
+        for path in result.collected_files:
+            print(f"collected\t{path}")
+    return 0
+
+
+def _cmd_remote_existing_launch(args: argparse.Namespace) -> int:
+    """``proto-tools remote existing launch``."""
+    nodes = remote_exec.load_existing_remote_batch_nodes_json(args.profile)
+    result = remote_exec.launch_existing_remote_command_batch(
+        nodes,
+        input_fasta=args.input,
+        software=args.software,
+        run_dir=args.run_dir,
+        bucket_size=args.bucket_size,
+        slurm_group_size=args.slurm_group_size,
+        wait_poll_interval=args.wait_poll_interval,
+        timeout_sec=args.timeout_sec,
+        remote_check_timeout_sec=args.remote_check_timeout_sec,
+    )
+    if args.json:
+        print(_dump_json(result.to_dict()))
+    else:
+        print(f"completed\t{result.run_id}\t{result.task_count}")
+        for node_name, count in result.assignment.items():
+            print(f"assigned\t{node_name}\t{count}")
+        print(f"summary\t{result.summary}")
+    return 0
+
+
+def _cmd_remote_compute(args: argparse.Namespace) -> int:
+    """``proto-tools remote compute``."""
+    config = remote_exec.resolve_remote_compute_config(args.software, registry_path=args.registry)
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.is_file():
+        raise ValueError(f"Remote compute input FASTA not found: {input_path}")
+    run_dir = Path(args.run_dir).expanduser().resolve()
+    nodes = remote_exec.load_existing_remote_batch_nodes_json(config.profile_path)
+    result = remote_exec.launch_existing_remote_command_batch(
+        nodes,
+        input_fasta=input_path,
+        software=config.software,
+        run_dir=run_dir,
+        bucket_size=config.bucket_size if args.bucket_size is None else args.bucket_size,
+        slurm_group_size=config.slurm_group_size if args.slurm_group_size is None else args.slurm_group_size,
+        wait_poll_interval=(
+            config.wait_poll_interval if args.wait_poll_interval is None else args.wait_poll_interval
+        ),
+        timeout_sec=config.timeout_sec if args.timeout_sec is None else args.timeout_sec,
+        remote_check_timeout_sec=(
+            config.remote_check_timeout_sec
+            if args.remote_check_timeout_sec is None
+            else args.remote_check_timeout_sec
+        ),
+    )
+    payload = {
+        "software": config.software,
+        "registry": str(config.registry_path),
+        "profile": str(config.profile_path),
+        "receipt": str(run_dir / "compute.json"),
+        **result.to_dict(),
+    }
+    remote_exec.write_remote_compute_receipt(payload, run_dir / "compute.json")
+    if args.json:
+        print(_dump_json(payload))
+    else:
+        print(f"completed\t{result.run_id}\t{result.task_count}")
+        print(f"software\t{config.software}")
+        print(f"profile\t{config.profile_path}")
+        print(f"receipt\t{run_dir / 'compute.json'}")
+        for node_name, count in result.assignment.items():
+            print(f"assigned\t{node_name}\t{count}")
+        print(f"summary\t{result.summary}")
+    return 0
+
+
+def _cmd_remote_deploy_render(args: argparse.Namespace) -> int:
+    """``proto-tools remote deploy render``."""
+    nodes = _remote_nodes_from_args(args)
+    report = remote_exec.build_deploy_render_report(
+        nodes,
+        args.local_repo_dir,
+        allow_dirty_checkout=args.allow_dirty_checkout,
+    )
+    if args.json:
+        print(_dump_json(report.to_dict()))
+    else:
+        for blocker in report.blockers:
+            print(f"blocker\t{blocker}")
+        for warning in report.warnings:
+            print(f"warning\t{warning}")
+        for action in report.actions:
+            print(f"action\t{action}")
+        for node in report.nodes:
+            for command in node.commands:
+                print(f"deploy-command\t{node.node_name}\t{shlex.join(list(command))}")
+    return 0 if report.ok else 1
+
+
+def _cmd_remote_deploy_apply(args: argparse.Namespace) -> int:
+    """``proto-tools remote deploy apply``."""
+    nodes = _remote_nodes_from_args(args)
+    report = remote_exec.build_deploy_render_report(
+        nodes,
+        args.local_repo_dir,
+        allow_dirty_checkout=args.allow_dirty_checkout,
+    )
+    blockers = list(report.blockers)
+    shared_roots = set(remote_exec.shared_remote_install_roots(nodes))
+    if args.allow_shared_install_root:
+        blockers = [blocker for blocker in blockers if blocker not in shared_roots]
+    if blockers:
+        shared_root_prefix = (
+            "shared install roots require --allow-shared-install-root; "
+            if any(blocker in shared_roots for blocker in blockers)
+            else ""
+        )
+        raise ValueError(
+            "remote deploy apply preflight failed: " + shared_root_prefix + "; ".join(blockers)
+        )
+    client = remote_exec.RemoteDeploymentClient()
+    payload = {}
+    for node in nodes:
+        results = client.deploy_node(node, args.local_repo_dir)
+        payload[node.name] = {
+            "command_count": len(results),
+            "returncodes": [getattr(result, "returncode", 0) for result in results],
+        }
+    if args.json:
+        print(_dump_json(payload))
+    else:
+        for name, summary in payload.items():
+            print(f"deployed\t{name}\tcommand_count={summary['command_count']}")
+    return 0
+
+
+def _cmd_remote_rsync_once(args: argparse.Namespace) -> int:
+    """``proto-tools remote rsync-once``."""
+    nodes = _remote_nodes_from_args(args)
+    for cmd in remote_exec.render_rsync_pull_commands(nodes, args.local_results_dir):
+        subprocess.run(cmd, check=True)  # noqa: S603
+    return 0
+
+
+def _cmd_remote_rsync_start(args: argparse.Namespace) -> int:
+    """``proto-tools remote rsync-start``."""
+    stdout = remote_exec.LocalRsyncPullClient().start(
+        _remote_nodes_from_args(args),
+        args.local_results_dir,
+        pid_path=args.pid_file,
+        log_path=args.log_file,
+        interval_sec=args.interval_sec,
+    )
+    print(stdout)
+    return 0
+
+
+def _cmd_remote_rsync_status(args: argparse.Namespace) -> int:
+    """``proto-tools remote rsync-status``."""
+    print(remote_exec.LocalRsyncPullClient().status(args.pid_file))
+    return 0
+
+
+def _cmd_remote_rsync_stop(args: argparse.Namespace) -> int:
+    """``proto-tools remote rsync-stop``."""
+    print(remote_exec.LocalRsyncPullClient().stop(args.pid_file))
+    return 0
+
+
+def _cmd_remote_run_plan(args: argparse.Namespace) -> int:
+    """``proto-tools remote run plan``."""
+    nodes = _validated_remote_nodes_from_args(args)
+    inputs = json.loads(Path(args.input_json).read_text())
+    config = None if args.config_json is None else json.loads(Path(args.config_json).read_text())
+    local_results_dir = Path(args.local_results_dir).resolve()
+    diagnostics: dict[str, Any] | None = None
+    initial_node_loads: dict[str, float] | None = None
+    if args.use_diagnostics_backlog:
+        diagnostics, initial_node_loads = remote_exec.remote_run_diagnostics_backlog_loads(
+            nodes,
+            timeout_sec=args.remote_check_timeout_sec,
+        )
+    planner_kwargs: dict[str, Any] = {}
+    if initial_node_loads is not None:
+        planner_kwargs["initial_node_loads"] = initial_node_loads
+    plan = remote_exec.RemoteDispatchPlanner(nodes, args.bucket_size, **planner_kwargs).build_plan(
+        args.tool,
+        inputs,
+        config,
+        run_id=args.run_id,
+    )
+    manifest = remote_exec.RemoteRunManifest.from_plan(
+        plan,
+        nodes=nodes,
+        bucket_size=args.bucket_size,
+        local_results_dir=local_results_dir,
+    )
+    remote_exec.write_remote_run_manifest(manifest, args.manifest, overwrite=args.overwrite)
+    summary = {
+        "run_id": manifest.run_id,
+        "manifest": str(args.manifest),
+        "bucket_count": len(manifest.requests),
+        "local_results_dir": manifest.local_results_dir,
+    }
+    if diagnostics is not None:
+        summary["diagnostics"] = diagnostics
+    if initial_node_loads is not None:
+        summary["initial_node_loads"] = initial_node_loads
+    if args.json:
+        print(_dump_json(summary))
+    else:
+        print(f"manifest\t{args.manifest}")
+        print(f"run_id\t{manifest.run_id}")
+        print(f"bucket_count\t{len(manifest.requests)}")
+        if initial_node_loads is not None:
+            print(f"initial_node_loads\t{json.dumps(initial_node_loads, sort_keys=True)}")
+    return 0
+
+
+def _cmd_remote_run_launch(args: argparse.Namespace) -> int:
+    """``proto-tools remote run launch``."""
+    nodes = _remote_nodes_from_args(args)
+    inputs = json.loads(Path(args.input_json).read_text())
+    config = None if args.config_json is None else json.loads(Path(args.config_json).read_text())
+    result = remote_exec.launch_remote_run(
+        args.tool,
+        nodes,
+        inputs,
+        config,
+        bucket_size=args.bucket_size,
+        local_results_dir=args.local_results_dir,
+        manifest_path=args.manifest,
+        output_path=args.output,
+        run_id=args.run_id,
+        overwrite=args.overwrite,
+        manager_poll_interval=args.manager_poll_interval,
+        slurm_group_size=args.slurm_group_size,
+        wait_poll_interval=args.wait_poll_interval,
+        timeout_sec=args.timeout_sec,
+        rsync_mode=args.rsync_mode,
+        rsync_pid_path=args.rsync_pid_file,
+        rsync_log_path=args.rsync_log_file,
+        rsync_interval_sec=args.rsync_interval_sec,
+        use_diagnostics_backlog=args.use_diagnostics_backlog,
+        overwrite_output=args.overwrite_output,
+        remote_check_timeout_sec=args.remote_check_timeout_sec,
+    )
+    if args.json:
+        print(_dump_json(result.to_dict()))
+    else:
+        print(f"completed\t{result.run_id}")
+        print(f"manifest\t{result.manifest_path}")
+        print(f"output\t{result.output_path}")
+        print(f"bucket_count\t{result.bucket_count}")
+    return 0
+
+
+def _cmd_remote_run_resume(args: argparse.Namespace) -> int:
+    """``proto-tools remote run resume``."""
+    manifest = remote_exec.load_remote_run_manifest(args.manifest)
+    result = remote_exec.resume_remote_run_manifest(
+        manifest,
+        manifest_path=args.manifest,
+        output_path=args.output,
+        manager_poll_interval=args.manager_poll_interval,
+        slurm_group_size=args.slurm_group_size,
+        wait_poll_interval=args.wait_poll_interval,
+        timeout_sec=args.timeout_sec,
+        rsync_mode=args.rsync_mode,
+        rsync_pid_path=args.rsync_pid_file,
+        rsync_log_path=args.rsync_log_file,
+        rsync_interval_sec=args.rsync_interval_sec,
+        overwrite_output=args.overwrite_output,
+        remote_check_timeout_sec=args.remote_check_timeout_sec,
+    )
+    if args.json:
+        print(_dump_json(result.to_dict()))
+    else:
+        print(f"completed\t{result.run_id}")
+        print(f"manifest\t{result.manifest_path}")
+        print(f"output\t{result.output_path}")
+        print(f"bucket_count\t{result.bucket_count}")
+    return 0
+
+
+def _cmd_remote_run_submit(args: argparse.Namespace) -> int:
+    """``proto-tools remote run submit``."""
+    manifest = remote_exec.load_remote_run_manifest(args.manifest)
+    staged = remote_exec.submit_remote_run_manifest(manifest)
+    summary = {"run_id": manifest.run_id, "bucket_count": len(staged)}
+    if args.json:
+        print(_dump_json(summary))
+    else:
+        print(f"submitted\t{manifest.run_id}\tbucket_count={len(staged)}")
+    return 0
+
+
+def _cmd_remote_run_wait(args: argparse.Namespace) -> int:
+    """``proto-tools remote run wait``."""
+    manifest = remote_exec.load_remote_run_manifest(args.manifest)
+    remote_exec.wait_remote_run_manifest(
+        manifest,
+        poll_interval=args.poll_interval,
+        timeout_sec=args.timeout_sec,
+        pull_results=not args.no_pull,
+        rsync_pid_path=args.rsync_pid_file,
+        rsync_log_path=args.rsync_log_file,
+    )
+    summary = {"run_id": manifest.run_id, "status": "completed"}
+    if args.json:
+        print(_dump_json(summary))
+    else:
+        print(f"completed\t{manifest.run_id}")
+    return 0
+
+
+def _cmd_remote_run_collect(args: argparse.Namespace) -> int:
+    """``proto-tools remote run collect``."""
+    remote_exec.ensure_remote_run_output_path_available(args.output, overwrite=args.overwrite_output)
+    manifest = remote_exec.load_remote_run_manifest(args.manifest)
+    output = remote_exec.collect_remote_run_manifest(manifest)
+    output_path = Path(args.output)
+    remote_exec.write_remote_run_output(output, output_path, overwrite=args.overwrite_output)
+    summary = {"run_id": manifest.run_id, "output": str(output_path)}
+    if args.json:
+        print(_dump_json(summary))
+    else:
+        print(f"output\t{output_path}")
+    return 0
+
+
 # =============================================================================
 # Argparse wiring
 # =============================================================================
@@ -352,6 +951,310 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Print a usage primer for coding agents (start here).",
     )
     p_agent.set_defaults(func=_cmd_agent_context)
+
+    p_remote = sub.add_parser("remote", help="Manage user-owned SSH remote execution nodes.")
+    remote_sub = p_remote.add_subparsers(dest="remote_verb", required=True)
+
+    def add_profile_args(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--profile", required=True, help="JSON profile with a top-level nodes list.")
+        p.add_argument("--node", action="append", help="Limit to one node name; repeat for multiple nodes.")
+
+    def add_existing_command_args(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--profile", required=True, help="Existing-command JSON profile with a top-level nodes list.")
+        p.add_argument("--node", required=True, help="Existing-command node name to run on.")
+        p.add_argument("--input", required=True, help="Local input file to upload.")
+        p.add_argument("--run-id", required=True, help="Safe run identifier used in the remote work directory.")
+        p.add_argument("--local-collect-dir", required=True, help="Local directory for collected remote outputs.")
+
+    p_remote_compute = remote_sub.add_parser(
+        "compute",
+        help="Distribute, supervise, and collect a maintained remote protein runtime.",
+    )
+    p_remote_compute.add_argument("software", help="Maintained software name or alias, for example af3.")
+    p_remote_compute.add_argument("input", help="Input FASTA; each record is one task.")
+    p_remote_compute.add_argument("run_dir", help="New local run directory, or the same directory to resume.")
+    p_remote_compute.add_argument("--registry", help="Override the $hand-compute runtime registry.")
+    p_remote_compute.add_argument("--bucket-size", type=int)
+    p_remote_compute.add_argument("--slurm-group-size", type=int)
+    p_remote_compute.add_argument("--wait-poll-interval", type=float)
+    p_remote_compute.add_argument("--timeout-sec", type=float)
+    p_remote_compute.add_argument("--remote-check-timeout-sec", type=float)
+    p_remote_compute.add_argument("--json", action="store_true")
+    p_remote_compute.set_defaults(func=_cmd_remote_compute)
+
+    p_remote_run = remote_sub.add_parser("run", help="Plan, submit, wait for, and collect remote bucket runs.")
+    run_sub = p_remote_run.add_subparsers(dest="run_verb", required=True)
+
+    p_remote_run_plan = run_sub.add_parser("plan", help="Create a manifest-backed remote run plan.")
+    p_remote_run_plan.add_argument("tool", help="Tool key to run remotely.")
+    add_profile_args(p_remote_run_plan)
+    p_remote_run_plan.add_argument("--input-json", required=True, help="JSON input payload for the tool.")
+    p_remote_run_plan.add_argument("--config-json", help="JSON config payload for the tool.")
+    p_remote_run_plan.add_argument("--bucket-size", type=int, required=True)
+    p_remote_run_plan.add_argument("--local-results-dir", required=True)
+    p_remote_run_plan.add_argument("--manifest", required=True)
+    p_remote_run_plan.add_argument("--run-id")
+    p_remote_run_plan.add_argument("--overwrite", action="store_true")
+    p_remote_run_plan.add_argument(
+        "--use-diagnostics-backlog",
+        action="store_true",
+        help="Seed planning load from current queue/running/submitted manager diagnostics.",
+    )
+    p_remote_run_plan.add_argument(
+        "--remote-check-timeout-sec",
+        type=float,
+        help="Per-SSH timeout for diagnostics when --use-diagnostics-backlog is set.",
+    )
+    p_remote_run_plan.add_argument("--json", action="store_true")
+    p_remote_run_plan.set_defaults(func=_cmd_remote_run_plan)
+
+    p_remote_run_launch = run_sub.add_parser(
+        "launch",
+        help="Preflight managers, submit a manifest run, wait, and collect output.",
+    )
+    p_remote_run_launch.add_argument("tool", help="Tool key to run remotely.")
+    add_profile_args(p_remote_run_launch)
+    p_remote_run_launch.add_argument("--input-json", required=True, help="JSON input payload for the tool.")
+    p_remote_run_launch.add_argument("--config-json", help="JSON config payload for the tool.")
+    p_remote_run_launch.add_argument("--bucket-size", type=int, required=True)
+    p_remote_run_launch.add_argument("--local-results-dir", required=True)
+    p_remote_run_launch.add_argument("--manifest", required=True)
+    p_remote_run_launch.add_argument("--output", required=True)
+    p_remote_run_launch.add_argument("--run-id")
+    p_remote_run_launch.add_argument("--overwrite", action="store_true")
+    p_remote_run_launch.add_argument(
+        "--overwrite-output",
+        action="store_true",
+        help="Allow replacing an existing merged output JSON.",
+    )
+    p_remote_run_launch.add_argument("--manager-poll-interval", type=float, default=5.0)
+    p_remote_run_launch.add_argument("--slurm-group-size", type=int, default=10)
+    p_remote_run_launch.add_argument("--wait-poll-interval", type=float, default=5.0)
+    p_remote_run_launch.add_argument("--timeout-sec", type=float)
+    p_remote_run_launch.add_argument(
+        "--remote-check-timeout-sec",
+        type=float,
+        help="Per-SSH timeout for manager preflight, start, and diagnostics checks.",
+    )
+    p_remote_run_launch.add_argument("--rsync-mode", choices=("inline", "background"), default="inline")
+    p_remote_run_launch.add_argument("--rsync-pid-file")
+    p_remote_run_launch.add_argument("--rsync-log-file")
+    p_remote_run_launch.add_argument("--rsync-interval-sec", type=int, default=10)
+    p_remote_run_launch.add_argument(
+        "--use-diagnostics-backlog",
+        action="store_true",
+        help="Seed planning load from current queue/running/submitted manager diagnostics.",
+    )
+    p_remote_run_launch.add_argument("--json", action="store_true")
+    p_remote_run_launch.set_defaults(func=_cmd_remote_run_launch)
+
+    p_remote_run_resume = run_sub.add_parser(
+        "resume",
+        help="Resume an existing manifest run without replanning or rewriting the manifest.",
+    )
+    p_remote_run_resume.add_argument("--manifest", required=True)
+    p_remote_run_resume.add_argument("--output", required=True)
+    p_remote_run_resume.add_argument(
+        "--overwrite-output",
+        action="store_true",
+        help="Allow replacing an existing merged output JSON.",
+    )
+    p_remote_run_resume.add_argument("--manager-poll-interval", type=float, default=5.0)
+    p_remote_run_resume.add_argument("--slurm-group-size", type=int, default=10)
+    p_remote_run_resume.add_argument("--wait-poll-interval", type=float, default=5.0)
+    p_remote_run_resume.add_argument("--timeout-sec", type=float)
+    p_remote_run_resume.add_argument(
+        "--remote-check-timeout-sec",
+        type=float,
+        help="Per-SSH timeout for manager preflight and start checks.",
+    )
+    p_remote_run_resume.add_argument("--rsync-mode", choices=("inline", "background"), default="inline")
+    p_remote_run_resume.add_argument("--rsync-pid-file")
+    p_remote_run_resume.add_argument("--rsync-log-file")
+    p_remote_run_resume.add_argument("--rsync-interval-sec", type=int, default=10)
+    p_remote_run_resume.add_argument("--json", action="store_true")
+    p_remote_run_resume.set_defaults(func=_cmd_remote_run_resume)
+
+    p_remote_run_submit = run_sub.add_parser("submit", help="Idempotently stage queued bucket requests from a manifest.")
+    p_remote_run_submit.add_argument("--manifest", required=True)
+    p_remote_run_submit.add_argument("--json", action="store_true")
+    p_remote_run_submit.set_defaults(func=_cmd_remote_run_submit)
+
+    p_remote_run_wait = run_sub.add_parser("wait", help="Wait for manifest results to appear locally.")
+    p_remote_run_wait.add_argument("--manifest", required=True)
+    p_remote_run_wait.add_argument("--poll-interval", type=float, default=5.0)
+    p_remote_run_wait.add_argument("--timeout-sec", type=float)
+    p_remote_run_wait.add_argument("--no-pull", action="store_true", help="Do not run rsync pull rounds while waiting.")
+    p_remote_run_wait.add_argument("--rsync-pid-file", help="Background rsync pid file to monitor while waiting.")
+    p_remote_run_wait.add_argument("--rsync-log-file", help="Background rsync log file to include when the pull loop stops.")
+    p_remote_run_wait.add_argument("--json", action="store_true")
+    p_remote_run_wait.set_defaults(func=_cmd_remote_run_wait)
+
+    p_remote_run_collect = run_sub.add_parser("collect", help="Merge completed manifest results into one output JSON.")
+    p_remote_run_collect.add_argument("--manifest", required=True)
+    p_remote_run_collect.add_argument("--output", required=True)
+    p_remote_run_collect.add_argument(
+        "--overwrite-output",
+        action="store_true",
+        help="Allow replacing an existing merged output JSON.",
+    )
+    p_remote_run_collect.add_argument("--json", action="store_true")
+    p_remote_run_collect.set_defaults(func=_cmd_remote_run_collect)
+
+    p_remote_existing = remote_sub.add_parser("existing", help="Run already-installed remote command profiles.")
+    existing_sub = p_remote_existing.add_subparsers(dest="existing_verb", required=True)
+
+    p_remote_existing_plan = existing_sub.add_parser("plan", help="Render stage/execute/collect commands.")
+    add_existing_command_args(p_remote_existing_plan)
+    p_remote_existing_plan.add_argument("--json", action="store_true")
+    p_remote_existing_plan.set_defaults(func=_cmd_remote_existing_plan)
+
+    p_remote_existing_run = existing_sub.add_parser("run", help="Run one existing remote command and collect outputs.")
+    add_existing_command_args(p_remote_existing_run)
+    p_remote_existing_run.add_argument("--timeout-sec", type=float)
+    p_remote_existing_run.add_argument("--json", action="store_true")
+    p_remote_existing_run.set_defaults(func=_cmd_remote_existing_run)
+
+    p_remote_existing_launch = existing_sub.add_parser(
+        "launch",
+        help="Distribute an existing-command FASTA batch through remote managers.",
+    )
+    p_remote_existing_launch.add_argument("software", help="Maintained software name, for example alphafold3.")
+    p_remote_existing_launch.add_argument("--profile", required=True, help="Combined manager/command profile JSON.")
+    p_remote_existing_launch.add_argument("--input", required=True, help="Input FASTA; each record is one task.")
+    p_remote_existing_launch.add_argument(
+        "--run-dir",
+        required=True,
+        help="New run directory, or an exact matching manifest to resume in place.",
+    )
+    p_remote_existing_launch.add_argument("--bucket-size", type=int, default=1)
+    p_remote_existing_launch.add_argument("--slurm-group-size", type=int, default=10)
+    p_remote_existing_launch.add_argument("--wait-poll-interval", type=float, default=5.0)
+    p_remote_existing_launch.add_argument("--timeout-sec", type=float)
+    p_remote_existing_launch.add_argument("--remote-check-timeout-sec", type=float)
+    p_remote_existing_launch.add_argument("--json", action="store_true")
+    p_remote_existing_launch.set_defaults(func=_cmd_remote_existing_launch)
+
+    p_remote_profile = remote_sub.add_parser("profile", help="Inspect remote node profiles.")
+    profile_sub = p_remote_profile.add_subparsers(dest="profile_verb", required=True)
+
+    p_remote_profile_scaffold = profile_sub.add_parser("scaffold", help="Write a remote node profile JSON.")
+    p_remote_profile_scaffold.add_argument("--output", required=True, help="Path to write the profile JSON.")
+    p_remote_profile_scaffold.add_argument("--direct", action="append", default=[], metavar="NAME[@HOST]=HOME")
+    p_remote_profile_scaffold.add_argument("--slurm", action="append", default=[], metavar="NAME[@HOST]=HOME")
+    p_remote_profile_scaffold.add_argument("--repo-name", default="proto-tools")
+    p_remote_profile_scaffold.add_argument("--work-name", default="proto_remote")
+    p_remote_profile_scaffold.add_argument("--work-name-template")
+    p_remote_profile_scaffold.add_argument("--bootstrap-python", default="python3")
+    p_remote_profile_scaffold.add_argument("--direct-worker-device", default="cuda:0")
+    p_remote_profile_scaffold.add_argument("--slurm-worker-device", default="cuda")
+    p_remote_profile_scaffold.add_argument("--direct-weight", type=float, default=1.0)
+    p_remote_profile_scaffold.add_argument("--slurm-weight", type=float, default=1.0)
+    p_remote_profile_scaffold.add_argument("--direct-max-concurrent-buckets", type=int, default=1)
+    p_remote_profile_scaffold.add_argument("--slurm-max-concurrent-buckets", type=int, default=1)
+    p_remote_profile_scaffold.add_argument(
+        "--slurm-max-active-jobs",
+        type=int,
+        default=1,
+        help="Maximum submitted Slurm jobs one node manager may keep active.",
+    )
+    p_remote_profile_scaffold.add_argument("--slurm-sbatch-arg", action="append", default=[])
+    p_remote_profile_scaffold.add_argument("--overwrite", action="store_true")
+    p_remote_profile_scaffold.add_argument("--json", action="store_true")
+    p_remote_profile_scaffold.set_defaults(func=_cmd_remote_profile_scaffold)
+
+    p_remote_profile_list = profile_sub.add_parser("list", help="List configured remote nodes.")
+    add_profile_args(p_remote_profile_list)
+    p_remote_profile_list.add_argument("--json", action="store_true")
+    p_remote_profile_list.set_defaults(func=_cmd_remote_profile_list)
+    p_remote_profile_validate = profile_sub.add_parser("validate", help="Run static checks on a remote node profile.")
+    add_profile_args(p_remote_profile_validate)
+    p_remote_profile_validate.add_argument("--json", action="store_true")
+    p_remote_profile_validate.set_defaults(func=_cmd_remote_profile_validate)
+
+    p_remote_smoke = remote_sub.add_parser("smoke", help="Run no-submit remote profile and manager checks.")
+    add_profile_args(p_remote_smoke)
+    p_remote_smoke.add_argument("--local-results-dir", default="remote_results")
+    p_remote_smoke.add_argument("--timeout-sec", type=float)
+    p_remote_smoke.add_argument("--json", action="store_true")
+    p_remote_smoke.set_defaults(func=_cmd_remote_smoke)
+
+    p_remote_deploy = remote_sub.add_parser("deploy", help="Render or apply remote manager deployment.")
+    deploy_sub = p_remote_deploy.add_subparsers(dest="deploy_verb", required=True)
+
+    p_remote_deploy_render = deploy_sub.add_parser("render", help="Render deployment commands without running them.")
+    add_profile_args(p_remote_deploy_render)
+    p_remote_deploy_render.add_argument("--local-repo-dir", required=True, help="Local proto-tools checkout to upload.")
+    p_remote_deploy_render.add_argument(
+        "--allow-dirty-checkout",
+        action="store_true",
+        help="Mark dirty local checkout state as a warning instead of a blocker.",
+    )
+    p_remote_deploy_render.add_argument("--json", action="store_true")
+    p_remote_deploy_render.set_defaults(func=_cmd_remote_deploy_render)
+
+    p_remote_deploy_apply = deploy_sub.add_parser("apply", help="Run deployment commands on remote nodes.")
+    add_profile_args(p_remote_deploy_apply)
+    p_remote_deploy_apply.add_argument("--local-repo-dir", required=True, help="Local proto-tools checkout to upload.")
+    p_remote_deploy_apply.add_argument(
+        "--allow-shared-install-root",
+        action="store_true",
+        help="Allow selected nodes to write the same repo_dir or venv_dir.",
+    )
+    p_remote_deploy_apply.add_argument(
+        "--allow-dirty-checkout",
+        action="store_true",
+        help="Allow uploading a checkout with tracked or untracked local changes.",
+    )
+    p_remote_deploy_apply.add_argument("--json", action="store_true")
+    p_remote_deploy_apply.set_defaults(func=_cmd_remote_deploy_apply)
+
+    p_remote_manager = remote_sub.add_parser("manager", help="Start and inspect node-side managers.")
+    manager_sub = p_remote_manager.add_subparsers(dest="manager_verb", required=True)
+    p_remote_manager_start = manager_sub.add_parser("start", help="Start manager loops on remote nodes.")
+    add_profile_args(p_remote_manager_start)
+    p_remote_manager_start.add_argument("--poll-interval", type=float, default=5.0)
+    p_remote_manager_start.add_argument("--slurm-group-size", type=int, default=10)
+    p_remote_manager_start.add_argument("--timeout-sec", type=float, help="Per-SSH timeout for this manager command.")
+    p_remote_manager_start.add_argument("--json", action="store_true")
+    p_remote_manager_start.set_defaults(func=_cmd_remote_manager_start)
+
+    for verb, handler, help_text in (
+        ("status", _cmd_remote_manager_status, "Show manager pid state."),
+        ("preflight", _cmd_remote_manager_preflight, "Run remote environment checks."),
+        ("diagnostics", _cmd_remote_manager_diagnostics, "Show manager queue/log diagnostics."),
+    ):
+        p = manager_sub.add_parser(verb, help=help_text)
+        add_profile_args(p)
+        p.add_argument("--timeout-sec", type=float, help="Per-SSH timeout for this manager command.")
+        p.add_argument("--json", action="store_true")
+        p.set_defaults(func=handler)
+
+    p_remote_rsync = remote_sub.add_parser("rsync", help="Manage local result pull loops.")
+    rsync_sub = p_remote_rsync.add_subparsers(dest="rsync_mode", required=True)
+    p_remote_rsync_pull = rsync_sub.add_parser("pull", help="Pull remote result roots to a local mirror.")
+    pull_sub = p_remote_rsync_pull.add_subparsers(dest="rsync_pull_verb", required=True)
+
+    p_remote_rsync_once = pull_sub.add_parser("once", help="Run one rsync pull round for all selected nodes.")
+    add_profile_args(p_remote_rsync_once)
+    p_remote_rsync_once.add_argument("--local-results-dir", required=True)
+    p_remote_rsync_once.set_defaults(func=_cmd_remote_rsync_once)
+
+    p_remote_rsync_start = pull_sub.add_parser("start", help="Start a local background rsync pull loop.")
+    add_profile_args(p_remote_rsync_start)
+    p_remote_rsync_start.add_argument("--local-results-dir", required=True)
+    p_remote_rsync_start.add_argument("--pid-file", required=True)
+    p_remote_rsync_start.add_argument("--log-file", required=True)
+    p_remote_rsync_start.add_argument("--interval-sec", type=int, default=10)
+    p_remote_rsync_start.set_defaults(func=_cmd_remote_rsync_start)
+
+    p_remote_rsync_status = pull_sub.add_parser("status", help="Show local rsync pull loop status.")
+    p_remote_rsync_status.add_argument("--pid-file", required=True)
+    p_remote_rsync_status.set_defaults(func=_cmd_remote_rsync_status)
+
+    p_remote_rsync_stop = pull_sub.add_parser("stop", help="Stop a local rsync pull loop.")
+    p_remote_rsync_stop.add_argument("--pid-file", required=True)
+    p_remote_rsync_stop.set_defaults(func=_cmd_remote_rsync_stop)
 
     p_list = sub.add_parser("list", help="List registered tools.")
     filt = p_list.add_mutually_exclusive_group()

--- a/proto_tools/utils/remote_execution.py
+++ b/proto_tools/utils/remote_execution.py
@@ -1,0 +1,5360 @@
+"""Remote queue and scheduling helpers for multi-node tool execution.
+
+This module keeps remote execution deliberately small:
+
+* local code plans contiguous input buckets across named nodes;
+* SSH submission stages JSON requests into a per-node queue;
+* a node-side manager consumes queued requests and writes JSON results; and
+* result files can be merged back into the tool's normal output model.
+
+The node manager runs ordinary registered proto-tools functions on the remote
+host, so each node still uses its local ``DeviceManager`` and persistent-worker
+machinery.
+"""
+
+import argparse
+import json
+import logging
+import math
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+import traceback
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, cast
+
+from proto_tools.tools.tool_registry import ToolRegistry
+from proto_tools.utils.base_config import BaseConfig
+from proto_tools.utils.tool_instance import ToolInstance
+from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput
+
+RemoteScheduler = Literal["direct", "slurm"]
+RemoteRsyncMode = Literal["inline", "background"]
+ExistingCommandScheduler = Literal["direct", "srun"]
+ExistingCommandStatus = Literal["ready", "partial", "blocked"]
+_SCHEMA_VERSION = 1
+_MANIFEST_SCHEMA_VERSION = 1
+_PROFILE_SCHEMA_VERSION = 1
+_EXISTING_COMMAND_PROFILE_SCHEMA_VERSION = 1
+_DEPLOY_RENDER_SCHEMA_VERSION = 1
+_REMOTE_COMPUTE_REGISTRY_SCHEMA_VERSION = 1
+_REMOTE_COMPUTE_REGISTRY_ENV = "PROTO_TOOLS_REMOTE_COMPUTE_REGISTRY"
+_DEPLOY_COMMAND_STEPS = ("mkdir", "rsync_upload", "install_editable")
+_SLURM_ACTIVE_STATES = {
+    "CONFIGURING",
+    "COMPLETING",
+    "PENDING",
+    "RUNNING",
+    "RESIZING",
+    "REQUEUED",
+    "REQUEUE_FED",
+    "REQUEUE_HOLD",
+    "SIGNALING",
+    "SUSPENDED",
+}
+_SLURM_COMPLETED_STATES = {"COMPLETED"}
+_SLURM_FAILED_STATES = {
+    "CANCELLED",
+    "DEADLINE",
+    "FAILED",
+    "BOOT_FAIL",
+    "NODE_FAIL",
+    "OUT_OF_MEMORY",
+    "PREEMPTED",
+    "REVOKED",
+    "TIMEOUT",
+}
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_SLURM_ACCOUNTING_GRACE_SEC = 3600.0
+_SLURM_ADMISSION_MAX_START_DELAY_SEC = 300.0
+logger = logging.getLogger(__name__)
+
+
+def _validate_path_segment(field: str, value: str) -> str:
+    """Return ``value`` or raise when it is unsafe as one path component."""
+    if not value:
+        raise ValueError(f"{field} must be non-empty")
+    if not _PATH_SEGMENT_RE.fullmatch(value):
+        raise ValueError(
+            f"{field} must be a safe path segment using letters, digits, '_', '-', or '.', got {value!r}"
+        )
+    return value
+
+
+def _request_path_segment(request: dict[str, Any], key: str) -> str:
+    """Read and validate one path segment from a request payload."""
+    return _validate_path_segment(f"request.{key}", str(request[key]))
+
+
+@dataclass(frozen=True)
+class RemoteNode:
+    """A remote execution target managed through SSH."""
+
+    name: str
+    host: str
+    work_dir: str
+    repo_dir: str | None = None
+    venv_dir: str | None = None
+    bootstrap_python: str | None = None
+    weight: float = 1.0
+    max_concurrent_buckets: int = 1
+    scheduler: RemoteScheduler = "direct"
+    worker_device: str = "cuda"
+    python: str = "python"
+    ssh_args: tuple[str, ...] = ()
+    sbatch_args: tuple[str, ...] = ()
+    max_active_slurm_jobs: int | None = None
+    rsync_host: str | None = None
+    rsync_ssh_args: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate node scheduling fields."""
+        _validate_path_segment("RemoteNode.name", self.name)
+        if not self.host:
+            raise ValueError(f"RemoteNode {self.name!r}: host must be non-empty")
+        if not self.work_dir:
+            raise ValueError(f"RemoteNode {self.name!r}: work_dir must be non-empty")
+        if self.weight <= 0:
+            raise ValueError(f"RemoteNode {self.name!r}: weight must be > 0")
+        if self.max_concurrent_buckets < 1:
+            raise ValueError(f"RemoteNode {self.name!r}: max_concurrent_buckets must be >= 1")
+        if self.max_active_slurm_jobs is not None and self.max_active_slurm_jobs < 1:
+            raise ValueError(f"RemoteNode {self.name!r}: max_active_slurm_jobs must be >= 1")
+        if self.scheduler not in ("direct", "slurm"):
+            raise ValueError(f"RemoteNode {self.name!r}: unsupported scheduler {self.scheduler!r}")
+
+    @property
+    def queue_root(self) -> PurePosixPath:
+        """Remote queue directory for staged requests."""
+        return PurePosixPath(self.work_dir) / "queue"
+
+    @property
+    def results_root(self) -> PurePosixPath:
+        """Remote results directory written by the node manager."""
+        return PurePosixPath(self.work_dir) / "results"
+
+    @property
+    def logs_root(self) -> PurePosixPath:
+        """Remote logs directory for background manager processes."""
+        return PurePosixPath(self.work_dir) / "logs"
+
+    @property
+    def manager_pid_path(self) -> PurePosixPath:
+        """Remote pid file for the background manager process."""
+        return PurePosixPath(self.work_dir) / "manager.pid"
+
+    @property
+    def manager_log_path(self) -> PurePosixPath:
+        """Remote log file for the background manager process."""
+        return self.logs_root / "manager.log"
+
+    @property
+    def sync_host(self) -> str:
+        """Host string used by rsync pulls."""
+        return self.rsync_host or self.host
+
+    @property
+    def sync_ssh_args(self) -> tuple[str, ...]:
+        """SSH args used by rsync; defaults to the submission SSH args."""
+        return self.ssh_args if self.rsync_ssh_args is None else self.rsync_ssh_args
+
+    @property
+    def effective_venv_dir(self) -> str | None:
+        """Remote virtualenv path, defaulting under repo_dir when configured."""
+        if self.venv_dir is not None:
+            return self.venv_dir
+        if self.repo_dir is not None:
+            return str(PurePosixPath(self.repo_dir) / ".venv")
+        return None
+
+    @property
+    def deploy_python(self) -> str:
+        """Python used to create/install the remote environment."""
+        return self.bootstrap_python or self.python
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RemoteNode":
+        """Create a node from a JSON-compatible mapping."""
+        values = dict(data)
+        for key in ("ssh_args", "sbatch_args", "rsync_ssh_args"):
+            if key in values and values[key] is not None:
+                values[key] = tuple(values[key])
+        return cls(**values)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize a node to JSON-compatible data."""
+        return {
+            "name": self.name,
+            "host": self.host,
+            "work_dir": self.work_dir,
+            "repo_dir": self.repo_dir,
+            "venv_dir": self.venv_dir,
+            "bootstrap_python": self.bootstrap_python,
+            "weight": self.weight,
+            "max_concurrent_buckets": self.max_concurrent_buckets,
+            "scheduler": self.scheduler,
+            "worker_device": self.worker_device,
+            "python": self.python,
+            "ssh_args": list(self.ssh_args),
+            "sbatch_args": list(self.sbatch_args),
+            "max_active_slurm_jobs": self.max_active_slurm_jobs,
+            "rsync_host": self.rsync_host,
+            "rsync_ssh_args": None if self.rsync_ssh_args is None else list(self.rsync_ssh_args),
+        }
+
+
+@dataclass(frozen=True)
+class RemoteProfileIssue:
+    """A static profile validation issue."""
+
+    level: Literal["error", "warning"]
+    node_name: str | None
+    field: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this issue to JSON-compatible data."""
+        return {
+            "level": self.level,
+            "node_name": self.node_name,
+            "field": self.field,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class RemoteSmokeReport:
+    """No-submit smoke report for remote node profiles."""
+
+    ok: bool
+    profile_issues: tuple[RemoteProfileIssue, ...]
+    preflight: dict[str, Any]
+    manager_status: dict[str, str]
+    diagnostics: dict[str, Any]
+    rsync_pull_commands: tuple[tuple[str, ...], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this report to JSON-compatible data."""
+        return {
+            "ok": self.ok,
+            "profile_issues": [issue.to_dict() for issue in self.profile_issues],
+            "preflight": self.preflight,
+            "manager_status": self.manager_status,
+            "diagnostics": self.diagnostics,
+            "rsync_pull_commands": [list(cmd) for cmd in self.rsync_pull_commands],
+        }
+
+
+@dataclass(frozen=True)
+class ExistingRemoteCommandNode:
+    """A remote node that runs an already-installed command instead of a proto-tools manager."""
+
+    name: str
+    host: str
+    work_dir: str
+    command_argv: tuple[str, ...]
+    status: ExistingCommandStatus = "ready"
+    software: str = "existing"
+    required_artifacts: tuple[str, ...] = ()
+    required_stdout_patterns: tuple[str, ...] = ()
+    scheduler: ExistingCommandScheduler = "direct"
+    env: dict[str, str] | None = None
+    gpu_admission: dict[str, int] | None = None
+    srun_args: tuple[str, ...] = ()
+    ssh_args: tuple[str, ...] = ()
+    rsync_host: str | None = None
+    rsync_ssh_args: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the existing-command node shape."""
+        _validate_path_segment("ExistingRemoteCommandNode.name", self.name)
+        if not self.host:
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: host must be non-empty")
+        if not self.work_dir:
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: work_dir must be non-empty")
+        if not PurePosixPath(self.work_dir).is_absolute():
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: work_dir must be absolute")
+        if not self.command_argv:
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: command_argv must be non-empty")
+        if self.status not in ("ready", "partial", "blocked"):
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: unsupported status {self.status!r}")
+        _validate_path_segment("ExistingRemoteCommandNode.software", self.software)
+        if not all(self.required_stdout_patterns):
+            raise ValueError(
+                f"ExistingRemoteCommandNode {self.name!r}: required_stdout_patterns must be non-empty strings"
+            )
+        if self.scheduler not in ("direct", "srun"):
+            raise ValueError(
+                f"ExistingRemoteCommandNode {self.name!r}: unsupported scheduler {self.scheduler!r}"
+            )
+        if self.scheduler == "srun" and not self.srun_args:
+            raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: srun_args are required for scheduler='srun'")
+        for key in (self.env or {}):
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+                raise ValueError(f"ExistingRemoteCommandNode {self.name!r}: invalid env var name {key!r}")
+        if self.gpu_admission is not None:
+            expected = {"max_utilization_percent", "max_memory_used_mib"}
+            if set(self.gpu_admission) != expected:
+                raise ValueError(
+                    f"ExistingRemoteCommandNode {self.name!r}: gpu_admission keys must be {sorted(expected)!r}"
+                )
+            utilization = self.gpu_admission["max_utilization_percent"]
+            memory = self.gpu_admission["max_memory_used_mib"]
+            if not 0 <= utilization <= 100:
+                raise ValueError(
+                    f"ExistingRemoteCommandNode {self.name!r}: max_utilization_percent must be in [0, 100]"
+                )
+            if memory < 0:
+                raise ValueError(
+                    f"ExistingRemoteCommandNode {self.name!r}: max_memory_used_mib must be >= 0"
+                )
+            if not (self.env or {}).get("CUDA_VISIBLE_DEVICES"):
+                raise ValueError(
+                    f"ExistingRemoteCommandNode {self.name!r}: gpu_admission requires CUDA_VISIBLE_DEVICES"
+                )
+
+    @property
+    def sync_host(self) -> str:
+        """Host string used by rsync pulls."""
+        return self.rsync_host or self.host
+
+    @property
+    def sync_ssh_args(self) -> tuple[str, ...]:
+        """SSH args used by rsync; defaults to the command SSH args."""
+        return self.ssh_args if self.rsync_ssh_args is None else self.rsync_ssh_args
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExistingRemoteCommandNode":
+        """Create a node from a JSON-compatible mapping."""
+        values = dict(data)
+        values["command_argv"] = tuple(values.get("command_argv", ()))
+        for key in (
+            "required_artifacts",
+            "required_stdout_patterns",
+            "srun_args",
+            "ssh_args",
+            "rsync_ssh_args",
+        ):
+            if key in values and values[key] is not None:
+                values[key] = tuple(values[key])
+        if values.get("env") is not None:
+            values["env"] = {str(k): str(v) for k, v in values["env"].items()}
+        if values.get("gpu_admission") is not None:
+            values["gpu_admission"] = {
+                str(k): int(v) for k, v in values["gpu_admission"].items()
+            }
+        return cls(**values)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this node to JSON-compatible data."""
+        return {
+            "name": self.name,
+            "host": self.host,
+            "work_dir": self.work_dir,
+            "command_argv": list(self.command_argv),
+            "status": self.status,
+            "software": self.software,
+            "required_artifacts": list(self.required_artifacts),
+            "required_stdout_patterns": list(self.required_stdout_patterns),
+            "scheduler": self.scheduler,
+            "env": self.env or {},
+            "gpu_admission": self.gpu_admission,
+            "srun_args": list(self.srun_args),
+            "ssh_args": list(self.ssh_args),
+            "rsync_host": self.rsync_host,
+            "rsync_ssh_args": None if self.rsync_ssh_args is None else list(self.rsync_ssh_args),
+        }
+
+
+@dataclass(frozen=True)
+class ExistingRemoteBatchNode:
+    """Pair one manager transport/scheduler with one maintained existing command."""
+
+    manager: RemoteNode
+    command: ExistingRemoteCommandNode
+
+    def __post_init__(self) -> None:
+        """Require both halves to describe the same node and one scheduler owner."""
+        if self.manager.name != self.command.name:
+            raise ValueError(
+                f"Existing batch node name mismatch: manager={self.manager.name!r}, command={self.command.name!r}"
+            )
+        if self.manager.host != self.command.host:
+            raise ValueError(
+                f"Existing batch node host mismatch for {self.manager.name!r}: "
+                f"manager={self.manager.host!r}, command={self.command.host!r}"
+            )
+        if self.command.scheduler != "direct":
+            raise ValueError(
+                f"Existing batch command {self.command.name!r} must use scheduler='direct'; "
+                "the manager owns direct/Slurm allocation"
+            )
+        if self.manager.scheduler == "slurm" and self.command.gpu_admission is not None:
+            raise ValueError(
+                f"Existing batch command {self.command.name!r} must not set gpu_admission under Slurm; "
+                "the Slurm allocation owns GPU admission"
+            )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExistingRemoteBatchNode":
+        """Load one nested manager/command profile row."""
+        manager = data.get("manager")
+        command = data.get("command")
+        if not isinstance(manager, dict) or not isinstance(command, dict):
+            raise ValueError("Existing remote batch node must contain manager and command objects")
+        return cls(
+            manager=RemoteNode.from_dict(manager),
+            command=ExistingRemoteCommandNode.from_dict(command),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the combined profile row."""
+        return {
+            "manager": self.manager.to_dict(),
+            "command": self.command.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class RemoteComputeConfig:
+    """Resolved default profile and launch settings for one maintained runtime."""
+
+    software: str
+    registry_path: Path
+    profile_path: Path
+    bucket_size: int
+    slurm_group_size: int
+    wait_poll_interval: float
+    timeout_sec: float | None
+    remote_check_timeout_sec: float | None
+
+
+@dataclass(frozen=True)
+class ExistingFastaRecord:
+    """One FASTA record preserved as one logical existing-command task."""
+
+    header: str
+    sequence: str
+
+    def to_text(self) -> str:
+        """Render the normalized single-record FASTA payload."""
+        return f">{self.header}\n{self.sequence}\n"
+
+
+def read_fasta_records(path: Path | str) -> tuple[ExistingFastaRecord, ...]:
+    """Read non-empty FASTA records while preserving full headers and order."""
+    input_path = Path(path)
+    if not input_path.is_file():
+        raise FileNotFoundError(f"FASTA input not found: {input_path}")
+    records: list[ExistingFastaRecord] = []
+    header: str | None = None
+    sequence_parts: list[str] = []
+    for line_number, raw_line in enumerate(input_path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            if header is not None:
+                sequence = "".join(sequence_parts)
+                if not sequence:
+                    raise ValueError(f"FASTA record {header!r} has an empty sequence")
+                records.append(ExistingFastaRecord(header=header, sequence=sequence))
+            header = line[1:].strip()
+            if not header:
+                raise ValueError(f"FASTA header is empty at line {line_number}")
+            sequence_parts = []
+            continue
+        if header is None:
+            raise ValueError(f"FASTA sequence appears before a header at line {line_number}")
+        sequence_parts.append(line)
+    if header is not None:
+        sequence = "".join(sequence_parts)
+        if not sequence:
+            raise ValueError(f"FASTA record {header!r} has an empty sequence")
+        records.append(ExistingFastaRecord(header=header, sequence=sequence))
+    if not records:
+        raise ValueError(f"FASTA input contains no records: {input_path}")
+    return tuple(records)
+
+
+@dataclass(frozen=True)
+class ExistingRemoteCommandPlan:
+    """Concrete command plan for one existing remote installation run."""
+
+    node_name: str
+    run_id: str
+    local_input_path: str
+    remote_input_path: str
+    remote_output_dir: str
+    local_collect_dir: str
+    prepare_command: tuple[str, ...]
+    upload_command: tuple[str, ...]
+    execute_command: tuple[str, ...]
+    collect_command: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this plan to JSON-compatible data."""
+        return {
+            "node_name": self.node_name,
+            "run_id": self.run_id,
+            "local_input_path": self.local_input_path,
+            "remote_input_path": self.remote_input_path,
+            "remote_output_dir": self.remote_output_dir,
+            "local_collect_dir": self.local_collect_dir,
+            "commands": {
+                "prepare": list(self.prepare_command),
+                "upload": list(self.upload_command),
+                "execute": list(self.execute_command),
+                "collect": list(self.collect_command),
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ExistingRemoteCommandResult:
+    """Result metadata for one existing remote command run."""
+
+    plan: ExistingRemoteCommandPlan
+    collected_files: tuple[str, ...]
+    command_results: tuple["ExistingRemoteCommandStepResult", ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this result to JSON-compatible data."""
+        return {
+            "plan": self.plan.to_dict(),
+            "collected_files": list(self.collected_files),
+            "command_results": [result.to_dict() for result in self.command_results],
+        }
+
+
+@dataclass(frozen=True)
+class ExistingRemoteCommandStepResult:
+    """Captured subprocess output for one existing-command step."""
+
+    step: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this step result to JSON-compatible data."""
+        return {
+            "step": self.step,
+            "returncode": self.returncode,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+@dataclass(frozen=True)
+class LocalCheckoutStatus:
+    """Local git checkout state used before deployment."""
+
+    path: str
+    head_commit: str | None
+    branch: str | None
+    dirty_count: int
+    untracked_count: int
+    status_lines: tuple[str, ...]
+    is_git_checkout: bool = True
+    error: str | None = None
+
+    @property
+    def dirty(self) -> bool:
+        """Whether tracked or untracked local changes are present."""
+        return bool(self.dirty_count or self.untracked_count)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize checkout state to JSON-compatible data."""
+        return {
+            "path": self.path,
+            "is_git_checkout": self.is_git_checkout,
+            "head_commit": self.head_commit,
+            "branch": self.branch,
+            "dirty": self.dirty,
+            "dirty_count": self.dirty_count,
+            "untracked_count": self.untracked_count,
+            "status_lines": list(self.status_lines),
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class RemoteDeployCommandPlan:
+    """One rendered deployment command."""
+
+    index: int
+    step: str
+    argv: tuple[str, ...]
+
+    @property
+    def shell(self) -> str:
+        """Shell-rendered command for display."""
+        return shlex.join(self.argv)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize command plan to JSON-compatible data."""
+        return {
+            "index": self.index,
+            "step": self.step,
+            "argv": list(self.argv),
+            "shell": self.shell,
+        }
+
+
+@dataclass(frozen=True)
+class RemoteDeployNodePlan:
+    """Rendered deployment plan for one node."""
+
+    node_name: str
+    host: str
+    scheduler: RemoteScheduler
+    work_dir: str
+    repo_dir: str | None
+    venv_dir: str | None
+    commands: tuple[tuple[str, ...], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize node deployment plan to JSON-compatible data."""
+        command_plans = tuple(
+            RemoteDeployCommandPlan(
+                index=index,
+                step=_DEPLOY_COMMAND_STEPS[index] if index < len(_DEPLOY_COMMAND_STEPS) else f"command_{index}",
+                argv=command,
+            )
+            for index, command in enumerate(self.commands)
+        )
+        return {
+            "name": self.node_name,
+            "host": self.host,
+            "scheduler": self.scheduler,
+            "work_dir": self.work_dir,
+            "repo_dir": self.repo_dir,
+            "venv_dir": self.venv_dir,
+            "command_count": len(self.commands),
+            "commands": [command.to_dict() for command in command_plans],
+        }
+
+
+@dataclass(frozen=True)
+class RemoteDeploymentRenderReport:
+    """No-submit deployment render report."""
+
+    ok: bool
+    local_repo_dir: str
+    local_checkout: LocalCheckoutStatus
+    profile_issues: tuple[RemoteProfileIssue, ...]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    actions: tuple[str, ...]
+    nodes: tuple[RemoteDeployNodePlan, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize deployment render report to JSON-compatible data."""
+        return {
+            "schema_version": _DEPLOY_RENDER_SCHEMA_VERSION,
+            "ok": self.ok,
+            "local_repo_dir": self.local_repo_dir,
+            "node_count": len(self.nodes),
+            "command_count": sum(len(node.commands) for node in self.nodes),
+            "local_checkout": self.local_checkout.to_dict(),
+            "profile_issues": [issue.to_dict() for issue in self.profile_issues],
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "actions": list(self.actions),
+            "nodes": [node.to_dict() for node in self.nodes],
+        }
+
+
+def load_remote_nodes_json(path: Path | str) -> list[RemoteNode]:
+    """Load remote nodes from a JSON file with a top-level ``nodes`` list."""
+    payload = json.loads(Path(path).read_text())
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError("Remote node profile must contain a top-level 'nodes' list")
+    return [RemoteNode.from_dict(node) for node in nodes]
+
+
+def write_remote_nodes_json(
+    nodes: list[RemoteNode],
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write a remote node profile atomically."""
+    output_path = Path(path)
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Remote node profile already exists: {output_path}")
+    _write_json_atomic(
+        output_path,
+        {
+            "profile_schema_version": _PROFILE_SCHEMA_VERSION,
+            "nodes": [node.to_dict() for node in nodes],
+        },
+    )
+
+
+def load_existing_remote_command_nodes_json(path: Path | str) -> list[ExistingRemoteCommandNode]:
+    """Load existing-command nodes from a JSON file with a top-level ``nodes`` list."""
+    payload = json.loads(Path(path).read_text())
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError("Existing remote command profile must contain a top-level 'nodes' list")
+    return [ExistingRemoteCommandNode.from_dict(node) for node in nodes]
+
+
+def write_existing_remote_command_nodes_json(
+    nodes: list[ExistingRemoteCommandNode],
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write an existing-command profile atomically."""
+    output_path = Path(path)
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Existing remote command profile already exists: {output_path}")
+    _write_json_atomic(
+        output_path,
+        {
+            "profile_schema_version": _EXISTING_COMMAND_PROFILE_SCHEMA_VERSION,
+            "nodes": [node.to_dict() for node in nodes],
+        },
+    )
+
+
+def load_existing_remote_batch_nodes_json(path: Path | str) -> list[ExistingRemoteBatchNode]:
+    """Load a combined manager/existing-command profile."""
+    payload = json.loads(Path(path).read_text())
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError("Existing remote batch profile must contain a top-level 'nodes' list")
+    return [ExistingRemoteBatchNode.from_dict(node) for node in nodes]
+
+
+def _default_remote_compute_registry() -> Path:
+    """Find the hand-compute registry in direct or bundled Codex skill installs."""
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+    skills_dir = codex_home / "skills"
+    direct = skills_dir / "hand-compute" / "references" / "runtime_registry.json"
+    if direct.is_file():
+        return direct.resolve()
+
+    bundled = sorted(
+        path
+        for path in skills_dir.glob("*/hand-compute/references/runtime_registry.json")
+        if path.is_file()
+    )
+    if len(bundled) == 1:
+        return bundled[0].resolve()
+    if len(bundled) > 1:
+        candidates = ", ".join(str(path.resolve()) for path in bundled)
+        raise ValueError(
+            "Multiple bundled $hand-compute runtime registries found; "
+            f"set {_REMOTE_COMPUTE_REGISTRY_ENV} explicitly: {candidates}"
+        )
+    return direct.resolve()
+
+
+def resolve_remote_compute_config(
+    software: str,
+    *,
+    registry_path: Path | str | None = None,
+) -> RemoteComputeConfig:
+    """Resolve one ready runtime from the hand-compute registry."""
+    if registry_path is None:
+        configured = os.environ.get(_REMOTE_COMPUTE_REGISTRY_ENV)
+        registry = (
+            Path(configured).expanduser().resolve()
+            if configured
+            else _default_remote_compute_registry()
+        )
+    else:
+        registry = Path(registry_path).expanduser().resolve()
+    if not registry.is_file():
+        raise ValueError(
+            f"Remote compute registry not found: {registry}. "
+            f"Install $hand-compute or set {_REMOTE_COMPUTE_REGISTRY_ENV}."
+        )
+
+    payload = json.loads(registry.read_text())
+    if payload.get("schema_version") != _REMOTE_COMPUTE_REGISTRY_SCHEMA_VERSION:
+        raise ValueError(
+            f"Remote compute registry {registry} must use "
+            f"schema_version={_REMOTE_COMPUTE_REGISTRY_SCHEMA_VERSION}"
+        )
+    software_entries = payload.get("software")
+    if not isinstance(software_entries, dict):
+        raise ValueError(f"Remote compute registry {registry} must contain a top-level 'software' object")
+
+    requested = software.strip().lower()
+    matches: list[tuple[str, dict[str, Any]]] = []
+    for canonical, raw_entry in software_entries.items():
+        if not isinstance(canonical, str) or not isinstance(raw_entry, dict):
+            raise ValueError(f"Remote compute registry {registry} has an invalid software entry")
+        aliases = raw_entry.get("aliases", [])
+        if not isinstance(aliases, list) or not all(isinstance(alias, str) for alias in aliases):
+            raise ValueError(f"Remote compute registry entry {canonical!r} must contain a string aliases list")
+        if requested == canonical.lower() or requested in {alias.lower() for alias in aliases}:
+            matches.append((canonical, raw_entry))
+    if not matches:
+        available = ", ".join(sorted(software_entries))
+        raise ValueError(f"Remote compute software {software!r} is not configured; available: {available}")
+    if len(matches) != 1:
+        raise ValueError(f"Remote compute software alias {software!r} matches multiple registry entries")
+
+    canonical, entry = matches[0]
+    _validate_path_segment("remote compute software", canonical)
+    status = entry.get("status")
+    if status != "ready":
+        raise ValueError(f"Remote compute software {canonical!r} is not ready; registry status={status!r}")
+    profile_value = entry.get("profile")
+    if not isinstance(profile_value, str) or not profile_value:
+        raise ValueError(f"Remote compute registry entry {canonical!r} must define profile")
+    profile = Path(profile_value).expanduser()
+    if not profile.is_absolute():
+        profile = registry.parent / profile
+    profile = profile.resolve()
+    if not profile.is_file():
+        raise ValueError(f"Remote compute profile for {canonical!r} not found: {profile}")
+
+    defaults = entry.get("defaults", {})
+    if not isinstance(defaults, dict):
+        raise ValueError(f"Remote compute registry entry {canonical!r} defaults must be an object")
+
+    def positive_int(name: str, fallback: int) -> int:
+        value = defaults.get(name, fallback)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"Remote compute registry {canonical!r} defaults.{name} must be a positive integer")
+        return int(value)
+
+    def positive_float(name: str, fallback: float | None) -> float | None:
+        value = defaults.get(name, fallback)
+        if value is None:
+            return None
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or value <= 0
+        ):
+            raise ValueError(f"Remote compute registry {canonical!r} defaults.{name} must be positive or null")
+        return float(value)
+
+    return RemoteComputeConfig(
+        software=canonical,
+        registry_path=registry,
+        profile_path=profile,
+        bucket_size=positive_int("bucket_size", 1),
+        slurm_group_size=positive_int("slurm_group_size", 10),
+        wait_poll_interval=positive_float("wait_poll_interval", 5.0) or 5.0,
+        timeout_sec=positive_float("timeout_sec", None),
+        remote_check_timeout_sec=positive_float("remote_check_timeout_sec", None),
+    )
+
+
+def write_existing_remote_batch_nodes_json(
+    nodes: list[ExistingRemoteBatchNode],
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write a combined manager/existing-command profile atomically."""
+    output_path = Path(path)
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Existing remote batch profile already exists: {output_path}")
+    _write_json_atomic(
+        output_path,
+        {
+            "profile_schema_version": _EXISTING_COMMAND_PROFILE_SCHEMA_VERSION,
+            "nodes": [node.to_dict() for node in nodes],
+        },
+    )
+
+
+def select_existing_remote_command_node(
+    nodes: list[ExistingRemoteCommandNode],
+    node_name: str,
+) -> ExistingRemoteCommandNode:
+    """Return the selected existing-command node or raise with a clear message."""
+    matches = [node for node in nodes if node.name == node_name]
+    if not matches:
+        available = ", ".join(node.name for node in nodes) or "<none>"
+        raise ValueError(f"Existing remote command node {node_name!r} not found; available: {available}")
+    if len(matches) > 1:
+        raise ValueError(f"Existing remote command node {node_name!r} is duplicated")
+    return matches[0]
+
+
+def _render_existing_argv(
+    node: ExistingRemoteCommandNode,
+    *,
+    remote_input_path: str,
+    remote_output_dir: str,
+) -> list[str]:
+    """Render an existing-command argv template with remote input/output paths."""
+    values = {"input": remote_input_path, "output": remote_output_dir}
+    try:
+        return [part.format(**values) for part in node.command_argv]
+    except KeyError as exc:
+        raise ValueError(
+            f"ExistingRemoteCommandNode {node.name!r}: unknown command_argv placeholder {exc.args[0]!r}"
+        ) from exc
+
+
+def render_existing_remote_shell_command(
+    node: ExistingRemoteCommandNode,
+    *,
+    remote_input_path: str,
+    remote_output_dir: str,
+) -> str:
+    """Render the remote shell command for an already-installed remote tool."""
+    exports = [
+        f"export {key}={shlex.quote(value)}"
+        for key, value in sorted((node.env or {}).items())
+    ]
+    inner_parts = [
+        "set -euo pipefail",
+        f"mkdir -p {shlex.quote(remote_output_dir)}",
+        *exports,
+        shlex.join(
+            _render_existing_argv(
+                node,
+                remote_input_path=remote_input_path,
+                remote_output_dir=remote_output_dir,
+            )
+        ),
+    ]
+    inner_script = "; ".join(inner_parts)
+    if node.scheduler == "direct":
+        return inner_script
+    return f"{shlex.join(['srun', *node.srun_args])} bash -lc {shlex.quote(inner_script)}"
+
+
+def plan_existing_remote_command(
+    node: ExistingRemoteCommandNode,
+    *,
+    local_input_path: Path | str,
+    run_id: str,
+    local_collect_dir: Path | str,
+) -> ExistingRemoteCommandPlan:
+    """Build a concrete stage/execute/collect plan for one existing remote command."""
+    _validate_path_segment("run_id", run_id)
+    input_path = Path(local_input_path)
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Local input file not found: {input_path}")
+    input_name = input_path.name
+    _validate_path_segment("input filename", input_name)
+    remote_run_dir = PurePosixPath(node.work_dir) / run_id
+    remote_input_path = str(remote_run_dir / "input" / input_name)
+    remote_output_dir = str(remote_run_dir / "output")
+    local_collect_path = Path(local_collect_dir)
+    execute_script = render_existing_remote_shell_command(
+        node,
+        remote_input_path=remote_input_path,
+        remote_output_dir=remote_output_dir,
+    )
+    prepare_script = (
+        f"set -euo pipefail; mkdir -p {shlex.quote(str(PurePosixPath(remote_input_path).parent))} "
+        f"{shlex.quote(remote_output_dir)}"
+    )
+    upload_target = f"{node.sync_host}:{remote_input_path}"
+    upload_command: list[str] = ["rsync", "-a"]
+    collect_source = f"{node.sync_host}:{remote_output_dir}/"
+    collect_command: list[str] = ["rsync", "-a"]
+    if node.sync_ssh_args:
+        upload_command.extend(["-e", shlex.join(["ssh", *node.sync_ssh_args])])
+        collect_command.extend(["-e", shlex.join(["ssh", *node.sync_ssh_args])])
+    upload_command.extend([str(input_path), upload_target])
+    collect_command.extend([collect_source, str(local_collect_path) + "/"])
+    return ExistingRemoteCommandPlan(
+        node_name=node.name,
+        run_id=run_id,
+        local_input_path=str(input_path),
+        remote_input_path=remote_input_path,
+        remote_output_dir=remote_output_dir,
+        local_collect_dir=str(local_collect_path),
+        prepare_command=("ssh", *node.ssh_args, node.host, "bash", "-lc", shlex.quote(prepare_script)),
+        upload_command=tuple(upload_command),
+        execute_command=("ssh", *node.ssh_args, node.host, "bash", "-lc", shlex.quote(execute_script)),
+        collect_command=tuple(collect_command),
+    )
+
+
+def run_existing_remote_command(
+    node: ExistingRemoteCommandNode,
+    *,
+    local_input_path: Path | str,
+    run_id: str,
+    local_collect_dir: Path | str,
+    runner: Any = subprocess.run,
+    timeout_sec: float | None = None,
+) -> ExistingRemoteCommandResult:
+    """Run one existing remote command and collect its output directory."""
+    plan = plan_existing_remote_command(
+        node,
+        local_input_path=local_input_path,
+        run_id=run_id,
+        local_collect_dir=local_collect_dir,
+    )
+    Path(plan.local_collect_dir).mkdir(parents=True, exist_ok=True)
+    runner_kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+    if timeout_sec is not None:
+        runner_kwargs["timeout"] = timeout_sec
+    command_results: list[ExistingRemoteCommandStepResult] = []
+    for step, command in (
+        ("prepare", plan.prepare_command),
+        ("upload", plan.upload_command),
+        ("execute", plan.execute_command),
+        ("collect", plan.collect_command),
+    ):
+        completed = runner(list(command), **runner_kwargs)
+        command_results.append(
+            ExistingRemoteCommandStepResult(
+                step=step,
+                returncode=int(getattr(completed, "returncode", 0)),
+                stdout=str(getattr(completed, "stdout", "") or ""),
+                stderr=str(getattr(completed, "stderr", "") or ""),
+            )
+        )
+    collected_files = tuple(
+        sorted(
+            str(path.relative_to(plan.local_collect_dir))
+            for path in Path(plan.local_collect_dir).rglob("*")
+            if path.is_file()
+        )
+    )
+    return ExistingRemoteCommandResult(
+        plan=plan,
+        collected_files=collected_files,
+        command_results=tuple(command_results),
+    )
+
+
+def scaffold_remote_node(
+    name: str,
+    home_dir: str,
+    *,
+    host: str | None = None,
+    scheduler: RemoteScheduler = "direct",
+    repo_name: str = "proto-tools",
+    work_name: str = "proto_remote",
+    bootstrap_python: str = "python3",
+    weight: float = 1.0,
+    max_concurrent_buckets: int = 1,
+    max_active_slurm_jobs: int | None = None,
+    worker_device: str | None = None,
+    sbatch_args: tuple[str, ...] = (),
+) -> RemoteNode:
+    """Create a conventional node profile entry from a remote home directory."""
+    home = PurePosixPath(home_dir)
+    if not home.is_absolute():
+        raise ValueError(f"Remote node {name!r}: home_dir must be an absolute path")
+    repo_dir = home / repo_name
+    venv_dir = repo_dir / ".venv"
+    rendered_work_name = work_name.format(node=name)
+    return RemoteNode(
+        name=name,
+        host=host or name,
+        work_dir=str(home / rendered_work_name),
+        repo_dir=str(repo_dir),
+        venv_dir=str(venv_dir),
+        bootstrap_python=bootstrap_python,
+        weight=weight,
+        max_concurrent_buckets=max_concurrent_buckets,
+        max_active_slurm_jobs=max_active_slurm_jobs,
+        scheduler=scheduler,
+        worker_device=worker_device or ("cuda" if scheduler == "slurm" else "cuda:0"),
+        python=str(venv_dir / "bin" / "python"),
+        sbatch_args=sbatch_args,
+    )
+
+
+def validate_remote_nodes(nodes: list[RemoteNode]) -> list[RemoteProfileIssue]:
+    """Return static profile issues without opening SSH connections."""
+    issues: list[RemoteProfileIssue] = []
+    if not nodes:
+        return [
+            RemoteProfileIssue(
+                level="error",
+                node_name=None,
+                field="nodes",
+                message="profile must contain at least one node",
+            )
+        ]
+
+    seen: dict[str, int] = {}
+    for node in nodes:
+        seen[node.name] = seen.get(node.name, 0) + 1
+    for name, count in seen.items():
+        if count > 1:
+            issues.append(
+                RemoteProfileIssue(
+                    level="error",
+                    node_name=name,
+                    field="name",
+                    message=f"duplicate node name appears {count} times",
+                )
+            )
+
+    roots_by_path: dict[str, list[str]] = {}
+    for node in nodes:
+        roots_by_path.setdefault(str(PurePosixPath(node.work_dir)), []).append(node.name)
+    for raw_path, names in roots_by_path.items():
+        if len(names) > 1:
+            issues.append(
+                RemoteProfileIssue(
+                    level="error",
+                    node_name=",".join(sorted(names)),
+                    field="work_dir",
+                    message=f"remote work_dir is shared by multiple nodes: {raw_path}",
+                )
+            )
+
+    for field in ("repo_dir", "venv_dir"):
+        paths_by_value: dict[str, list[str]] = {}
+        for node in nodes:
+            candidate_path = node.repo_dir if field == "repo_dir" else node.effective_venv_dir
+            if candidate_path is not None:
+                paths_by_value.setdefault(str(PurePosixPath(candidate_path)), []).append(node.name)
+        for shared_path, names in paths_by_value.items():
+            if len(names) > 1:
+                issues.append(
+                    RemoteProfileIssue(
+                        level="warning",
+                        node_name=",".join(sorted(names)),
+                        field=field,
+                        message=f"remote {field} is shared by multiple nodes: {shared_path}",
+                    )
+                )
+
+    for node in nodes:
+        path_fields: tuple[tuple[str, str | None], ...] = (
+            ("work_dir", node.work_dir),
+            ("repo_dir", node.repo_dir),
+            ("venv_dir", node.effective_venv_dir),
+        )
+        for field, candidate_path in path_fields:
+            if candidate_path is not None and not PurePosixPath(candidate_path).is_absolute():
+                issues.append(
+                    RemoteProfileIssue(
+                        level="error",
+                        node_name=node.name,
+                        field=field,
+                        message=f"{field} must be an absolute remote path",
+                    )
+                )
+        if node.repo_dir is None:
+            issues.append(
+                RemoteProfileIssue(
+                    level="warning",
+                    node_name=node.name,
+                    field="repo_dir",
+                    message="manager startup will not set a repo-local PYTHONPATH",
+                )
+            )
+        if node.scheduler == "slurm" and not node.sbatch_args:
+            issues.append(
+                RemoteProfileIssue(
+                    level="warning",
+                    node_name=node.name,
+                    field="sbatch_args",
+                    message="Slurm node has no sbatch arguments; cluster defaults will be used",
+                )
+            )
+        if node.scheduler == "slurm" and node.max_active_slurm_jobs is None:
+            issues.append(
+                RemoteProfileIssue(
+                    level="error",
+                    node_name=node.name,
+                    field="max_active_slurm_jobs",
+                    message="Slurm node requires max_active_slurm_jobs to avoid unbounded sbatch submission",
+                )
+            )
+        if node.scheduler == "direct" and node.sbatch_args:
+            issues.append(
+                RemoteProfileIssue(
+                    level="warning",
+                    node_name=node.name,
+                    field="sbatch_args",
+                    message="direct node has sbatch arguments that manager-loop will ignore",
+                )
+            )
+        if node.scheduler == "direct" and node.max_active_slurm_jobs is not None:
+            issues.append(
+                RemoteProfileIssue(
+                    level="warning",
+                    node_name=node.name,
+                    field="max_active_slurm_jobs",
+                    message="direct node has max_active_slurm_jobs that manager-loop will ignore",
+                )
+            )
+        if node.scheduler == "direct" and node.max_concurrent_buckets > 1:
+            issues.append(
+                RemoteProfileIssue(
+                    level="warning",
+                    node_name=node.name,
+                    field="max_concurrent_buckets",
+                    message=(
+                        "direct node max_concurrent_buckets only affects local planning capacity; "
+                        "one node manager still executes buckets serially"
+                    ),
+                )
+            )
+    return issues
+
+
+def _remote_bash_command(node: RemoteNode, script: str) -> list[str]:
+    """Build an SSH command that runs ``script`` under remote bash."""
+    return ["ssh", *node.ssh_args, node.host, "bash", "-lc", shlex.quote(script)]
+
+
+def _remote_env_prefix(node: RemoteNode) -> str:
+    """Shell exports required before running repo-local manager commands."""
+    if node.repo_dir is None:
+        return ""
+    return f"cd {shlex.quote(node.repo_dir)} && export PYTHONPATH={shlex.quote(node.repo_dir)}${{PYTHONPATH:+:$PYTHONPATH}} && "
+
+
+def render_rsync_upload_command(node: RemoteNode, local_repo_dir: Path | str) -> list[str]:
+    """Render the rsync command that uploads a repo checkout to one node."""
+    if node.repo_dir is None:
+        raise ValueError(f"RemoteNode {node.name!r}: repo_dir is required for deployment")
+    source = str(Path(local_repo_dir)) + "/"
+    cmd = [
+        "rsync",
+        "-az",
+        "--partial",
+        "--delete",
+        "--exclude",
+        ".git",
+        "--exclude",
+        ".venv",
+        "--exclude",
+        ".pytest_cache",
+        "--exclude",
+        ".ruff_cache",
+        "--exclude",
+        "__pycache__",
+        "--exclude",
+        "logs",
+    ]
+    if node.sync_ssh_args:
+        cmd.extend(["-e", shlex.join(["ssh", *node.sync_ssh_args])])
+    cmd.extend([source, f"{node.host}:{node.repo_dir}/"])
+    return cmd
+
+
+def render_deploy_commands(node: RemoteNode, local_repo_dir: Path | str) -> list[list[str]]:
+    """Render explicit deployment commands for a remote node.
+
+    The commands create the manager directories, rsync the current checkout,
+    create a virtualenv, and install the checkout editable. They are rendered
+    only; callers decide when to execute them.
+    """
+    if node.repo_dir is None:
+        raise ValueError(f"RemoteNode {node.name!r}: repo_dir is required for deployment")
+    venv_dir = node.effective_venv_dir
+    if venv_dir is None:
+        raise ValueError(f"RemoteNode {node.name!r}: venv_dir is required for deployment")
+    mkdir_script = (
+        "set -euo pipefail; "
+        f"mkdir -p {shlex.quote(node.repo_dir)} "
+        f"{shlex.quote(str(node.queue_root))} "
+        f"{shlex.quote(str(node.results_root))} "
+        f"{shlex.quote(str(node.logs_root))}"
+    )
+    install_script = (
+        "set -euo pipefail; "
+        f"cd {shlex.quote(node.repo_dir)}; "
+        f"{shlex.quote(node.deploy_python)} -m venv {shlex.quote(venv_dir)}; "
+        f"{shlex.quote(str(PurePosixPath(venv_dir) / 'bin' / 'python'))} -m pip install -e ."
+    )
+    return [
+        _remote_bash_command(node, mkdir_script),
+        render_rsync_upload_command(node, local_repo_dir),
+        _remote_bash_command(node, install_script),
+    ]
+
+
+def inspect_local_checkout(
+    local_repo_dir: Path | str,
+    *,
+    runner: Any = subprocess.run,
+) -> LocalCheckoutStatus:
+    """Inspect local git state before rendering or applying deployment."""
+    requested = Path(local_repo_dir).resolve()
+
+    def run_git(repo: Path, *args: str) -> str:
+        result = runner(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return str(getattr(result, "stdout", "") or "").strip()
+
+    try:
+        repo = Path(run_git(requested, "rev-parse", "--show-toplevel")).resolve()
+    except subprocess.CalledProcessError as exc:
+        return LocalCheckoutStatus(
+            path=str(requested),
+            head_commit=None,
+            branch=None,
+            dirty_count=0,
+            untracked_count=0,
+            status_lines=(),
+            is_git_checkout=False,
+            error=str(exc),
+        )
+
+    status_lines = tuple(
+        line for line in run_git(repo, "status", "--porcelain=v1", "--untracked-files=all").splitlines() if line
+    )
+    untracked_count = sum(1 for line in status_lines if line.startswith("??"))
+    dirty_count = len(status_lines) - untracked_count
+    return LocalCheckoutStatus(
+        path=str(repo),
+        head_commit=run_git(repo, "rev-parse", "HEAD"),
+        branch=run_git(repo, "rev-parse", "--abbrev-ref", "HEAD"),
+        dirty_count=dirty_count,
+        untracked_count=untracked_count,
+        status_lines=status_lines,
+    )
+
+
+def shared_remote_install_roots(nodes: list[RemoteNode]) -> tuple[str, ...]:
+    """Return shared repo/venv roots that would make concurrent deploy unsafe."""
+    messages: list[str] = []
+    for field in ("repo_dir", "venv_dir"):
+        roots: dict[str, list[str]] = {}
+        for node in nodes:
+            root = node.repo_dir if field == "repo_dir" else node.effective_venv_dir
+            if root is not None:
+                roots.setdefault(root, []).append(node.name)
+        for root, names in roots.items():
+            if len(names) > 1:
+                messages.append(f"{field} {root} shared by {','.join(sorted(names))}")
+    return tuple(messages)
+
+
+def build_deploy_render_report(
+    nodes: list[RemoteNode],
+    local_repo_dir: Path | str,
+    *,
+    allow_dirty_checkout: bool = False,
+    runner: Any = subprocess.run,
+) -> RemoteDeploymentRenderReport:
+    """Build a no-submit deployment render report."""
+    checkout = inspect_local_checkout(local_repo_dir, runner=runner)
+    profile_issues = tuple(validate_remote_nodes(nodes))
+    blockers = [issue.message for issue in profile_issues if issue.level == "error"]
+    warnings = [issue.message for issue in profile_issues if issue.level == "warning"]
+    actions: list[str] = []
+
+    if not checkout.is_git_checkout:
+        blockers.append(f"local repo dir is not a git checkout: {checkout.path}")
+        actions.append("run deploy from a git checkout")
+    elif checkout.dirty and allow_dirty_checkout:
+        warnings.append(
+            f"deploying local checkout with dirty_count={checkout.dirty_count} "
+            f"untracked_count={checkout.untracked_count}"
+        )
+    elif checkout.dirty:
+        blockers.append(
+            f"local checkout has {checkout.dirty_count} tracked and "
+            f"{checkout.untracked_count} untracked changed paths"
+        )
+        actions.append("commit, stash, or pass --allow-dirty-checkout")
+
+    shared_roots = shared_remote_install_roots(nodes)
+    blockers.extend(shared_roots)
+    if shared_roots:
+        actions.append("select one shared-root node or pass --allow-shared-install-root before deploy apply")
+
+    node_plans: list[RemoteDeployNodePlan] = []
+    for node in nodes:
+        node_blocked = False
+        if node.repo_dir is None:
+            blockers.append(f"{node.name}: repo_dir is required for deployment")
+            node_blocked = True
+        if node.effective_venv_dir is None:
+            blockers.append(f"{node.name}: venv_dir is required for deployment")
+            node_blocked = True
+        if node.scheduler == "slurm":
+            joined_args = " ".join(node.sbatch_args).lower()
+            if "gpu" not in joined_args:
+                warnings.append(f"{node.name}: Slurm sbatch_args do not mention a GPU resource")
+            if node.name.lower() == "h100" and "h100" not in joined_args:
+                warnings.append(f"{node.name}: Slurm sbatch_args do not mention h100")
+
+        commands: tuple[tuple[str, ...], ...] = ()
+        if not node_blocked:
+            commands = tuple(tuple(command) for command in render_deploy_commands(node, checkout.path))
+        node_plans.append(
+            RemoteDeployNodePlan(
+                node_name=node.name,
+                host=node.host,
+                scheduler=node.scheduler,
+                work_dir=node.work_dir,
+                repo_dir=node.repo_dir,
+                venv_dir=node.effective_venv_dir,
+                commands=commands,
+            )
+        )
+
+    return RemoteDeploymentRenderReport(
+        ok=not blockers,
+        local_repo_dir=checkout.path,
+        local_checkout=checkout,
+        profile_issues=profile_issues,
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+        actions=tuple(dict.fromkeys(actions)),
+        nodes=tuple(node_plans),
+    )
+
+
+@dataclass(frozen=True)
+class RemoteBucket:
+    """A contiguous group of iterable input rows."""
+
+    bucket_id: str
+    item_indices: tuple[int, ...]
+    total_cost: float
+
+    def __post_init__(self) -> None:
+        """Validate bucket identifiers before they become filenames."""
+        _validate_path_segment("RemoteBucket.bucket_id", self.bucket_id)
+
+
+@dataclass(frozen=True)
+class RemoteAssignment:
+    """One bucket assigned to one remote node."""
+
+    node: RemoteNode
+    bucket: RemoteBucket
+
+
+@dataclass(frozen=True)
+class RemoteDispatchPlan:
+    """Complete bucket assignment for one tool invocation."""
+
+    tool_key: str
+    run_id: str
+    input_fields: tuple[str, ...]
+    iterable_output_field: str
+    inputs: BaseToolInput
+    config: BaseConfig
+    assignments: tuple[RemoteAssignment, ...]
+
+    def __post_init__(self) -> None:
+        """Validate plan identifiers before queue/result paths are rendered."""
+        _validate_path_segment("RemoteDispatchPlan.run_id", self.run_id)
+
+    def request_for(self, assignment: RemoteAssignment) -> dict[str, Any]:
+        """Build the JSON-serializable request for one assignment."""
+        update = {
+            field: [getattr(self.inputs, field)[idx] for idx in assignment.bucket.item_indices]
+            for field in self.input_fields
+        }
+        bucket_inputs = self.inputs.model_copy(update=update)
+        bucket_config = self.config.model_copy(update={"device": assignment.node.worker_device})
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "tool_key": self.tool_key,
+            "run_id": self.run_id,
+            "bucket_id": assignment.bucket.bucket_id,
+            "item_indices": list(assignment.bucket.item_indices),
+            "inputs": bucket_inputs.model_dump(mode="json", exclude_none=True),
+            "config": bucket_config.model_dump(mode="json", exclude_none=True),
+        }
+
+    def assignments_for_node(self, node_name: str) -> tuple[RemoteAssignment, ...]:
+        """Return assignments for ``node_name`` in deterministic order."""
+        return tuple(assignment for assignment in self.assignments if assignment.node.name == node_name)
+
+
+@dataclass(frozen=True)
+class RemoteRunRequest:
+    """One manifest-backed bucket request."""
+
+    node_name: str
+    bucket_id: str
+    item_indices: tuple[int, ...]
+    total_cost: float
+    request: dict[str, Any]
+
+    def __post_init__(self) -> None:
+        """Validate manifest request path components."""
+        _validate_path_segment("RemoteRunRequest.node_name", self.node_name)
+        _validate_path_segment("RemoteRunRequest.bucket_id", self.bucket_id)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RemoteRunRequest":
+        """Create a run request from JSON-compatible data."""
+        return cls(
+            node_name=str(data["node_name"]),
+            bucket_id=str(data["bucket_id"]),
+            item_indices=tuple(int(index) for index in data["item_indices"]),
+            total_cost=float(data["total_cost"]),
+            request=cast(dict[str, Any], data["request"]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the run request to JSON-compatible data."""
+        return {
+            "node_name": self.node_name,
+            "bucket_id": self.bucket_id,
+            "item_indices": list(self.item_indices),
+            "total_cost": self.total_cost,
+            "request": self.request,
+        }
+
+
+@dataclass(frozen=True)
+class RemoteRunManifest:
+    """Disk-backed remote run plan for resumable submit, wait, and collect."""
+
+    manifest_schema_version: int
+    request_schema_version: int
+    run_id: str
+    tool_key: str
+    bucket_size: int
+    input_fields: tuple[str, ...]
+    iterable_output_field: str
+    local_results_dir: str
+    nodes: tuple[RemoteNode, ...]
+    requests: tuple[RemoteRunRequest, ...]
+
+    def __post_init__(self) -> None:
+        """Validate manifest path components and request identity."""
+        _validate_path_segment("RemoteRunManifest.run_id", self.run_id)
+        node_names = [node.name for node in self.nodes]
+        duplicate_nodes = sorted({name for name in node_names if node_names.count(name) > 1})
+        if duplicate_nodes:
+            raise ValueError(f"Remote run manifest has duplicate node name(s): {duplicate_nodes}")
+        known_nodes = set(node_names)
+        bucket_ids = [request.bucket_id for request in self.requests]
+        duplicate_buckets = sorted({bucket_id for bucket_id in bucket_ids if bucket_ids.count(bucket_id) > 1})
+        if duplicate_buckets:
+            raise ValueError(f"Remote run manifest has duplicate bucket id(s): {duplicate_buckets}")
+        for request in self.requests:
+            if request.node_name not in known_nodes:
+                raise ValueError(f"Remote run manifest references unknown node {request.node_name!r}")
+            payload = request.request
+            identity_checks = (
+                ("run_id", self.run_id, payload.get("run_id")),
+                ("bucket_id", request.bucket_id, payload.get("bucket_id")),
+                ("tool_key", self.tool_key, payload.get("tool_key")),
+                ("item_indices", list(request.item_indices), payload.get("item_indices")),
+            )
+            mismatches = [
+                f"{field} expected {expected!r} got {actual!r}"
+                for field, expected, actual in identity_checks
+                if actual != expected
+            ]
+            if mismatches:
+                raise ValueError(
+                    f"Remote run manifest request identity mismatch for {request.node_name}/{request.bucket_id}: "
+                    + "; ".join(mismatches)
+                )
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: RemoteDispatchPlan,
+        *,
+        nodes: list[RemoteNode],
+        bucket_size: int,
+        local_results_dir: Path | str,
+    ) -> "RemoteRunManifest":
+        """Create a manifest from an in-memory dispatch plan."""
+        nodes_by_name = {node.name: node for node in nodes}
+        missing_nodes = sorted({assignment.node.name for assignment in plan.assignments} - set(nodes_by_name))
+        if missing_nodes:
+            raise ValueError(f"Manifest nodes missing assignments for: {missing_nodes}")
+        return cls(
+            manifest_schema_version=_MANIFEST_SCHEMA_VERSION,
+            request_schema_version=_SCHEMA_VERSION,
+            run_id=plan.run_id,
+            tool_key=plan.tool_key,
+            bucket_size=bucket_size,
+            input_fields=plan.input_fields,
+            iterable_output_field=plan.iterable_output_field,
+            local_results_dir=str(Path(local_results_dir)),
+            nodes=tuple(nodes),
+            requests=tuple(
+                RemoteRunRequest(
+                    node_name=assignment.node.name,
+                    bucket_id=assignment.bucket.bucket_id,
+                    item_indices=assignment.bucket.item_indices,
+                    total_cost=assignment.bucket.total_cost,
+                    request=plan.request_for(assignment),
+                )
+                for assignment in plan.assignments
+            ),
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RemoteRunManifest":
+        """Create a manifest from JSON-compatible data."""
+        manifest_version = int(data["manifest_schema_version"])
+        request_version = int(data["request_schema_version"])
+        if manifest_version != _MANIFEST_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported remote run manifest_schema_version: {manifest_version!r}")
+        if request_version != _SCHEMA_VERSION:
+            raise ValueError(f"Unsupported remote run request_schema_version: {request_version!r}")
+        return cls(
+            manifest_schema_version=manifest_version,
+            request_schema_version=request_version,
+            run_id=str(data["run_id"]),
+            tool_key=str(data["tool_key"]),
+            bucket_size=int(data["bucket_size"]),
+            input_fields=tuple(str(field) for field in data["input_fields"]),
+            iterable_output_field=str(data["iterable_output_field"]),
+            local_results_dir=str(data["local_results_dir"]),
+            nodes=tuple(RemoteNode.from_dict(node) for node in data["nodes"]),
+            requests=tuple(RemoteRunRequest.from_dict(request) for request in data["requests"]),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the manifest to JSON-compatible data."""
+        return {
+            "manifest_schema_version": self.manifest_schema_version,
+            "request_schema_version": self.request_schema_version,
+            "run_id": self.run_id,
+            "tool_key": self.tool_key,
+            "bucket_size": self.bucket_size,
+            "input_fields": list(self.input_fields),
+            "iterable_output_field": self.iterable_output_field,
+            "local_results_dir": self.local_results_dir,
+            "nodes": [node.to_dict() for node in self.nodes],
+            "requests": [request.to_dict() for request in self.requests],
+        }
+
+    def node_for_request(self, request: RemoteRunRequest) -> RemoteNode:
+        """Return the node assigned to one manifest request."""
+        nodes_by_name = {node.name: node for node in self.nodes}
+        try:
+            return nodes_by_name[request.node_name]
+        except KeyError as exc:
+            raise ValueError(f"Remote run manifest references unknown node {request.node_name!r}") from exc
+
+    def local_result_path(self, request: RemoteRunRequest) -> Path:
+        """Return the local result path expected after rsync mirroring."""
+        return Path(self.local_results_dir) / request.node_name / self.run_id / f"{request.bucket_id}.json"
+
+
+@dataclass(frozen=True)
+class RemoteLaunchResult:
+    """Summary of a manifest-backed remote launch."""
+
+    run_id: str
+    manifest_path: str
+    output_path: str
+    local_results_dir: str
+    bucket_count: int
+    staged_count: int
+    preflight: dict[str, Any]
+    managers: dict[str, str]
+    rsync_status: str | None = None
+    diagnostics: dict[str, Any] | None = None
+    initial_node_loads: dict[str, float] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize launch summary to JSON-compatible data."""
+        payload = {
+            "run_id": self.run_id,
+            "manifest": self.manifest_path,
+            "output": self.output_path,
+            "local_results_dir": self.local_results_dir,
+            "bucket_count": self.bucket_count,
+            "staged_count": self.staged_count,
+            "preflight": self.preflight,
+            "managers": self.managers,
+            "rsync_status": self.rsync_status,
+        }
+        if self.diagnostics is not None:
+            payload["diagnostics"] = self.diagnostics
+        if self.initial_node_loads is not None:
+            payload["initial_node_loads"] = self.initial_node_loads
+        return payload
+
+
+@dataclass(frozen=True)
+class ExistingRemoteBatchLaunchResult:
+    """Summary of a completed manager-backed existing-command batch."""
+
+    run_id: str
+    task_count: int
+    assignment: dict[str, int]
+    manifest: str
+    local_results_dir: str
+    local_artifacts_dir: str
+    summary: str
+    preflight: dict[str, Any]
+    managers: dict[str, str]
+    admission: dict[str, dict[str, Any]]
+    rebalances: tuple[dict[str, str], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the user-facing launch result."""
+        return {
+            "run_id": self.run_id,
+            "task_count": self.task_count,
+            "assignment": self.assignment,
+            "manifest": self.manifest,
+            "local_results_dir": self.local_results_dir,
+            "local_artifacts_dir": self.local_artifacts_dir,
+            "summary": self.summary,
+            "preflight": self.preflight,
+            "managers": self.managers,
+            "admission": self.admission,
+            "rebalances": list(self.rebalances),
+        }
+
+
+def write_remote_compute_receipt(payload: dict[str, Any], path: Path | str) -> None:
+    """Persist the terminal high-level command result for later audit."""
+    _write_json_atomic(Path(path), payload, overwrite=True)
+
+
+class RemoteDispatchPlanner:
+    """Plan bucketed remote execution across heterogeneous nodes."""
+
+    def __init__(
+        self,
+        nodes: list[RemoteNode],
+        bucket_size: int,
+        *,
+        initial_node_loads: dict[str, float] | None = None,
+    ):
+        """Initialize a planner with node capabilities and bucket size."""
+        if not nodes:
+            raise ValueError("RemoteDispatchPlanner requires at least one node")
+        if bucket_size < 1:
+            raise ValueError(f"bucket_size must be >= 1, got {bucket_size}")
+        names = [node.name for node in nodes]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(f"Duplicate remote node names: {duplicates}")
+        load_names = set(initial_node_loads or {})
+        unknown_load_names = sorted(load_names - set(names))
+        if unknown_load_names:
+            raise ValueError(f"Initial node loads reference unknown node(s): {unknown_load_names}")
+        for node_name, load in (initial_node_loads or {}).items():
+            if load < 0:
+                raise ValueError(f"Initial node load for {node_name!r} must be >= 0, got {load}")
+        self.nodes = tuple(nodes)
+        self.bucket_size = bucket_size
+        self.initial_node_loads = dict(initial_node_loads or {})
+
+    def build_plan(
+        self,
+        tool_key: str,
+        inputs: BaseToolInput | dict[str, Any],
+        config: BaseConfig | dict[str, Any] | None = None,
+        *,
+        run_id: str | None = None,
+    ) -> RemoteDispatchPlan:
+        """Build a remote dispatch plan for an iterable-input tool."""
+        spec = ToolRegistry.get(tool_key)
+        if spec.iterable_input_fields is None or spec.iterable_output_field is None:
+            raise ValueError(f"Tool {tool_key!r} does not declare iterable inputs for remote bucketing")
+
+        typed_inputs = inputs if isinstance(inputs, spec.input_model) else spec.input_model.model_validate(inputs)
+        typed_config: BaseConfig
+        if config is None:
+            typed_config = cast(BaseConfig, spec.config_model())
+        elif isinstance(config, spec.config_model):
+            typed_config = config
+        else:
+            typed_config = cast(BaseConfig, spec.config_model.model_validate(config))
+
+        active_fields = tuple(
+            field for field in spec.iterable_input_fields if getattr(typed_inputs, field, None) is not None
+        )
+        if not active_fields:
+            raise ValueError(f"Tool {tool_key!r} has no populated iterable input fields")
+        primary_field = active_fields[0]
+        primary_items = list(getattr(typed_inputs, primary_field))
+        for field in active_fields[1:]:
+            values = getattr(typed_inputs, field)
+            if len(values) != len(primary_items):
+                raise ValueError(
+                    f"Remote iterable field {field!r} (len {len(values)}) is not aligned "
+                    f"with primary {primary_field!r} (len {len(primary_items)})"
+                )
+
+        buckets = self._make_buckets(type(typed_inputs), primary_items)
+        assignments = self._assign_buckets(buckets)
+        return RemoteDispatchPlan(
+            tool_key=tool_key,
+            run_id=run_id or f"{tool_key}-{uuid.uuid4().hex}",
+            input_fields=active_fields,
+            iterable_output_field=spec.iterable_output_field,
+            inputs=typed_inputs,
+            config=typed_config,
+            assignments=assignments,
+        )
+
+    def _make_buckets(self, input_model: type[BaseToolInput], items: list[Any]) -> tuple[RemoteBucket, ...]:
+        """Split input rows into contiguous buckets."""
+        buckets: list[RemoteBucket] = []
+        for bucket_index, start in enumerate(range(0, len(items), self.bucket_size)):
+            end = min(start + self.bucket_size, len(items))
+            indices = tuple(range(start, end))
+            total_cost = sum(float(input_model.item_cost(items[idx])) for idx in indices)
+            buckets.append(
+                RemoteBucket(bucket_id=f"bucket-{bucket_index:05d}", item_indices=indices, total_cost=total_cost)
+            )
+        return tuple(buckets)
+
+    def _assign_buckets(self, buckets: tuple[RemoteBucket, ...]) -> tuple[RemoteAssignment, ...]:
+        """Assign buckets by LPT using node weight and concurrency as capacity."""
+        loads = {node.name: self.initial_node_loads.get(node.name, 0.0) for node in self.nodes}
+        nodes_by_name = {node.name: node for node in self.nodes}
+        assignments: list[RemoteAssignment] = []
+        for bucket in sorted(buckets, key=lambda item: item.total_cost, reverse=True):
+            node_name = min(
+                loads,
+                key=lambda name: (
+                    loads[name] / (nodes_by_name[name].weight * nodes_by_name[name].max_concurrent_buckets)
+                ),
+            )
+            node = nodes_by_name[node_name]
+            assignments.append(RemoteAssignment(node=node, bucket=bucket))
+            loads[node.name] += bucket.total_cost
+        return tuple(
+            sorted(assignments, key=lambda item: item.bucket.item_indices[0] if item.bucket.item_indices else -1)
+        )
+
+
+class RemoteSubmissionClient:
+    """Stage planned bucket requests into node-side manager queues over SSH."""
+
+    _STAGE_MANY_PY = (
+        "import json, os, pathlib, sys\n"
+        "root = pathlib.Path(sys.argv[1])\n"
+        "emit_summary = len(sys.argv) > 2 and sys.argv[2] == '--summary'\n"
+        "payload = json.load(sys.stdin)\n"
+        "state_root = root.parent.parent\n"
+        "root.mkdir(parents=True, exist_ok=True)\n"
+        "summary = {'staged': [], 'skipped': []}\n"
+        "def same_request(path, request):\n"
+        "    try:\n"
+        "        return json.loads(path.read_text()) == request\n"
+        "    except Exception as exc:\n"
+        "        raise SystemExit(f'unreadable existing request at {path}: {type(exc).__name__}: {exc}')\n"
+        "def same_completed_result(path, request):\n"
+        "    try:\n"
+        "        envelope = json.loads(path.read_text())\n"
+        "    except Exception as exc:\n"
+        "        raise SystemExit(f'unreadable existing result at {path}: {type(exc).__name__}: {exc}')\n"
+        "    expected = {\n"
+        "        'run_id': request.get('run_id'),\n"
+        "        'bucket_id': request.get('bucket_id'),\n"
+        "        'tool_key': request.get('tool_key'),\n"
+        "        'item_indices': request.get('item_indices', []),\n"
+        "    }\n"
+        "    actual = {key: envelope.get(key) for key in expected}\n"
+        "    if actual != expected:\n"
+        "        raise SystemExit(f'existing result differs from manifest at {path}')\n"
+        "    if envelope.get('status') == 'failed':\n"
+        "        raise SystemExit(f'request previously failed at {path}; use a new run_id or clear it after review')\n"
+        "    if envelope.get('status') == 'completed' and actual == expected:\n"
+        "        return True\n"
+        "    raise SystemExit(f'existing non-completed result at {path}; clear it after review')\n"
+        "for item in payload['requests']:\n"
+        "    name = item['filename']\n"
+        "    if '/' in name or name.startswith('.'):\n"
+        "        raise SystemExit(f'invalid request filename: {name!r}')\n"
+        "    request = item['request']\n"
+        "    relative = pathlib.Path(root.name) / name\n"
+        "    protected = {\n"
+        "        state: state_root / state / relative\n"
+        "        for state in ('queue', 'running', 'submitted', 'done', 'failed')\n"
+        "    }\n"
+        "    result_path = state_root / 'results' / root.name / name\n"
+        "    for state, path in protected.items():\n"
+        "        if not path.exists():\n"
+        "            continue\n"
+        "        if state == 'running':\n"
+        "            if not same_request(path, request):\n"
+        "                raise SystemExit(\n"
+        "                    f'existing running request differs from manifest at {path}; use a new run_id or clear it after review'\n"
+        "                )\n"
+        "            if result_path.exists() and same_completed_result(result_path, request):\n"
+        "                summary['skipped'].append({'filename': name, 'state': 'running_result', 'path': str(result_path)})\n"
+        "                break\n"
+        "            summary['skipped'].append({'filename': name, 'state': 'running', 'path': str(path)})\n"
+        "            break\n"
+        "        if state == 'failed':\n"
+        "            raise SystemExit(\n"
+        "                f'request previously failed at {path}; use a new run_id or clear it after review'\n"
+        "            )\n"
+        "        if same_request(path, request):\n"
+        "            summary['skipped'].append({'filename': name, 'state': state, 'path': str(path)})\n"
+        "            break\n"
+        "        raise SystemExit(\n"
+        "            f'existing {state} request differs from manifest at {path}; use a new run_id or clear it after review'\n"
+        "        )\n"
+        "    else:\n"
+        "        if result_path.exists() and same_completed_result(result_path, request):\n"
+        "            summary['skipped'].append({'filename': name, 'state': 'result', 'path': str(result_path)})\n"
+        "            continue\n"
+        "        final = root / name\n"
+        "        tmp = root / ('.' + name + '.tmp')\n"
+        "        tmp.write_text(json.dumps(request, sort_keys=True) + '\\n')\n"
+        "        os.replace(tmp, final)\n"
+        "        summary['staged'].append({'filename': name, 'path': str(final)})\n"
+        "        continue\n"
+        "    continue\n"
+        "if emit_summary:\n"
+        "    print(json.dumps(summary, sort_keys=True))\n"
+    )
+
+    def render_stage_script(self, node: RemoteNode, run_id: str, bucket_id: str) -> str:
+        """Return the remote shell script used to atomically stage one request."""
+        _validate_path_segment("run_id", run_id)
+        _validate_path_segment("bucket_id", bucket_id)
+        queue_dir = node.queue_root / run_id
+        final_path = queue_dir / f"{bucket_id}.json"
+        tmp_path = queue_dir / f".{bucket_id}.json.tmp"
+        return (
+            f"mkdir -p {shlex.quote(str(queue_dir))} && "
+            f"umask 077 && "
+            f"cat > {shlex.quote(str(tmp_path))} && "
+            f"mv {shlex.quote(str(tmp_path))} {shlex.quote(str(final_path))}"
+        )
+
+    def render_stage_many_script(self, node: RemoteNode, run_id: str, *, summary: bool = False) -> str:
+        """Return the remote shell script used to stage many requests at once."""
+        _validate_path_segment("run_id", run_id)
+        queue_dir = node.queue_root / run_id
+        summary_arg = " --summary" if summary else ""
+        return (
+            "umask 077 && "
+            f"{shlex.quote(node.python)} -c {shlex.quote(self._STAGE_MANY_PY)} "
+            f"{shlex.quote(str(queue_dir))}{summary_arg}"
+        )
+
+    def submit_assignment(
+        self,
+        plan: RemoteDispatchPlan,
+        assignment: RemoteAssignment,
+        *,
+        runner: Any = subprocess.run,
+    ) -> PurePosixPath:
+        """Stage one assignment request over SSH and return its remote queue path."""
+        payload = json.dumps(plan.request_for(assignment), sort_keys=True) + "\n"
+        script = self.render_stage_script(assignment.node, plan.run_id, assignment.bucket.bucket_id)
+        cmd = ["ssh", *assignment.node.ssh_args, assignment.node.host, script]
+        runner(cmd, input=payload, text=True, check=True)
+        return assignment.node.queue_root / plan.run_id / f"{assignment.bucket.bucket_id}.json"
+
+    def submit_node_assignments(
+        self,
+        plan: RemoteDispatchPlan,
+        node: RemoteNode,
+        assignments: list[RemoteAssignment],
+        *,
+        runner: Any = subprocess.run,
+    ) -> list[PurePosixPath]:
+        """Stage all assignments for one node through one SSH command."""
+        if not assignments:
+            return []
+        payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "run_id": plan.run_id,
+            "requests": [
+                {
+                    "filename": f"{assignment.bucket.bucket_id}.json",
+                    "request": plan.request_for(assignment),
+                }
+                for assignment in assignments
+            ],
+        }
+        script = self.render_stage_many_script(node, plan.run_id)
+        cmd = ["ssh", *node.ssh_args, node.host, script]
+        runner(cmd, input=json.dumps(payload, sort_keys=True) + "\n", text=True, check=True)
+        return [node.queue_root / plan.run_id / f"{assignment.bucket.bucket_id}.json" for assignment in assignments]
+
+    def submit_plan(
+        self,
+        plan: RemoteDispatchPlan,
+        *,
+        runner: Any = subprocess.run,
+    ) -> list[PurePosixPath]:
+        """Stage every bucket request in a plan."""
+        assignments_by_node: dict[str, list[RemoteAssignment]] = {}
+        nodes_by_name: dict[str, RemoteNode] = {}
+        for assignment in plan.assignments:
+            assignments_by_node.setdefault(assignment.node.name, []).append(assignment)
+            nodes_by_name[assignment.node.name] = assignment.node
+
+        paths_by_bucket: dict[str, PurePosixPath] = {}
+        for node_name, assignments in assignments_by_node.items():
+            node_paths = self.submit_node_assignments(
+                plan,
+                nodes_by_name[node_name],
+                assignments,
+                runner=runner,
+            )
+            for assignment, path in zip(assignments, node_paths, strict=True):
+                paths_by_bucket[assignment.bucket.bucket_id] = path
+        return [paths_by_bucket[assignment.bucket.bucket_id] for assignment in plan.assignments]
+
+
+def load_remote_run_manifest(path: Path | str) -> RemoteRunManifest:
+    """Load a remote run manifest from disk."""
+    return RemoteRunManifest.from_dict(json.loads(Path(path).read_text()))
+
+
+def write_remote_run_manifest(
+    manifest: RemoteRunManifest,
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write a remote run manifest atomically."""
+    output_path = Path(path)
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Remote run manifest already exists: {output_path}")
+    _write_json_atomic(output_path, manifest.to_dict())
+
+
+def plan_existing_remote_command_batch(
+    nodes: list[ExistingRemoteBatchNode],
+    *,
+    input_fasta: Path | str,
+    run_id: str,
+    bucket_size: int,
+    local_results_dir: Path | str,
+    software: str,
+    initial_node_loads: dict[str, float] | None = None,
+) -> RemoteRunManifest:
+    """Freeze a FASTA batch as node-specific existing-command manager requests."""
+    _validate_path_segment("run_id", run_id)
+    _validate_path_segment("software", software)
+    if not nodes:
+        raise ValueError("Existing remote command batch requires at least one node")
+    manager_nodes = [node.manager for node in nodes]
+    _raise_for_remote_profile_errors(manager_nodes)
+    command_by_name = {node.command.name: node.command for node in nodes}
+    if len(command_by_name) != len(nodes):
+        raise ValueError("Existing remote command batch has duplicate node names")
+    for node in nodes:
+        command = node.command
+        if command.status != "ready":
+            raise ValueError(
+                f"Existing remote command profile {command.name!r} has status={command.status!r}; ready is required"
+            )
+        if command.software != software:
+            raise ValueError(
+                f"Existing remote command profile {command.name!r} software={command.software!r}, "
+                f"expected {software!r}"
+            )
+        if not command.required_artifacts:
+            raise ValueError(f"Existing remote command profile {command.name!r} has no required_artifacts")
+    _validate_existing_batch_gpu_contract(nodes, software)
+
+    records = read_fasta_records(input_fasta)
+    buckets: list[RemoteBucket] = []
+    for bucket_index, start in enumerate(range(0, len(records), bucket_size)):
+        end = min(start + bucket_size, len(records))
+        indices = tuple(range(start, end))
+        buckets.append(
+            RemoteBucket(
+                bucket_id=f"bucket-{bucket_index:05d}",
+                item_indices=indices,
+                total_cost=float(sum(len(records[index].sequence) for index in indices)),
+            )
+        )
+    planner = RemoteDispatchPlanner(
+        manager_nodes,
+        bucket_size,
+        initial_node_loads=initial_node_loads,
+    )
+    assignments = planner._assign_buckets(tuple(buckets))
+    requests: list[RemoteRunRequest] = []
+    artifact_destinations: set[str] = set()
+    for assignment in assignments:
+        manager = assignment.node
+        command = command_by_name[manager.name]
+        resource_admission: dict[str, Any] | None = None
+        if command.gpu_admission is not None:
+            gpu_id = (command.env or {})["CUDA_VISIBLE_DEVICES"].split(",", 1)[0].strip()
+            if not gpu_id:
+                raise ValueError(
+                    f"Existing remote command profile {command.name!r} has an empty CUDA_VISIBLE_DEVICES"
+                )
+            resource_admission = {
+                "kind": "cuda_idle",
+                "gpu_id": gpu_id,
+                **command.gpu_admission,
+            }
+        artifact_root = PurePosixPath(command.work_dir) / run_id / "artifacts"
+        tasks: list[dict[str, Any]] = []
+        for index in assignment.bucket.item_indices:
+            task_id = f"task_{index:05d}"
+            artifact_dir = artifact_root / task_id / f"attempt_{manager.name}"
+            artifact_text = str(artifact_dir)
+            if artifact_text in artifact_destinations:
+                raise ValueError(f"Duplicate existing command artifact destination: {artifact_text}")
+            artifact_destinations.add(artifact_text)
+            record = records[index]
+            tasks.append(
+                {
+                    "task_id": task_id,
+                    "header": record.header,
+                    "sequence_length": len(record.sequence),
+                    "input_filename": f"{task_id}.fasta",
+                    "input_text": record.to_text(),
+                    "artifact_dir": artifact_text,
+                    "required_artifacts": list(command.required_artifacts),
+                }
+            )
+        existing_command = {
+            "software": software,
+            "node_name": manager.name,
+            "artifact_root": str(artifact_root),
+            "command_argv": list(command.command_argv),
+            "env": command.env or {},
+            "required_stdout_patterns": list(command.required_stdout_patterns),
+            "tasks": tasks,
+        }
+        if resource_admission is not None:
+            existing_command["resource_admission"] = resource_admission
+        request = {
+            "schema_version": _SCHEMA_VERSION,
+            "request_kind": "existing_command",
+            "tool_key": f"existing-{software}",
+            "run_id": run_id,
+            "bucket_id": assignment.bucket.bucket_id,
+            "item_indices": list(assignment.bucket.item_indices),
+            "existing_command": existing_command,
+        }
+        requests.append(
+            RemoteRunRequest(
+                node_name=manager.name,
+                bucket_id=assignment.bucket.bucket_id,
+                item_indices=assignment.bucket.item_indices,
+                total_cost=assignment.bucket.total_cost,
+                request=request,
+            )
+        )
+    return RemoteRunManifest(
+        manifest_schema_version=_MANIFEST_SCHEMA_VERSION,
+        request_schema_version=_SCHEMA_VERSION,
+        run_id=run_id,
+        tool_key=f"existing-{software}",
+        bucket_size=bucket_size,
+        input_fields=("fasta_records",),
+        iterable_output_field="existing_command_results",
+        local_results_dir=str(Path(local_results_dir).resolve()),
+        nodes=tuple(manager_nodes),
+        requests=tuple(requests),
+    )
+
+
+def render_existing_artifact_pull_commands(
+    manifest: RemoteRunManifest,
+    local_artifacts_dir: Path | str,
+) -> list[list[str]]:
+    """Render one rsync pull per assigned node for existing-command artifacts."""
+    local_root = Path(local_artifacts_dir)
+    requests_by_node: dict[str, list[RemoteRunRequest]] = {}
+    for request in manifest.requests:
+        requests_by_node.setdefault(request.node_name, []).append(request)
+    commands: list[list[str]] = []
+    for node in manifest.nodes:
+        requests = requests_by_node.get(node.name, [])
+        if not requests:
+            continue
+        roots = {
+            str(request.request["existing_command"]["artifact_root"])
+            for request in requests
+        }
+        if len(roots) != 1:
+            raise ValueError(f"Existing command manifest has inconsistent artifact roots for node {node.name!r}")
+        remote_root = roots.pop()
+        cmd = ["rsync", "-a"]
+        if node.sync_ssh_args:
+            cmd.extend(["-e", shlex.join(["ssh", *node.sync_ssh_args])])
+        cmd.extend(
+            [
+                f"{node.sync_host}:{remote_root}/",
+                str(local_root / node.name) + "/",
+            ]
+        )
+        commands.append(cmd)
+    return commands
+
+
+def collect_existing_remote_command_manifest(
+    manifest: RemoteRunManifest,
+    local_artifacts_dir: Path | str,
+) -> dict[str, Any]:
+    """Validate completed existing-command envelopes and their mirrored native artifacts."""
+    local_root = Path(local_artifacts_dir)
+    rows_by_index: dict[int, dict[str, Any]] = {}
+    for node, request, result_path in _manifest_result_entries(manifest):
+        envelope = cast(dict[str, Any], json.loads(result_path.read_text()))
+        _validate_manifest_result_envelope(manifest, node, request, result_path, envelope)
+        command_results = envelope.get("existing_command_results")
+        tasks = request.request.get("existing_command", {}).get("tasks")
+        if not isinstance(command_results, list) or not isinstance(tasks, list):
+            raise RuntimeError(f"Existing command result is missing task rows: {node.name}/{request.bucket_id}")
+        if len(command_results) != len(request.item_indices) or len(tasks) != len(request.item_indices):
+            raise RuntimeError(
+                f"Existing command result count mismatch for {node.name}/{request.bucket_id}: "
+                f"results={len(command_results)} tasks={len(tasks)} items={len(request.item_indices)}"
+            )
+        result_by_task = {str(result.get("task_id")): result for result in command_results}
+        for index, task in zip(request.item_indices, tasks, strict=True):
+            task_id = str(task["task_id"])
+            result = result_by_task.get(task_id)
+            if result is None:
+                raise RuntimeError(f"Existing command result missing {task_id!r} for {node.name}/{request.bucket_id}")
+            expected_stdout_patterns = request.request["existing_command"].get(
+                "required_stdout_patterns", []
+            )
+            validated_stdout_patterns = result.get("validated_stdout_patterns", [])
+            if validated_stdout_patterns != expected_stdout_patterns:
+                raise RuntimeError(
+                    f"Existing command stdout evidence mismatch for {task_id!r}: "
+                    f"expected={expected_stdout_patterns!r} validated={validated_stdout_patterns!r}"
+                )
+            local_task_dir = local_root / node.name / task_id / f"attempt_{node.name}"
+            required = task.get("required_artifacts")
+            if not isinstance(required, list):
+                raise RuntimeError(f"Existing command manifest task {task_id!r} has no required_artifacts")
+            artifacts = _required_existing_artifacts(local_task_dir / "output", required)
+            envelope_artifacts = sorted(str(path) for path in result.get("artifacts", []))
+            if artifacts != envelope_artifacts:
+                raise RuntimeError(
+                    f"Existing command artifact inventory mismatch for {task_id!r}: "
+                    f"envelope={envelope_artifacts!r} local={artifacts!r}"
+                )
+            rows_by_index[index] = {
+                "item_index": index,
+                "task_id": task_id,
+                "header": str(task["header"]),
+                "sequence_length": int(task["sequence_length"]),
+                "node": node.name,
+                "local_artifact_dir": str(local_task_dir),
+                "artifacts": artifacts,
+            }
+            if validated_stdout_patterns:
+                rows_by_index[index]["validated_stdout_patterns"] = list(validated_stdout_patterns)
+    expected = {index for request in manifest.requests for index in request.item_indices}
+    if set(rows_by_index) != expected:
+        raise RuntimeError(
+            f"Existing command collected task indices differ: expected={sorted(expected)} actual={sorted(rows_by_index)}"
+        )
+    tasks = [rows_by_index[index] for index in sorted(rows_by_index)]
+    return {
+        "run_id": manifest.run_id,
+        "tool_key": manifest.tool_key,
+        "task_count": len(tasks),
+        "tasks": tasks,
+    }
+
+
+def ensure_remote_run_output_path_available(path: Path | str, *, overwrite: bool = False) -> None:
+    """Raise when a remote run output path would be overwritten."""
+    output_path = Path(path)
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Remote run output already exists: {output_path}")
+
+
+def write_remote_run_output(
+    output: BaseToolOutput,
+    path: Path | str,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Write a collected remote run output atomically."""
+    output_path = Path(path)
+    _write_text_atomic(
+        output_path,
+        str(output.model_dump_json(indent=2)) + "\n",
+        overwrite=overwrite,
+        exists_message=f"Remote run output already exists: {output_path}",
+    )
+
+
+def submit_remote_run_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    bucket_ids: set[str] | None = None,
+    runner: Any = subprocess.run,
+) -> list[PurePosixPath]:
+    """Stage all or a selected set of bucket requests recorded in a manifest."""
+    submitter = RemoteSubmissionClient()
+    known_bucket_ids = {request.bucket_id for request in manifest.requests}
+    if bucket_ids is not None and not bucket_ids <= known_bucket_ids:
+        raise ValueError(f"Unknown manifest bucket ids: {sorted(bucket_ids - known_bucket_ids)}")
+    selected_requests = [
+        request
+        for request in manifest.requests
+        if bucket_ids is None or request.bucket_id in bucket_ids
+    ]
+    requests_by_node: dict[str, list[RemoteRunRequest]] = {}
+    for request in selected_requests:
+        requests_by_node.setdefault(request.node_name, []).append(request)
+
+    paths_by_bucket: dict[str, PurePosixPath] = {}
+    for node in manifest.nodes:
+        node_requests = requests_by_node.get(node.name, [])
+        if not node_requests:
+            continue
+        payload = {
+            "schema_version": _SCHEMA_VERSION,
+            "run_id": manifest.run_id,
+            "requests": [
+                {
+                    "filename": f"{request.bucket_id}.json",
+                    "request": request.request,
+                }
+                for request in node_requests
+            ],
+        }
+        script = submitter.render_stage_many_script(node, manifest.run_id)
+        cmd = ["ssh", *node.ssh_args, node.host, script]
+        runner(cmd, input=json.dumps(payload, sort_keys=True) + "\n", text=True, check=True)
+        for request in node_requests:
+            paths_by_bucket[request.bucket_id] = node.queue_root / manifest.run_id / f"{request.bucket_id}.json"
+
+    return [paths_by_bucket[request.bucket_id] for request in selected_requests]
+
+
+def _manifest_result_entries(manifest: RemoteRunManifest) -> list[tuple[RemoteNode, RemoteRunRequest, Path]]:
+    """Return expected local result entries for one manifest."""
+    return [
+        (
+            manifest.node_for_request(request),
+            request,
+            manifest.local_result_path(request),
+        )
+        for request in manifest.requests
+    ]
+
+
+def _validate_manifest_result_envelope(
+    manifest: RemoteRunManifest,
+    node: RemoteNode,
+    request: RemoteRunRequest,
+    path: Path,
+    envelope: dict[str, Any],
+) -> None:
+    """Raise when a mirrored manifest result is not the exact completed bucket."""
+    identity_checks = (
+        ("run_id", manifest.run_id, envelope.get("run_id")),
+        ("bucket_id", request.bucket_id, envelope.get("bucket_id")),
+        ("tool_key", manifest.tool_key, envelope.get("tool_key")),
+        ("item_indices", list(request.item_indices), envelope.get("item_indices")),
+    )
+    mismatches = [
+        f"{field} expected {expected!r} got {actual!r}"
+        for field, expected, actual in identity_checks
+        if actual != expected
+    ]
+    if mismatches:
+        raise RuntimeError(
+            f"Remote run {manifest.run_id} got result for wrong identity at "
+            f"{node.name}/{request.bucket_id}: {'; '.join(mismatches)} (result_path={path})"
+        )
+
+    status = envelope.get("status")
+    if status == "failed":
+        trace_tail = str(envelope.get("traceback", "")).splitlines()[-1:] or [""]
+        raise RuntimeError(
+            f"Remote run {manifest.run_id} failed: {node.name}/{request.bucket_id}: "
+            f"{envelope.get('error', '<no error>')} (result_path={path}; trace_tail={trace_tail[0]})"
+        )
+    if status != "completed":
+        raise RuntimeError(
+            f"Remote run {manifest.run_id} has non-completed result for "
+            f"{node.name}/{request.bucket_id}: status={status!r} (result_path={path})"
+        )
+
+
+def _missing_or_raise_for_invalid_manifest_results(manifest: RemoteRunManifest) -> list[Path]:
+    """Return missing manifest result paths after validating every visible envelope."""
+    missing: list[Path] = []
+    for node, request, path in _manifest_result_entries(manifest):
+        if not path.exists():
+            missing.append(path)
+            continue
+        try:
+            envelope = cast(dict[str, Any], json.loads(path.read_text()))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Remote run {manifest.run_id} has unreadable result for "
+                f"{node.name}/{request.bucket_id}: {exc} (result_path={path})"
+            ) from exc
+        _validate_manifest_result_envelope(manifest, node, request, path, envelope)
+    return missing
+
+
+def _tail_text(path: Path | str, line_count: int) -> str:
+    """Return the last ``line_count`` lines from a local text file."""
+    text_path = Path(path)
+    if not text_path.exists():
+        return ""
+    return "\n".join(text_path.read_text(errors="replace").splitlines()[-line_count:])
+
+
+def _raise_if_background_rsync_inactive(
+    manifest: RemoteRunManifest,
+    missing: list[Path],
+    *,
+    rsync_pid_path: Path | str | None,
+    rsync_log_path: Path | str | None,
+    rsync_client: "LocalRsyncPullClient | None",
+    rsync_log_tail_lines: int,
+    runner: Any,
+) -> None:
+    """Raise when background rsync health is requested but its pid is not running."""
+    if rsync_pid_path is None or not missing:
+        return
+    status = (rsync_client or LocalRsyncPullClient()).status(rsync_pid_path, runner=runner).strip()
+    if status.startswith("running "):
+        return
+    preview = ", ".join(str(path) for path in missing[:3])
+    message = (
+        f"Remote run {manifest.run_id} rsync pull loop is not running: status={status!r}; "
+        f"pid_path={rsync_pid_path}; waiting for {len(missing)} result(s): {preview}"
+    )
+    if rsync_log_path is not None:
+        tail = _tail_text(rsync_log_path, rsync_log_tail_lines)
+        message += f"; log_path={rsync_log_path}; log_tail={tail or '<empty or missing>'}"
+    raise RuntimeError(message)
+
+
+def _run_inline_rsync_pull(command: list[str], *, runner: Any) -> str | None:
+    """Run one inline rsync command and return a retryable transport error."""
+    try:
+        runner(command, check=True)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        stderr = str(getattr(exc, "stderr", "") or "").strip()
+        return f"{exc}; stderr={stderr or '<empty>'}"
+    return None
+
+
+def wait_remote_run_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    poll_interval: float = 5.0,
+    timeout_sec: float | None = None,
+    pull_results: bool = True,
+    rsync_pid_path: Path | str | None = None,
+    rsync_log_path: Path | str | None = None,
+    rsync_client: "LocalRsyncPullClient | None" = None,
+    rsync_log_tail_lines: int = 40,
+    poll_hook: Callable[[RemoteRunManifest], RemoteRunManifest] | None = None,
+    runner: Any = subprocess.run,
+) -> RemoteRunManifest:
+    """Wait until every manifest result exists locally."""
+    if poll_interval <= 0:
+        raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
+    if timeout_sec is not None and timeout_sec <= 0:
+        raise ValueError(f"timeout_sec must be > 0, got {timeout_sec}")
+    if rsync_log_tail_lines < 1:
+        raise ValueError(f"rsync_log_tail_lines must be >= 1, got {rsync_log_tail_lines}")
+    deadline = None if timeout_sec is None else time.monotonic() + timeout_sec
+    last_pull_error: str | None = None
+    while True:
+        if poll_hook is not None:
+            manifest = poll_hook(manifest)
+        missing = _missing_or_raise_for_invalid_manifest_results(manifest)
+        if not missing:
+            return manifest
+        if pull_results:
+            pull_failed = False
+            for cmd in render_rsync_pull_commands(list(manifest.nodes), manifest.local_results_dir):
+                pull_error = _run_inline_rsync_pull(cmd, runner=runner)
+                if pull_error is not None:
+                    pull_failed = True
+                    last_pull_error = pull_error
+                    logger.warning(
+                        "Remote run %s rsync pull attempt failed; will retry within the wait timeout: %s",
+                        manifest.run_id,
+                        last_pull_error,
+                    )
+            if not pull_failed:
+                last_pull_error = None
+            missing = _missing_or_raise_for_invalid_manifest_results(manifest)
+            if not missing:
+                return manifest
+        _raise_if_background_rsync_inactive(
+            manifest,
+            missing,
+            rsync_pid_path=rsync_pid_path,
+            rsync_log_path=rsync_log_path,
+            rsync_client=rsync_client,
+            rsync_log_tail_lines=rsync_log_tail_lines,
+            runner=runner,
+        )
+        if deadline is not None and time.monotonic() >= deadline:
+            preview = ", ".join(str(path) for path in missing[:3])
+            message = f"Remote run {manifest.run_id} timed out waiting for {len(missing)} result(s): {preview}"
+            if last_pull_error is not None:
+                message += f"; last rsync pull error: {last_pull_error}"
+            raise TimeoutError(message)
+        time.sleep(poll_interval)
+
+
+def collect_remote_run_manifest(manifest: RemoteRunManifest) -> BaseToolOutput:
+    """Merge completed manifest result files into the tool's output model."""
+    spec = ToolRegistry.get(manifest.tool_key)
+    output_items: dict[int, Any] = {}
+    warnings: list[str] = []
+    errors: list[str] = []
+    metadata: dict[str, Any] = {"remote_dispatch": {"run_id": manifest.run_id, "buckets": len(manifest.requests)}}
+
+    for node, request, result_path in _manifest_result_entries(manifest):
+        envelope = cast(dict[str, Any], json.loads(result_path.read_text()))
+        _validate_manifest_result_envelope(manifest, node, request, result_path, envelope)
+        output = spec.output_model.model_validate(envelope["output"])
+        bucket_outputs = list(getattr(output, manifest.iterable_output_field))
+        if len(bucket_outputs) != len(request.item_indices):
+            raise RuntimeError(
+                f"Remote bucket {request.bucket_id} returned {len(bucket_outputs)} "
+                f"{manifest.iterable_output_field} for {len(request.item_indices)} input item(s)"
+            )
+        output_items.update(dict(zip(request.item_indices, bucket_outputs, strict=True)))
+        warnings.extend(output.warnings)
+        errors.extend(output.errors)
+
+    expected = {index for request in manifest.requests for index in request.item_indices}
+    missing = sorted(expected - set(output_items))
+    if missing:
+        raise RuntimeError(f"Missing remote output item(s): {missing}")
+    merged = [output_items[index] for index in sorted(output_items)]
+    output_payload: dict[str, Any] = {
+        manifest.iterable_output_field: merged,
+        "warnings": warnings,
+        "errors": errors,
+        "metadata": metadata,
+    }
+    return cast(BaseToolOutput, spec.output_model.model_validate(output_payload))
+
+
+def _raise_for_remote_profile_errors(nodes: list[RemoteNode]) -> None:
+    """Raise when static remote profile validation reports errors."""
+    errors = [issue for issue in validate_remote_nodes(nodes) if issue.level == "error"]
+    if errors:
+        first = errors[0]
+        raise ValueError(f"Invalid remote profile: {first.node_name or '-'} {first.field}: {first.message}")
+
+
+def _raise_for_preflight_failures(preflight: dict[str, Any]) -> None:
+    """Raise when any remote preflight reports ``ok=false``."""
+    failed = {name: payload for name, payload in preflight.items() if not payload.get("ok")}
+    if failed:
+        raise ValueError(f"Remote preflight failed: {json.dumps(failed, sort_keys=True)}")
+
+
+def _pending_bucket_count_from_diagnostics(payload: dict[str, Any]) -> int:
+    """Return pending bucket count from manager diagnostics."""
+    counts = payload.get("counts") or {}
+    return sum(int(counts.get(key, 0) or 0) for key in ("queue", "running", "submitted"))
+
+
+def remote_run_diagnostics_backlog_loads(
+    nodes: list[RemoteNode],
+    *,
+    manager_client: "RemoteManagerClient | None" = None,
+    timeout_sec: float | None = None,
+    runner: Any = subprocess.run,
+) -> tuple[dict[str, Any], dict[str, float]]:
+    """Read manager diagnostics and convert visible backlog into planner loads."""
+    manager = manager_client or RemoteManagerClient()
+    diagnostics: dict[str, Any] = {}
+    for node in nodes:
+        if timeout_sec is None:
+            diagnostics[node.name] = manager.diagnostics_node(node, runner=runner)
+        else:
+            diagnostics[node.name] = manager.diagnostics_node(node, timeout_sec=timeout_sec, runner=runner)
+    initial_node_loads = {
+        node.name: float(_pending_bucket_count_from_diagnostics(diagnostics[node.name])) for node in nodes
+    }
+    return diagnostics, initial_node_loads
+
+
+def _manager_preflight_node(
+    manager: "RemoteManagerClient",
+    node: RemoteNode,
+    *,
+    timeout_sec: float | None,
+    runner: Any,
+) -> dict[str, Any]:
+    """Run preflight with an optional timeout without changing narrow test fakes."""
+    if timeout_sec is None:
+        return manager.preflight_node(node, runner=runner)
+    return manager.preflight_node(node, timeout_sec=timeout_sec, runner=runner)
+
+
+def _manager_start_node(
+    manager: "RemoteManagerClient",
+    node: RemoteNode,
+    *,
+    poll_interval: float,
+    slurm_group_size: int,
+    timeout_sec: float | None,
+    runner: Any,
+) -> str:
+    """Start a manager with an optional timeout without changing narrow test fakes."""
+    if timeout_sec is None:
+        return manager.start_node(
+            node,
+            poll_interval=poll_interval,
+            slurm_group_size=slurm_group_size,
+            runner=runner,
+        )
+    return manager.start_node(
+        node,
+        poll_interval=poll_interval,
+        slurm_group_size=slurm_group_size,
+        timeout_sec=timeout_sec,
+        runner=runner,
+    )
+
+
+def _validate_remote_run_rsync_mode(
+    rsync_mode: RemoteRsyncMode,
+    *,
+    rsync_pid_path: Path | str | None,
+    rsync_log_path: Path | str | None,
+) -> None:
+    """Validate rsync mode arguments for manifest-backed runs."""
+    if rsync_mode not in ("inline", "background"):
+        raise ValueError(f"Unsupported rsync_mode {rsync_mode!r}")
+    if rsync_mode == "background" and (rsync_pid_path is None or rsync_log_path is None):
+        raise ValueError("background rsync_mode requires rsync_pid_path and rsync_log_path")
+
+
+def _submit_wait_collect_remote_run_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    manifest_path: Path | str,
+    output_path: Path | str,
+    preflight: dict[str, Any],
+    managers: dict[str, str],
+    diagnostics: dict[str, Any] | None,
+    initial_node_loads: dict[str, float] | None,
+    wait_poll_interval: float,
+    timeout_sec: float | None,
+    rsync_mode: RemoteRsyncMode,
+    rsync_pid_path: Path | str | None,
+    rsync_log_path: Path | str | None,
+    rsync_interval_sec: int,
+    rsync_client: "LocalRsyncPullClient | None",
+    overwrite_output: bool,
+    runner: Any,
+) -> RemoteLaunchResult:
+    """Submit, wait for, collect, and summarize one manifest-backed run."""
+    _validate_remote_run_rsync_mode(
+        rsync_mode,
+        rsync_pid_path=rsync_pid_path,
+        rsync_log_path=rsync_log_path,
+    )
+    ensure_remote_run_output_path_available(output_path, overwrite=overwrite_output)
+    nodes = list(manifest.nodes)
+    local_results = Path(manifest.local_results_dir)
+    rsync_status: str | None = None
+    active_rsync: LocalRsyncPullClient | None = None
+    if rsync_mode == "background":
+        active_rsync = rsync_client or LocalRsyncPullClient()
+        rsync_status = active_rsync.start(
+            nodes,
+            local_results,
+            pid_path=cast(Path | str, rsync_pid_path),
+            log_path=cast(Path | str, rsync_log_path),
+            interval_sec=rsync_interval_sec,
+            runner=runner,
+        )
+
+    staged = submit_remote_run_manifest(manifest, runner=runner)
+    wait_remote_run_manifest(
+        manifest,
+        poll_interval=wait_poll_interval,
+        timeout_sec=timeout_sec,
+        pull_results=rsync_mode == "inline",
+        rsync_pid_path=rsync_pid_path if rsync_mode == "background" else None,
+        rsync_log_path=rsync_log_path if rsync_mode == "background" else None,
+        rsync_client=active_rsync if rsync_mode == "background" else None,
+        runner=runner,
+    )
+    output = collect_remote_run_manifest(manifest)
+    write_remote_run_output(output, output_path, overwrite=overwrite_output)
+    return RemoteLaunchResult(
+        run_id=manifest.run_id,
+        manifest_path=str(manifest_path),
+        output_path=str(output_path),
+        local_results_dir=manifest.local_results_dir,
+        bucket_count=len(manifest.requests),
+        staged_count=len(staged),
+        preflight=preflight,
+        managers=managers,
+        rsync_status=rsync_status,
+        diagnostics=diagnostics,
+        initial_node_loads=initial_node_loads,
+    )
+
+
+def resume_remote_run_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    manifest_path: Path | str,
+    output_path: Path | str,
+    manager_poll_interval: float = 5.0,
+    slurm_group_size: int = 10,
+    wait_poll_interval: float = 5.0,
+    timeout_sec: float | None = None,
+    rsync_mode: RemoteRsyncMode = "inline",
+    rsync_pid_path: Path | str | None = None,
+    rsync_log_path: Path | str | None = None,
+    rsync_interval_sec: int = 10,
+    overwrite_output: bool = False,
+    remote_check_timeout_sec: float | None = None,
+    manager_client: "RemoteManagerClient | None" = None,
+    rsync_client: "LocalRsyncPullClient | None" = None,
+    runner: Any = subprocess.run,
+) -> RemoteLaunchResult:
+    """Resume an existing manifest by starting managers, submitting, waiting, and collecting."""
+    ensure_remote_run_output_path_available(output_path, overwrite=overwrite_output)
+    nodes = list(manifest.nodes)
+    _raise_for_remote_profile_errors(nodes)
+    manager = manager_client or RemoteManagerClient()
+    preflight = {
+        node.name: _manager_preflight_node(
+            manager,
+            node,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+        for node in nodes
+    }
+    _raise_for_preflight_failures(preflight)
+    managers = {
+        node.name: _manager_start_node(
+            manager,
+            node,
+            poll_interval=manager_poll_interval,
+            slurm_group_size=slurm_group_size,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+        for node in nodes
+    }
+    return _submit_wait_collect_remote_run_manifest(
+        manifest,
+        manifest_path=manifest_path,
+        output_path=output_path,
+        preflight=preflight,
+        managers=managers,
+        diagnostics=None,
+        initial_node_loads=None,
+        wait_poll_interval=wait_poll_interval,
+        timeout_sec=timeout_sec,
+        rsync_mode=rsync_mode,
+        rsync_pid_path=rsync_pid_path,
+        rsync_log_path=rsync_log_path,
+        rsync_interval_sec=rsync_interval_sec,
+        rsync_client=rsync_client,
+        overwrite_output=overwrite_output,
+        runner=runner,
+    )
+
+
+def _validate_existing_batch_gpu_contract(nodes: list[ExistingRemoteBatchNode], software: str) -> None:
+    """Reject CPU demo profiles before GPU scientific work reaches a manager."""
+    if software.lower() not in {"af3", "alphafold3"}:
+        return
+    for node in nodes:
+        manager = node.manager
+        if not manager.worker_device.startswith("cuda"):
+            raise ValueError(
+                f"AlphaFold3 existing batch node {manager.name!r} must use a CUDA worker_device, "
+                f"got {manager.worker_device!r}"
+            )
+        if manager.scheduler == "direct" and not (node.command.env or {}).get("CUDA_VISIBLE_DEVICES"):
+            raise ValueError(
+                f"AlphaFold3 direct node {manager.name!r} must set CUDA_VISIBLE_DEVICES in command env"
+            )
+        if manager.scheduler == "direct" and node.command.gpu_admission is None:
+            raise ValueError(
+                f"AlphaFold3 direct node {manager.name!r} must configure gpu_admission so busy GPUs stay queued"
+            )
+        if manager.scheduler == "slurm" and not any("gpu" in arg for arg in manager.sbatch_args):
+            raise ValueError(f"AlphaFold3 Slurm node {manager.name!r} must request a GPU in sbatch_args")
+        if "CudaDevice" not in node.command.required_stdout_patterns:
+            raise ValueError(
+                f"AlphaFold3 existing batch node {manager.name!r} required_stdout_patterns "
+                "must include 'CudaDevice' so CPU execution cannot pass artifact validation"
+            )
+
+
+def _existing_batch_runtime_preflight_command(node: ExistingRemoteBatchNode) -> list[str]:
+    """Render a no-inference path and GPU visibility preflight for one existing command."""
+    command = node.command
+    executable = command.command_argv[0]
+    if not PurePosixPath(executable).is_absolute():
+        raise ValueError(f"Existing batch command executable must be absolute: {executable!r}")
+    paths: list[str] = []
+    for token in command.command_argv[1:]:
+        candidate = token.rsplit("=", 1)[-1]
+        if "{" in candidate or not PurePosixPath(candidate).is_absolute():
+            continue
+        paths.append(candidate)
+    checks = [
+        "set -euo pipefail",
+        f"test -x {shlex.quote(executable)}",
+        *(f"test -e {shlex.quote(path)}" for path in dict.fromkeys(paths)),
+    ]
+    if node.manager.scheduler == "direct":
+        gpu_id = (command.env or {}).get("CUDA_VISIBLE_DEVICES", "").split(",", 1)[0]
+        if not gpu_id:
+            raise ValueError(f"Direct existing batch node {node.manager.name!r} has no CUDA_VISIBLE_DEVICES")
+        checks.append(f"nvidia-smi -i {shlex.quote(gpu_id)} --query-gpu=index --format=csv,noheader >/dev/null")
+    else:
+        checks.extend(["command -v sbatch >/dev/null", "command -v sacct >/dev/null"])
+    checks.append("printf 'runtime-ready\\n'")
+    script = "; ".join(checks)
+    return ["ssh", *node.manager.ssh_args, node.manager.host, "bash", "-lc", shlex.quote(script)]
+
+
+def _ensure_existing_batch_manager_state(
+    node: RemoteNode,
+    *,
+    timeout_sec: float | None,
+    runner: Any,
+) -> None:
+    """Create only the manager state directories authorized by the profile."""
+    root = PurePosixPath(node.work_dir)
+    paths = [
+        root,
+        node.queue_root,
+        node.results_root,
+        node.logs_root,
+        *(root / name for name in ("running", "done", "failed", "submitted", "cancelled")),
+    ]
+    remote_command = shlex.join(["mkdir", "-p", *(str(path) for path in paths)])
+    kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+    if timeout_sec is not None:
+        kwargs["timeout"] = timeout_sec
+    runner(["ssh", *node.ssh_args, node.host, remote_command], **kwargs)
+
+
+def _existing_batch_admission_probe_command(node: ExistingRemoteBatchNode) -> list[str]:
+    """Render one direct-GPU or Slurm scheduling admission probe."""
+    if node.manager.scheduler == "slurm":
+        sbatch_args = [arg for arg in node.manager.sbatch_args if arg != "--parsable"]
+        remote_command = shlex.join(["sbatch", "--test-only", *sbatch_args, "--wrap=true"])
+        return ["ssh", *node.manager.ssh_args, node.manager.host, remote_command]
+    gpu_id = (node.command.env or {}).get("CUDA_VISIBLE_DEVICES", "").split(",", 1)[0].strip()
+    if not gpu_id:
+        raise ValueError(f"Direct existing batch node {node.manager.name!r} has no CUDA_VISIBLE_DEVICES")
+    return [
+        "ssh",
+        *node.manager.ssh_args,
+        node.manager.host,
+        "nvidia-smi",
+        "-i",
+        gpu_id,
+        "--query-gpu=utilization.gpu,memory.used",
+        "--format=csv,noheader,nounits",
+    ]
+
+
+def _probe_existing_batch_admission(
+    node: ExistingRemoteBatchNode,
+    *,
+    timeout_sec: float | None,
+    runner: Any,
+) -> dict[str, Any]:
+    """Return whether one node can accept newly planned work now."""
+    kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+    if timeout_sec is not None:
+        kwargs["timeout"] = timeout_sec
+    command = _existing_batch_admission_probe_command(node)
+    completed = runner(command, **kwargs)
+    if node.manager.scheduler == "slurm":
+        stdout = str(getattr(completed, "stdout", "") or "").strip()
+        stderr = str(getattr(completed, "stderr", "") or "").strip()
+        output = "\n".join(part for part in (stdout, stderr) if part)
+        match = re.search(r"\bto start at ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]{8})\b", output)
+        if match is None:
+            raise ValueError(
+                f"Existing batch Slurm admission probe for node {node.manager.name!r} returned "
+                f"unexpected output: stdout={stdout!r}; stderr={stderr!r}"
+            )
+        start_at = match.group(1)
+        start_delay_sec = max(0.0, datetime.fromisoformat(start_at).timestamp() - time.time())
+        return {
+            "kind": "slurm_test_only",
+            "ready": start_delay_sec <= _SLURM_ADMISSION_MAX_START_DELAY_SEC,
+            "start_at": start_at,
+            "start_delay_sec": start_delay_sec,
+            "max_start_delay_sec": _SLURM_ADMISSION_MAX_START_DELAY_SEC,
+        }
+    stdout = str(getattr(completed, "stdout", "") or "").strip()
+    fields = [field.strip() for field in stdout.splitlines()[-1].split(",")] if stdout else []
+    if len(fields) != 2:
+        raise ValueError(
+            f"Existing batch admission probe for node {node.manager.name!r} returned "
+            f"unexpected output: stdout={stdout!r}; stderr={str(getattr(completed, 'stderr', '') or '')!r}"
+        )
+    utilization, memory = (int(field) for field in fields)
+    thresholds = node.command.gpu_admission or {}
+    max_utilization = int(thresholds["max_utilization_percent"])
+    max_memory = int(thresholds["max_memory_used_mib"])
+    return {
+        "kind": "cuda_idle",
+        "ready": utilization <= max_utilization and memory <= max_memory,
+        "gpu_id": (node.command.env or {})["CUDA_VISIBLE_DEVICES"].split(",", 1)[0].strip(),
+        "utilization_percent": utilization,
+        "memory_used_mib": memory,
+        "max_utilization_percent": max_utilization,
+        "max_memory_used_mib": max_memory,
+    }
+
+
+def _select_existing_batch_planning_nodes(
+    nodes: list[ExistingRemoteBatchNode],
+    admission: dict[str, dict[str, Any]],
+) -> list[ExistingRemoteBatchNode]:
+    """Prefer admitted nodes, using direct queues as the holding pool when all are busy."""
+    ready = [node for node in nodes if admission[node.manager.name]["ready"]]
+    direct = [node for node in nodes if node.manager.scheduler == "direct"]
+    return ready or direct or nodes
+
+
+_WITHDRAW_QUEUED_REQUEST_PY = """import json, os, pathlib, sys
+queue_path = pathlib.Path(sys.argv[1])
+cancelled_path = pathlib.Path(sys.argv[2])
+expected = json.load(sys.stdin)
+def same(path):
+    return json.loads(path.read_text()) == expected
+if cancelled_path.exists():
+    if not same(cancelled_path):
+        raise SystemExit(f'cancelled request differs at {cancelled_path}')
+    status = 'already_cancelled'
+elif queue_path.exists():
+    try:
+        if not same(queue_path):
+            raise SystemExit(f'queued request differs at {queue_path}')
+        cancelled_path.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(queue_path, cancelled_path)
+        status = 'withdrawn'
+    except FileNotFoundError:
+        status = 'not_queued'
+else:
+    status = 'not_queued'
+print(json.dumps({'status': status, 'queue_path': str(queue_path), 'cancelled_path': str(cancelled_path)}, sort_keys=True))
+"""
+
+
+def _withdraw_queued_manifest_request(
+    node: RemoteNode,
+    request: RemoteRunRequest,
+    *,
+    cancellation_id: str,
+    timeout_sec: float | None = None,
+    retry_interval: float = 1.0,
+    runner: Any,
+) -> dict[str, Any]:
+    """Atomically preserve and withdraw one exact unclaimed remote request."""
+    _validate_path_segment("cancellation_id", cancellation_id)
+    queue_path = node.queue_root / request.request["run_id"] / f"{request.bucket_id}.json"
+    cancelled_path = (
+        PurePosixPath(node.work_dir)
+        / "cancelled"
+        / request.request["run_id"]
+        / request.bucket_id
+        / f"{cancellation_id}.json"
+    )
+    remote_command = shlex.join(
+        [
+            node.python,
+            "-c",
+            _WITHDRAW_QUEUED_REQUEST_PY,
+            str(queue_path),
+            str(cancelled_path),
+        ]
+    )
+    command = [
+        "ssh",
+        *node.ssh_args,
+        node.host,
+        remote_command,
+    ]
+    deadline = None if timeout_sec is None else time.monotonic() + timeout_sec
+    while True:
+        kwargs: dict[str, Any] = {
+            "input": json.dumps(request.request, sort_keys=True) + "\n",
+            "check": True,
+            "text": True,
+            "capture_output": True,
+        }
+        if deadline is not None:
+            kwargs["timeout"] = max(0.001, deadline - time.monotonic())
+        try:
+            completed = runner(command, **kwargs)
+            break
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode != 255 or deadline is None or time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"Remote queue withdrawal failed for {node.name}/{request.bucket_id}: "
+                    f"stdout={str(exc.stdout or '')!r}; stderr={str(exc.stderr or '')!r}"
+                ) from exc
+            logger.warning(
+                "Retrying SSH queue withdrawal for %s/%s after transport failure: %s",
+                node.name,
+                request.bucket_id,
+                str(exc.stderr or exc),
+            )
+            time.sleep(min(retry_interval, max(0.0, deadline - time.monotonic())))
+    return _parse_remote_manager_json_result(node, "queue withdrawal", completed)
+
+
+def _manifest_replacing_request(
+    manifest: RemoteRunManifest,
+    replacement: RemoteRunRequest,
+    *,
+    batch_nodes: list[ExistingRemoteBatchNode],
+) -> RemoteRunManifest:
+    """Return a manifest with one bucket replacement and only referenced node snapshots."""
+    requests = tuple(
+        replacement if request.bucket_id == replacement.bucket_id else request
+        for request in manifest.requests
+    )
+    referenced = {request.node_name for request in requests}
+    managers = {node.manager.name: node.manager for node in batch_nodes}
+    missing = sorted(referenced - set(managers))
+    if missing:
+        raise ValueError(f"Rebalanced manifest references unavailable profile node(s): {missing}")
+    return RemoteRunManifest(
+        manifest_schema_version=manifest.manifest_schema_version,
+        request_schema_version=manifest.request_schema_version,
+        run_id=manifest.run_id,
+        tool_key=manifest.tool_key,
+        bucket_size=manifest.bucket_size,
+        input_fields=manifest.input_fields,
+        iterable_output_field=manifest.iterable_output_field,
+        local_results_dir=manifest.local_results_dir,
+        nodes=tuple(node.manager for node in batch_nodes if node.manager.name in referenced),
+        requests=requests,
+    )
+
+
+def _validate_existing_batch_resume_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    batch_nodes: list[ExistingRemoteBatchNode],
+    input_fasta: Path | str,
+    software: str,
+) -> None:
+    """Reject changed work while allowing journaled node reassignments."""
+    nodes_by_name = {node.manager.name: node for node in batch_nodes}
+    referenced = {request.node_name for request in manifest.requests}
+    missing = sorted(referenced - set(nodes_by_name))
+    if missing:
+        raise ValueError(f"Existing batch profile is missing manifest node(s): {missing}")
+    manifest_nodes = {node.name: node.to_dict() for node in manifest.nodes}
+    expected_nodes = {
+        name: nodes_by_name[name].manager.to_dict()
+        for name in referenced
+    }
+    if manifest_nodes != expected_nodes:
+        raise ValueError("Existing batch manifest node snapshots differ from the current profile")
+
+    expected_by_node: dict[str, dict[str, RemoteRunRequest]] = {}
+    for name in referenced:
+        expected = plan_existing_remote_command_batch(
+            [nodes_by_name[name]],
+            input_fasta=input_fasta,
+            run_id=manifest.run_id,
+            bucket_size=manifest.bucket_size,
+            local_results_dir=manifest.local_results_dir,
+            software=software,
+        )
+        expected_by_node[name] = {request.bucket_id: request for request in expected.requests}
+    expected_bucket_ids = set(next(iter(expected_by_node.values())))
+    actual_bucket_ids = {request.bucket_id for request in manifest.requests}
+    if len(actual_bucket_ids) != len(manifest.requests) or actual_bucket_ids != expected_bucket_ids:
+        raise ValueError("Existing batch manifest buckets differ from the requested FASTA batch")
+    mismatches = [
+        request.bucket_id
+        for request in manifest.requests
+        if request.to_dict()
+        != expected_by_node[request.node_name][request.bucket_id].to_dict()
+    ]
+    if mismatches:
+        raise ValueError(
+            "Requested existing batch does not match the existing manifest bucket(s): "
+            + ", ".join(sorted(mismatches))
+        )
+
+
+def _rebalance_unclaimed_existing_batch_manifest(
+    manifest: RemoteRunManifest,
+    *,
+    batch_nodes: list[ExistingRemoteBatchNode],
+    input_fasta: Path | str,
+    software: str,
+    admission: dict[str, dict[str, Any]],
+    manifest_path: Path | str,
+    withdraw_timeout_sec: float | None = None,
+    withdrawer: Any = _withdraw_queued_manifest_request,
+    runner: Any = subprocess.run,
+) -> tuple[RemoteRunManifest, list[dict[str, str]]]:
+    """Move missing, unclaimed requests from unavailable nodes to admitted nodes."""
+    _missing_or_raise_for_invalid_manifest_results(manifest)
+    ready_nodes = [node for node in batch_nodes if admission[node.manager.name]["ready"]]
+    incomplete_by_node = {
+        node.manager.name: sum(
+            1
+            for request in manifest.requests
+            if request.node_name == node.manager.name
+            and not manifest.local_result_path(request).exists()
+        )
+        for node in ready_nodes
+    }
+    target_capacity = {
+        node.manager.name: max(
+            0,
+            (
+                1
+                if node.manager.scheduler == "direct"
+                else cast(int, node.manager.max_active_slurm_jobs)
+            )
+            - incomplete_by_node[node.manager.name],
+        )
+        for node in ready_nodes
+    }
+    target_slots = [
+        node
+        for slot_index in range(max(target_capacity.values(), default=0))
+        for node in ready_nodes
+        if target_capacity[node.manager.name] > slot_index
+    ]
+    candidates = [
+        request
+        for request in manifest.requests
+        if not manifest.local_result_path(request).exists()
+        and not admission[request.node_name]["ready"]
+    ][: len(target_slots)]
+    if not candidates or not target_slots:
+        return manifest, []
+
+    target_by_bucket = {
+        request.bucket_id: target_slots[index].manager.name
+        for index, request in enumerate(candidates)
+    }
+    selected_target_names = set(target_by_bucket.values())
+    target_manifests = {
+        node.manager.name: plan_existing_remote_command_batch(
+            [node],
+            input_fasta=input_fasta,
+            run_id=manifest.run_id,
+            bucket_size=manifest.bucket_size,
+            local_results_dir=manifest.local_results_dir,
+            software=software,
+        )
+        for node in ready_nodes
+        if node.manager.name in selected_target_names
+    }
+    target_requests = {
+        node_name: {request.bucket_id: request for request in target.requests}
+        for node_name, target in target_manifests.items()
+    }
+    nodes_by_name = {node.manager.name: node.manager for node in batch_nodes}
+    journal_root = Path(manifest_path).parent / "rebalances"
+    moves: list[dict[str, str]] = []
+    updated = manifest
+    for candidate in candidates:
+        target_name = target_by_bucket[candidate.bucket_id]
+        replacement = target_requests[target_name][candidate.bucket_id]
+        journal_identity = {
+            "bucket_id": candidate.bucket_id,
+            "from_node": candidate.node_name,
+            "to_node": target_name,
+            "old_request": candidate.to_dict(),
+            "new_request": replacement.to_dict(),
+        }
+        prior_indices: list[int] = []
+        incomplete: list[tuple[Path, dict[str, Any]]] = []
+        for path in sorted(journal_root.glob(f"{candidate.bucket_id}.move-*.json")):
+            match = re.search(r"\.move-([0-9]+)\.", path.name)
+            if match is not None:
+                prior_indices.append(int(match.group(1)))
+            payload = cast(dict[str, Any], json.loads(path.read_text()))
+            if payload.get("status") not in {"planned", "not_moved"}:
+                continue
+            if all(payload.get(key) == value for key, value in journal_identity.items()):
+                incomplete.append((path, payload))
+        if len(incomplete) > 1:
+            raise RuntimeError(
+                f"Multiple incomplete rebalance journals for {candidate.bucket_id}: "
+                + ", ".join(str(path) for path, _ in incomplete)
+            )
+        if incomplete:
+            journal_path, journal = incomplete[0]
+            cancellation_id = str(journal["cancellation_id"])
+            journal["status"] = "planned"
+            journal.pop("withdrawal", None)
+            _write_json_atomic(journal_path, journal, overwrite=True)
+        else:
+            move_index = max(prior_indices, default=0) + 1
+            cancellation_id = (
+                f"move-{move_index:05d}-{candidate.node_name}-to-{target_name}"
+            )
+            journal_path = journal_root / (
+                f"{candidate.bucket_id}.move-{move_index:05d}."
+                f"{candidate.node_name}-to-{target_name}.json"
+            )
+            journal = {
+                "schema_version": 1,
+                "status": "planned",
+                "cancellation_id": cancellation_id,
+                **journal_identity,
+            }
+            _write_json_atomic(journal_path, journal)
+
+        withdrawal = withdrawer(
+            nodes_by_name[candidate.node_name],
+            candidate,
+            cancellation_id=cancellation_id,
+            timeout_sec=withdraw_timeout_sec,
+            runner=runner,
+        )
+        if withdrawal.get("status") not in {"withdrawn", "already_cancelled"}:
+            journal["status"] = "not_moved"
+            journal["withdrawal"] = withdrawal
+            _write_json_atomic(journal_path, journal, overwrite=True)
+            continue
+        updated = _manifest_replacing_request(updated, replacement, batch_nodes=batch_nodes)
+        write_remote_run_manifest(updated, manifest_path, overwrite=True)
+        journal["status"] = "completed"
+        journal["withdrawal"] = withdrawal
+        _write_json_atomic(journal_path, journal, overwrite=True)
+        moves.append(
+            {
+                "bucket_id": candidate.bucket_id,
+                "from_node": candidate.node_name,
+                "to_node": target_name,
+            }
+        )
+    return updated, moves
+
+
+def launch_existing_remote_command_batch(
+    nodes: list[ExistingRemoteBatchNode],
+    *,
+    input_fasta: Path | str,
+    software: str,
+    run_dir: Path | str,
+    bucket_size: int = 1,
+    slurm_group_size: int = 10,
+    wait_poll_interval: float = 5.0,
+    timeout_sec: float | None = None,
+    remote_check_timeout_sec: float | None = None,
+    manager_client: "RemoteManagerClient | None" = None,
+    runner: Any = subprocess.run,
+) -> ExistingRemoteBatchLaunchResult:
+    """Plan, launch, wait for, mirror, and validate an existing-command FASTA batch."""
+    run_root = Path(run_dir).resolve()
+    run_id = _validate_path_segment("run_dir name", run_root.name)
+    manifest_path = run_root / "run.manifest.json"
+    local_results = run_root / "remote_results"
+    local_artifacts = run_root / "artifacts"
+    summary_path = run_root / "summary.json"
+    _validate_existing_batch_gpu_contract(nodes, software)
+    resume_existing = manifest_path.is_file()
+    if run_root.exists() and not resume_existing:
+        existing_files = [path for path in run_root.rglob("*") if path.is_file() or path.is_symlink()]
+        if existing_files:
+            raise FileExistsError(
+                f"Existing batch run directory has no resumable manifest and is not empty: {run_root}"
+            )
+    manifest: RemoteRunManifest | None = None
+    if resume_existing:
+        manifest = load_remote_run_manifest(manifest_path)
+        _validate_existing_batch_resume_manifest(
+            manifest,
+            batch_nodes=nodes,
+            input_fasta=input_fasta,
+            software=software,
+        )
+
+    runtime_preflight: dict[str, Any] = {}
+    admission: dict[str, dict[str, Any]] = {}
+    for batch_node in nodes:
+        kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+        if remote_check_timeout_sec is not None:
+            kwargs["timeout"] = remote_check_timeout_sec
+        completed = runner(_existing_batch_runtime_preflight_command(batch_node), **kwargs)
+        runtime_preflight[batch_node.manager.name] = {
+            "ok": True,
+            "stdout": str(getattr(completed, "stdout", "") or ""),
+            "stderr": str(getattr(completed, "stderr", "") or ""),
+        }
+        admission[batch_node.manager.name] = _probe_existing_batch_admission(
+            batch_node,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+    initial_admission = {name: dict(value) for name, value in admission.items()}
+
+    rebalances: list[dict[str, str]] = []
+    if resume_existing:
+        manifest = cast(RemoteRunManifest, manifest)
+        manifest, rebalances = _rebalance_unclaimed_existing_batch_manifest(
+            manifest,
+            batch_nodes=nodes,
+            input_fasta=input_fasta,
+            software=software,
+            admission=admission,
+            manifest_path=manifest_path,
+            withdraw_timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+    else:
+        planning_nodes = _select_existing_batch_planning_nodes(nodes, admission)
+        manifest = plan_existing_remote_command_batch(
+            planning_nodes,
+            input_fasta=input_fasta,
+            run_id=run_id,
+            bucket_size=bucket_size,
+            local_results_dir=local_results,
+            software=software,
+        )
+    if not resume_existing:
+        write_remote_run_manifest(manifest, manifest_path)
+
+    manager = manager_client or RemoteManagerClient()
+    manager_preflight: dict[str, dict[str, Any]] = {}
+    managers: dict[str, str] = {}
+    local_results.mkdir(parents=True, exist_ok=True)
+
+    def activate_manifest_nodes(active_manifest: RemoteRunManifest) -> None:
+        for manager_node in active_manifest.nodes:
+            if manager_node.name not in manager_preflight:
+                _ensure_existing_batch_manager_state(
+                    manager_node,
+                    timeout_sec=remote_check_timeout_sec,
+                    runner=runner,
+                )
+                result = _manager_preflight_node(
+                    manager,
+                    manager_node,
+                    timeout_sec=remote_check_timeout_sec,
+                    runner=runner,
+                )
+                _raise_for_preflight_failures({manager_node.name: result})
+                manager_preflight[manager_node.name] = result
+            if manager_node.name not in managers:
+                managers[manager_node.name] = _manager_start_node(
+                    manager,
+                    manager_node,
+                    poll_interval=5.0,
+                    slurm_group_size=slurm_group_size,
+                    timeout_sec=remote_check_timeout_sec,
+                    runner=runner,
+                )
+            (local_results / manager_node.name).mkdir(exist_ok=True)
+
+    activate_manifest_nodes(manifest)
+    submit_remote_run_manifest(manifest, runner=runner)
+
+    last_rebalance_probe = float("-inf")
+
+    def rebalance_poll_hook(current: RemoteRunManifest) -> RemoteRunManifest:
+        nonlocal last_rebalance_probe
+        now = time.monotonic()
+        if now - last_rebalance_probe < 30.0:
+            return current
+        last_rebalance_probe = now
+        for batch_node in nodes:
+            admission[batch_node.manager.name] = _probe_existing_batch_admission(
+                batch_node,
+                timeout_sec=remote_check_timeout_sec,
+                runner=runner,
+            )
+        updated, moves = _rebalance_unclaimed_existing_batch_manifest(
+            current,
+            batch_nodes=nodes,
+            input_fasta=input_fasta,
+            software=software,
+            admission=admission,
+            manifest_path=manifest_path,
+            withdraw_timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+        if not moves:
+            return current
+        rebalances.extend(moves)
+        activate_manifest_nodes(updated)
+        submit_remote_run_manifest(
+            updated,
+            bucket_ids={move["bucket_id"] for move in moves},
+            runner=runner,
+        )
+        return updated
+
+    manifest = wait_remote_run_manifest(
+        manifest,
+        poll_interval=wait_poll_interval,
+        timeout_sec=timeout_sec,
+        pull_results=True,
+        poll_hook=rebalance_poll_hook,
+        runner=runner,
+    )
+    manager_nodes = list(manifest.nodes)
+    local_artifacts.mkdir(parents=True, exist_ok=True)
+    for manager_node in manager_nodes:
+        (local_artifacts / manager_node.name).mkdir(exist_ok=True)
+    for command in render_existing_artifact_pull_commands(manifest, local_artifacts):
+        runner(command, check=True)
+    summary = collect_existing_remote_command_manifest(manifest, local_artifacts)
+    _write_json_atomic(summary_path, summary)
+    assignment = {
+        manager_node.name: sum(request.node_name == manager_node.name for request in manifest.requests)
+        for manager_node in manager_nodes
+    }
+    return ExistingRemoteBatchLaunchResult(
+        run_id=run_id,
+        task_count=int(summary["task_count"]),
+        assignment=assignment,
+        manifest=str(manifest_path),
+        local_results_dir=str(local_results),
+        local_artifacts_dir=str(local_artifacts),
+        summary=str(summary_path),
+        preflight={
+            name: {
+                "runtime": runtime_preflight[name],
+                "admission": initial_admission[name],
+                "manager": manager_preflight.get(name),
+            }
+            for name in runtime_preflight
+        },
+        managers=managers,
+        admission=admission,
+        rebalances=tuple(rebalances),
+    )
+
+
+def launch_remote_run(
+    tool_key: str,
+    nodes: list[RemoteNode],
+    inputs: BaseToolInput | dict[str, Any],
+    config: BaseConfig | dict[str, Any] | None,
+    *,
+    bucket_size: int,
+    local_results_dir: Path | str,
+    manifest_path: Path | str,
+    output_path: Path | str,
+    run_id: str | None = None,
+    overwrite: bool = False,
+    manager_poll_interval: float = 5.0,
+    slurm_group_size: int = 10,
+    wait_poll_interval: float = 5.0,
+    timeout_sec: float | None = None,
+    rsync_mode: RemoteRsyncMode = "inline",
+    rsync_pid_path: Path | str | None = None,
+    rsync_log_path: Path | str | None = None,
+    rsync_interval_sec: int = 10,
+    use_diagnostics_backlog: bool = False,
+    overwrite_output: bool = False,
+    remote_check_timeout_sec: float | None = None,
+    manager_client: "RemoteManagerClient | None" = None,
+    rsync_client: "LocalRsyncPullClient | None" = None,
+    runner: Any = subprocess.run,
+) -> RemoteLaunchResult:
+    """Preflight managers, submit a manifest run, wait, and collect output."""
+    ensure_remote_run_output_path_available(output_path, overwrite=overwrite_output)
+    _validate_remote_run_rsync_mode(
+        rsync_mode,
+        rsync_pid_path=rsync_pid_path,
+        rsync_log_path=rsync_log_path,
+    )
+
+    _raise_for_remote_profile_errors(nodes)
+    manager = manager_client or RemoteManagerClient()
+    preflight = {
+        node.name: _manager_preflight_node(
+            manager,
+            node,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+        for node in nodes
+    }
+    _raise_for_preflight_failures(preflight)
+    managers = {
+        node.name: _manager_start_node(
+            manager,
+            node,
+            poll_interval=manager_poll_interval,
+            slurm_group_size=slurm_group_size,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+        for node in nodes
+    }
+    diagnostics: dict[str, Any] | None = None
+    initial_node_loads: dict[str, float] | None = None
+    if use_diagnostics_backlog:
+        diagnostics, initial_node_loads = remote_run_diagnostics_backlog_loads(
+            nodes,
+            manager_client=manager,
+            timeout_sec=remote_check_timeout_sec,
+            runner=runner,
+        )
+
+    local_results = Path(local_results_dir).resolve()
+    plan = RemoteDispatchPlanner(nodes, bucket_size, initial_node_loads=initial_node_loads).build_plan(
+        tool_key,
+        inputs,
+        config,
+        run_id=run_id,
+    )
+    manifest = RemoteRunManifest.from_plan(
+        plan,
+        nodes=nodes,
+        bucket_size=bucket_size,
+        local_results_dir=local_results,
+    )
+    write_remote_run_manifest(manifest, manifest_path, overwrite=overwrite)
+
+    return _submit_wait_collect_remote_run_manifest(
+        manifest,
+        manifest_path=manifest_path,
+        output_path=output_path,
+        preflight=preflight,
+        managers=managers,
+        diagnostics=diagnostics,
+        initial_node_loads=initial_node_loads,
+        wait_poll_interval=wait_poll_interval,
+        timeout_sec=timeout_sec,
+        rsync_mode=rsync_mode,
+        rsync_pid_path=rsync_pid_path,
+        rsync_log_path=rsync_log_path,
+        rsync_interval_sec=rsync_interval_sec,
+        rsync_client=rsync_client,
+        overwrite_output=overwrite_output,
+        runner=runner,
+    )
+
+
+class RemoteToolDispatcher:
+    """ToolRegistry dispatch backend for explicit ``device="remote"`` calls."""
+
+    def __init__(
+        self,
+        nodes: list[RemoteNode],
+        *,
+        bucket_size: int,
+        local_results_dir: Path | str,
+        submission_client: RemoteSubmissionClient | None = None,
+        poll_interval: float = 5.0,
+        timeout_sec: float | None = None,
+        pull_results: bool = True,
+        runner: Any = subprocess.run,
+    ):
+        """Initialize a synchronous remote dispatcher."""
+        if poll_interval <= 0:
+            raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
+        if timeout_sec is not None and timeout_sec <= 0:
+            raise ValueError(f"timeout_sec must be > 0, got {timeout_sec}")
+        self.nodes = list(nodes)
+        self.planner = RemoteDispatchPlanner(self.nodes, bucket_size)
+        self.local_results_dir = Path(local_results_dir)
+        self.submission_client = submission_client or RemoteSubmissionClient()
+        self.poll_interval = poll_interval
+        self.timeout_sec = timeout_sec
+        self.pull_results = pull_results
+        self.runner = runner
+        self.last_plan: RemoteDispatchPlan | None = None
+        self._previous_backend: Any = None
+
+    def __enter__(self) -> "RemoteToolDispatcher":
+        """Install this object as the active ToolRegistry dispatch backend."""
+        self._previous_backend = ToolRegistry._dispatch_backend
+        ToolRegistry.configure_dispatch_backend(self)
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
+        """Restore the previous ToolRegistry dispatch backend."""
+        ToolRegistry.configure_dispatch_backend(self._previous_backend)
+        self._previous_backend = None
+        return False
+
+    def __call__(self, tool_key: str, inputs: BaseToolInput, config: BaseConfig) -> BaseToolOutput | None:
+        """Route only explicit ``device="remote"`` tool calls."""
+        if getattr(config, "device", None) != "remote":
+            return None
+        plan = self.planner.build_plan(tool_key, inputs, config)
+        self.last_plan = plan
+        self.submission_client.submit_plan(plan, runner=self.runner)
+        self.wait_for_plan(plan)
+        return collect_plan_outputs(plan, self.local_results_dir)
+
+    def wait_for_plan(self, plan: RemoteDispatchPlan) -> None:
+        """Wait until every bucket result for ``plan`` exists locally."""
+        deadline = None if self.timeout_sec is None else time.monotonic() + self.timeout_sec
+        while True:
+            self._raise_for_failed_results(plan)
+            missing = [path for path in self._local_result_paths(plan) if not path.exists()]
+            if not missing:
+                return
+            if self.pull_results:
+                self.pull_once()
+                self._raise_for_failed_results(plan)
+                missing = [path for path in self._local_result_paths(plan) if not path.exists()]
+                if not missing:
+                    return
+            if deadline is not None and time.monotonic() >= deadline:
+                preview = ", ".join(str(path) for path in missing[:3])
+                raise TimeoutError(
+                    f"Remote dispatch {plan.run_id} timed out waiting for {len(missing)} result(s): {preview}"
+                )
+            time.sleep(self.poll_interval)
+
+    def pull_once(self) -> None:
+        """Run one rsync pull round for every configured node."""
+        for cmd in render_rsync_pull_commands(self.nodes, self.local_results_dir):
+            self.runner(cmd, check=True)
+
+    def _local_result_paths(self, plan: RemoteDispatchPlan) -> list[Path]:
+        """Return local result paths expected after rsync mirroring."""
+        return [path for _, _, path in self._local_result_entries(plan)]
+
+    def _local_result_entries(self, plan: RemoteDispatchPlan) -> list[tuple[RemoteNode, RemoteBucket, Path]]:
+        """Return expected local result entries with node and bucket metadata."""
+        return [
+            (
+                assignment.node,
+                assignment.bucket,
+                self.local_results_dir / assignment.node.name / plan.run_id / f"{assignment.bucket.bucket_id}.json",
+            )
+            for assignment in plan.assignments
+        ]
+
+    def _raise_for_failed_results(self, plan: RemoteDispatchPlan) -> None:
+        """Raise as soon as any mirrored result envelope reports failure."""
+        failures: list[str] = []
+        for node, bucket, path in self._local_result_entries(plan):
+            if not path.exists():
+                continue
+            try:
+                envelope = json.loads(path.read_text())
+            except json.JSONDecodeError as exc:
+                failures.append(f"{node.name}/{bucket.bucket_id}: unreadable {path}: {exc}")
+                continue
+            if envelope.get("status") == "failed":
+                failures.append(
+                    f"{node.name}/{bucket.bucket_id}: {envelope.get('error', '<no error>')} (result_path={path})"
+                )
+        if failures:
+            raise RuntimeError(f"Remote dispatch {plan.run_id} failed: {'; '.join(failures)}")
+
+
+def _parse_remote_manager_json_result(
+    node: RemoteNode,
+    operation: str,
+    result: Any,
+) -> dict[str, Any]:
+    """Parse a final one-line manager JSON payload and surface preceding stdout noise."""
+    stdout = str(getattr(result, "stdout", "") or "{}").strip()
+    stderr = str(getattr(result, "stderr", "") or "")
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        lines = stdout.splitlines()
+        try:
+            payload = json.loads(lines[-1])
+        except (IndexError, json.JSONDecodeError) as final_exc:
+            raise ValueError(
+                f"Remote manager {operation} for node {node.name!r} returned invalid JSON: "
+                f"stdout={stdout!r}; stderr={stderr!r}"
+            ) from final_exc
+        prefix = "\n".join(lines[:-1]).strip()
+        if prefix:
+            logger.warning(
+                "Remote manager %s for node %r wrote non-JSON stdout before its payload: %s",
+                operation,
+                node.name,
+                prefix,
+            )
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Remote manager {operation} for node {node.name!r} returned JSON "
+            f"{type(payload).__name__}, expected object: stdout={stdout!r}; stderr={stderr!r}"
+        )
+    return cast(dict[str, Any], payload)
+
+
+class RemoteManagerClient:
+    """Start and inspect node-side managers over SSH."""
+
+    def start_node(
+        self,
+        node: RemoteNode,
+        *,
+        poll_interval: float = 5.0,
+        slurm_group_size: int = 10,
+        timeout_sec: float | None = None,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Start one node manager in the background and return remote stdout."""
+        script = render_start_manager_script(
+            node,
+            poll_interval=poll_interval,
+            slurm_group_size=slurm_group_size,
+        )
+        kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+        if timeout_sec is not None:
+            kwargs["timeout"] = timeout_sec
+        result = runner(_remote_bash_command(node, script), **kwargs)
+        return str(getattr(result, "stdout", "")).strip()
+
+    def status_node(
+        self,
+        node: RemoteNode,
+        *,
+        timeout_sec: float | None = None,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Return one node manager status string."""
+        kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+        if timeout_sec is not None:
+            kwargs["timeout"] = timeout_sec
+        result = runner(
+            _remote_bash_command(node, render_manager_status_script(node)),
+            **kwargs,
+        )
+        return str(getattr(result, "stdout", "")).strip()
+
+    def preflight_node(
+        self,
+        node: RemoteNode,
+        *,
+        timeout_sec: float | None = None,
+        runner: Any = subprocess.run,
+    ) -> dict[str, Any]:
+        """Run preflight checks on one node and return parsed JSON."""
+        kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+        if timeout_sec is not None:
+            kwargs["timeout"] = timeout_sec
+        result = runner(
+            _remote_bash_command(node, render_preflight_script(node)),
+            **kwargs,
+        )
+        return _parse_remote_manager_json_result(node, "preflight", result)
+
+    def diagnostics_node(
+        self,
+        node: RemoteNode,
+        *,
+        timeout_sec: float | None = None,
+        runner: Any = subprocess.run,
+    ) -> dict[str, Any]:
+        """Return queue/result/log diagnostics for one node."""
+        kwargs: dict[str, Any] = {"check": True, "text": True, "capture_output": True}
+        if timeout_sec is not None:
+            kwargs["timeout"] = timeout_sec
+        result = runner(
+            _remote_bash_command(node, render_manager_diagnostics_script(node)),
+            **kwargs,
+        )
+        return _parse_remote_manager_json_result(node, "diagnostics", result)
+
+
+class RemoteDeploymentClient:
+    """Run explicit remote deployment commands over SSH/rsync."""
+
+    def deploy_node(
+        self,
+        node: RemoteNode,
+        local_repo_dir: Path | str,
+        *,
+        runner: Any = subprocess.run,
+    ) -> list[Any]:
+        """Execute rendered deployment commands for one node."""
+        return [
+            runner(cmd, check=True, text=True, capture_output=True)
+            for cmd in render_deploy_commands(node, local_repo_dir)
+        ]
+
+
+def render_rsync_pull_commands(nodes: list[RemoteNode], local_results_dir: Path | str) -> list[list[str]]:
+    """Render one rsync pull command per node result root."""
+    local_root = Path(local_results_dir)
+    commands: list[list[str]] = []
+    for node in nodes:
+        _validate_path_segment("RemoteNode.name", node.name)
+        cmd = [
+            "rsync",
+            "-az",
+            "--partial",
+        ]
+        if node.sync_ssh_args:
+            cmd.extend(["-e", shlex.join(["ssh", *node.sync_ssh_args])])
+        cmd.extend(
+            [
+                f"{node.sync_host}:{node.results_root}/",
+                str(local_root / node.name) + "/",
+            ]
+        )
+        commands.append(cmd)
+    return commands
+
+
+def _remote_error_text(value: Any) -> str:
+    """Render subprocess output values as JSON-safe text."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _remote_check_error(exc: subprocess.CalledProcessError | subprocess.TimeoutExpired) -> dict[str, Any]:
+    """Serialize a failed remote smoke check without hiding the command failure."""
+    if isinstance(exc, subprocess.CalledProcessError):
+        return {
+            "type": type(exc).__name__,
+            "returncode": exc.returncode,
+            "cmd": exc.cmd,
+            "stdout": _remote_error_text(getattr(exc, "stdout", None)),
+            "stderr": _remote_error_text(exc.stderr),
+        }
+    return {
+        "type": type(exc).__name__,
+        "cmd": exc.cmd,
+        "timeout": exc.timeout,
+        "stdout": _remote_error_text(exc.stdout),
+        "stderr": _remote_error_text(exc.stderr),
+    }
+
+
+def _failed_remote_check_payload(
+    node: RemoteNode,
+    stage: str,
+    exc: subprocess.CalledProcessError | subprocess.TimeoutExpired,
+) -> dict[str, Any]:
+    """Build a visible failed-check payload for a node smoke stage."""
+    error = _remote_check_error(exc)
+    detail = error.get("stderr") or error.get("stdout") or error.get("type")
+    return {
+        "node": node.name,
+        "ok": False,
+        "checks": [{"name": stage, "ok": False, "detail": detail}],
+        "error": error,
+    }
+
+
+def _remote_status_failure(exc: subprocess.CalledProcessError | subprocess.TimeoutExpired) -> str:
+    """Build a compact visible status string for failed manager status checks."""
+    error = _remote_check_error(exc)
+    detail = error.get("stderr") or error.get("stdout") or error.get("type")
+    return f"check-failed: {detail}"
+
+
+def smoke_remote_nodes(
+    nodes: list[RemoteNode],
+    *,
+    local_results_dir: Path | str,
+    timeout_sec: float | None = None,
+    manager_client: RemoteManagerClient | None = None,
+    runner: Any = subprocess.run,
+) -> RemoteSmokeReport:
+    """Run no-submit static and remote preflight checks for remote nodes."""
+    profile_issues = tuple(validate_remote_nodes(nodes))
+    profile_errors = [issue for issue in profile_issues if issue.level == "error"]
+    if profile_errors:
+        return RemoteSmokeReport(
+            ok=False,
+            profile_issues=profile_issues,
+            preflight={},
+            manager_status={},
+            diagnostics={},
+            rsync_pull_commands=(),
+        )
+
+    manager = manager_client or RemoteManagerClient()
+
+    def run_preflight(node: RemoteNode) -> tuple[dict[str, Any], bool]:
+        try:
+            return manager.preflight_node(node, timeout_sec=timeout_sec, runner=runner), False
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            return _failed_remote_check_payload(node, "preflight", exc), True
+
+    def run_status(node: RemoteNode) -> tuple[str, bool]:
+        try:
+            return manager.status_node(node, timeout_sec=timeout_sec, runner=runner), False
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            return _remote_status_failure(exc), True
+
+    def run_diagnostics(node: RemoteNode) -> tuple[dict[str, Any], bool]:
+        try:
+            return manager.diagnostics_node(node, timeout_sec=timeout_sec, runner=runner), False
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            return _failed_remote_check_payload(node, "diagnostics", exc), True
+
+    preflight_results = {node.name: run_preflight(node) for node in nodes}
+    status_results = {node.name: run_status(node) for node in nodes}
+    diagnostics_results = {node.name: run_diagnostics(node) for node in nodes}
+    preflight = {name: result for name, (result, _) in preflight_results.items()}
+    manager_status = {name: result for name, (result, _) in status_results.items()}
+    diagnostics = {name: result for name, (result, _) in diagnostics_results.items()}
+    remote_check_failed = any(failed for _, failed in preflight_results.values())
+    remote_check_failed = remote_check_failed or any(failed for _, failed in status_results.values())
+    remote_check_failed = remote_check_failed or any(failed for _, failed in diagnostics_results.values())
+    rsync_commands = tuple(tuple(cmd) for cmd in render_rsync_pull_commands(nodes, local_results_dir))
+    ok = all(payload.get("ok") for payload in preflight.values()) and not remote_check_failed
+    return RemoteSmokeReport(
+        ok=ok,
+        profile_issues=profile_issues,
+        preflight=preflight,
+        manager_status=manager_status,
+        diagnostics=diagnostics,
+        rsync_pull_commands=rsync_commands,
+    )
+
+
+def _shell_command_line(cmd: list[str]) -> str:
+    """Render a shell-safe command line."""
+    return " ".join(shlex.quote(part) for part in cmd)
+
+
+def render_continuous_rsync_script(
+    nodes: list[RemoteNode],
+    local_results_dir: Path | str,
+    *,
+    interval_sec: int = 10,
+) -> str:
+    """Render a loop that continuously pulls result roots in parallel."""
+    if not nodes:
+        raise ValueError("render_continuous_rsync_script requires at least one node")
+    if interval_sec < 1:
+        raise ValueError(f"interval_sec must be >= 1, got {interval_sec}")
+    lines = ["while true; do", "  pids=()"]
+    for cmd in render_rsync_pull_commands(nodes, local_results_dir):
+        lines.append(f"  {_shell_command_line(cmd)} &")
+        lines.append('  pids+=("$!")')
+    lines.extend(
+        [
+            "  status=0",
+            '  for pid in "${pids[@]}"; do',
+            '    wait "$pid" || status=$?',
+            "  done",
+            '  if [ "$status" -ne 0 ]; then',
+            '    exit "$status"',
+            "  fi",
+            f"  sleep {interval_sec}",
+            "done",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_start_rsync_pull_script(
+    nodes: list[RemoteNode],
+    local_results_dir: Path | str,
+    *,
+    pid_path: Path | str,
+    log_path: Path | str,
+    interval_sec: int = 10,
+) -> str:
+    """Render a local shell script that starts the background rsync pull loop."""
+    loop_script = render_continuous_rsync_script(nodes, local_results_dir, interval_sec=interval_sec)
+    pid = shlex.quote(str(pid_path))
+    log = shlex.quote(str(log_path))
+    pid_parent = shlex.quote(str(Path(pid_path).parent))
+    log_parent = shlex.quote(str(Path(log_path).parent))
+    local_root = shlex.quote(str(local_results_dir))
+    return (
+        "set -euo pipefail; "
+        f"mkdir -p {pid_parent} {log_parent} {local_root}; "
+        f'if [ -s {pid} ] && kill -0 "$(cat {pid})" 2>/dev/null; then '
+        f'echo running "$(cat {pid})"; '
+        "else "
+        f"nohup bash -lc {shlex.quote(loop_script)} >> {log} 2>&1 < /dev/null & "
+        f"echo $! > {pid}; "
+        "sleep 0.2; "
+        f'if kill -0 "$(cat {pid})" 2>/dev/null; then '
+        f'echo started "$(cat {pid})"; '
+        "else "
+        "echo failed; "
+        f"if [ -f {log} ]; then tail -n 40 {log}; fi; "
+        "exit 1; "
+        "fi; "
+        "fi"
+    )
+
+
+def render_rsync_pull_status_script(pid_path: Path | str) -> str:
+    """Render a local shell script that reports the rsync pull loop state."""
+    pid = shlex.quote(str(pid_path))
+    return (
+        "set -euo pipefail; "
+        f'if [ -s {pid} ] && kill -0 "$(cat {pid})" 2>/dev/null; then '
+        f'echo running "$(cat {pid})"; '
+        f"elif [ -s {pid} ]; then "
+        f'echo stale "$(cat {pid})"; '
+        "else "
+        "echo stopped; "
+        "fi"
+    )
+
+
+def render_stop_rsync_pull_script(pid_path: Path | str) -> str:
+    """Render a local shell script that stops the rsync pull loop."""
+    pid = shlex.quote(str(pid_path))
+    return (
+        "set -euo pipefail; "
+        f'if [ -s {pid} ] && kill -0 "$(cat {pid})" 2>/dev/null; then '
+        f'kill "$(cat {pid})"; '
+        f"rm -f {pid}; "
+        "echo stopped; "
+        f"elif [ -s {pid} ]; then "
+        f"rm -f {pid}; "
+        "echo stale-removed; "
+        "else "
+        "echo stopped; "
+        "fi"
+    )
+
+
+class LocalRsyncPullClient:
+    """Manage the local background rsync pull loop."""
+
+    def start(
+        self,
+        nodes: list[RemoteNode],
+        local_results_dir: Path | str,
+        *,
+        pid_path: Path | str,
+        log_path: Path | str,
+        interval_sec: int = 10,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Start the pull loop locally and return its stdout."""
+        result = runner(
+            [
+                "bash",
+                "-lc",
+                render_start_rsync_pull_script(
+                    nodes,
+                    local_results_dir,
+                    pid_path=pid_path,
+                    log_path=log_path,
+                    interval_sec=interval_sec,
+                ),
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return str(getattr(result, "stdout", "")).strip()
+
+    def status(
+        self,
+        pid_path: Path | str,
+        *,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Return local pull loop status."""
+        result = runner(
+            ["bash", "-lc", render_rsync_pull_status_script(pid_path)],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return str(getattr(result, "stdout", "")).strip()
+
+    def stop(
+        self,
+        pid_path: Path | str,
+        *,
+        runner: Any = subprocess.run,
+    ) -> str:
+        """Stop the local pull loop and return its stdout."""
+        result = runner(
+            ["bash", "-lc", render_stop_rsync_pull_script(pid_path)],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return str(getattr(result, "stdout", "")).strip()
+
+
+def render_manager_loop_command(
+    node: RemoteNode,
+    *,
+    poll_interval: float = 5.0,
+    once: bool = False,
+    slurm_group_size: int = 10,
+) -> list[str]:
+    """Render the manager-loop command for a remote node."""
+    if poll_interval <= 0:
+        raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
+    if slurm_group_size < 1:
+        raise ValueError(f"slurm_group_size must be >= 1, got {slurm_group_size}")
+    if node.scheduler == "slurm" and node.max_active_slurm_jobs is None:
+        raise ValueError(f"RemoteNode {node.name!r}: Slurm manager requires max_active_slurm_jobs")
+    cmd = [
+        node.python,
+        "-m",
+        "proto_tools.utils.remote_execution",
+        "manager-loop",
+        "--queue-dir",
+        str(node.queue_root),
+        "--results-dir",
+        str(node.results_root),
+        "--scheduler",
+        node.scheduler,
+        "--poll-interval",
+        str(poll_interval),
+        "--python",
+        node.python,
+        "--slurm-group-size",
+        str(slurm_group_size),
+    ]
+    if node.max_active_slurm_jobs is not None:
+        cmd.extend(["--max-active-slurm-jobs", str(node.max_active_slurm_jobs)])
+    cmd.extend(f"--sbatch-arg={arg}" for arg in node.sbatch_args)
+    if once:
+        cmd.append("--once")
+    return cmd
+
+
+def render_start_manager_script(
+    node: RemoteNode,
+    *,
+    poll_interval: float = 5.0,
+    slurm_group_size: int = 10,
+) -> str:
+    """Render a remote shell script that starts a manager if it is not already running."""
+    manager_cmd = _remote_env_prefix(node) + shlex.join(
+        render_manager_loop_command(
+            node,
+            poll_interval=poll_interval,
+            slurm_group_size=slurm_group_size,
+        )
+    )
+    pid_path = shlex.quote(str(node.manager_pid_path))
+    log_path = shlex.quote(str(node.manager_log_path))
+    return (
+        "set -euo pipefail; "
+        f"mkdir -p {shlex.quote(str(node.queue_root))} "
+        f"{shlex.quote(str(node.results_root))} "
+        f"{shlex.quote(str(node.logs_root))}; "
+        f'if [ -s {pid_path} ] && kill -0 "$(cat {pid_path})" 2>/dev/null; then '
+        f'echo running "$(cat {pid_path})"; '
+        "else "
+        f"nohup bash -lc {shlex.quote(manager_cmd)} >> {log_path} 2>&1 < /dev/null & "
+        f"echo $! > {pid_path}; "
+        "sleep 0.2; "
+        f'if kill -0 "$(cat {pid_path})" 2>/dev/null; then '
+        f'echo started "$(cat {pid_path})"; '
+        "else "
+        "echo failed; "
+        f"tail -n 40 {log_path} 2>/dev/null || true; "
+        "exit 1; "
+        "fi; "
+        "fi"
+    )
+
+
+def render_manager_status_script(node: RemoteNode) -> str:
+    """Render a remote shell script that reports manager pid state."""
+    pid_path = shlex.quote(str(node.manager_pid_path))
+    return (
+        "set -euo pipefail; "
+        f'if [ -s {pid_path} ] && kill -0 "$(cat {pid_path})" 2>/dev/null; then '
+        f'echo running "$(cat {pid_path})"; '
+        f"elif [ -s {pid_path} ]; then "
+        f'echo stale "$(cat {pid_path})"; '
+        "else "
+        "echo stopped; "
+        "fi"
+    )
+
+
+def render_preflight_script(node: RemoteNode) -> str:
+    """Render a JSON-emitting remote preflight script."""
+    repo_dir = json.dumps(node.repo_dir)
+    work_dir = json.dumps(node.work_dir)
+    queue_dir = json.dumps(str(node.queue_root))
+    results_dir = json.dumps(str(node.results_root))
+    logs_dir = json.dumps(str(node.logs_root))
+    scheduler = json.dumps(node.scheduler)
+    node_name = json.dumps(node.name)
+    script = f"""import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import sys
+
+checks = []
+
+def add(name, ok, detail):
+    checks.append({{"name": name, "ok": bool(ok), "detail": str(detail)}})
+
+add("python>=3.10", sys.version_info >= (3, 10), sys.version.split()[0])
+add("import proto_tools", importlib.util.find_spec("proto_tools") is not None, "proto_tools")
+
+repo_dir = {repo_dir}
+if repo_dir is not None:
+    repo_path = pathlib.Path(repo_dir)
+    add("repo_dir exists", repo_path.is_dir(), repo_dir)
+
+for label, raw_path in [
+    ("work_dir", {work_dir}),
+    ("queue_dir", {queue_dir}),
+    ("results_dir", {results_dir}),
+    ("logs_dir", {logs_dir}),
+]:
+    path = pathlib.Path(raw_path)
+    add(label + " exists", path.is_dir(), raw_path)
+    add(label + " writable", path.is_dir() and os.access(path, os.W_OK), raw_path)
+
+add("rsync available", shutil.which("rsync") is not None, shutil.which("rsync"))
+if {scheduler} == "slurm":
+    add("sbatch available", shutil.which("sbatch") is not None, shutil.which("sbatch"))
+    add("sacct available", shutil.which("sacct") is not None, shutil.which("sacct"))
+
+print(json.dumps({{"node": {node_name}, "ok": all(item["ok"] for item in checks), "checks": checks}}, sort_keys=True))
+"""
+    return "set -euo pipefail; " + _remote_env_prefix(node) + f"{shlex.quote(node.python)} - <<'PY'\n{script}PY"
+
+
+def render_manager_diagnostics_script(node: RemoteNode) -> str:
+    """Render a JSON-emitting remote manager diagnostics script."""
+    paths_payload = json.dumps(
+        {
+            "queue": str(node.queue_root),
+            "running": str(PurePosixPath(node.work_dir) / "running"),
+            "submitted": str(PurePosixPath(node.work_dir) / "submitted"),
+            "done": str(PurePosixPath(node.work_dir) / "done"),
+            "failed": str(PurePosixPath(node.work_dir) / "failed"),
+            "results": str(node.results_root),
+        }
+    )
+    pid_path = json.dumps(str(node.manager_pid_path))
+    log_path = json.dumps(str(node.manager_log_path))
+    node_name = json.dumps(node.name)
+    script = f"""import json
+import os
+import pathlib
+import time
+
+paths = {paths_payload}
+pid_path = pathlib.Path({pid_path})
+log_path = pathlib.Path({log_path})
+now = time.time()
+
+def is_sidecar(path):
+    return str(path).endswith(".json.slurm.json")
+
+def is_tmp(path):
+    return str(path).endswith(".tmp")
+
+def logical_json_files(root):
+    if not root.exists():
+        return []
+    return [path for path in root.rglob("*.json") if not is_sidecar(path) and not is_tmp(path)]
+
+def age_sec(path):
+    try:
+        return max(0.0, round(now - path.stat().st_mtime, 3))
+    except OSError:
+        return None
+
+def request_summary(path):
+    item = {{"path": str(path), "age_sec": age_sec(path)}}
+    try:
+        payload = json.loads(path.read_text())
+    except Exception as exc:
+        item["error"] = f"unreadable: {{type(exc).__name__}}: {{exc}}"
+    else:
+        item["run_id"] = payload.get("run_id")
+        item["bucket_id"] = payload.get("bucket_id")
+        item["tool_key"] = payload.get("tool_key")
+    return item
+
+counts = {{}}
+for key, raw_path in paths.items():
+    counts[key] = len(logical_json_files(pathlib.Path(raw_path)))
+
+sidecar_counts = {{}}
+submitted_root = pathlib.Path(paths["submitted"])
+sidecar_counts["submitted"] = (
+    len(list(submitted_root.rglob("*.json.slurm.json"))) if submitted_root.exists() else 0
+)
+
+if pid_path.exists():
+    pid = pid_path.read_text().strip()
+    running = pid.isdigit() and pathlib.Path("/proc", pid).exists()
+    manager = {{"status": "running" if running else "stale", "pid": pid}}
+else:
+    manager = {{"status": "stopped", "pid": None}}
+
+log_tail = ""
+if log_path.exists():
+    log_tail = "\\n".join(log_path.read_text(errors="replace").splitlines()[-20:])
+
+recent_failed = []
+failed_root = pathlib.Path(paths["failed"])
+if failed_root.exists():
+    for path in sorted(logical_json_files(failed_root))[:5]:
+        item = {{"path": str(path), "age_sec": age_sec(path)}}
+        try:
+            payload = json.loads(path.read_text())
+        except Exception as exc:
+            item["error"] = f"unreadable: {{type(exc).__name__}}: {{exc}}"
+        else:
+            item["error"] = payload.get("error")
+            item["run_id"] = payload.get("run_id")
+            item["bucket_id"] = payload.get("bucket_id")
+            item["tool_key"] = payload.get("tool_key")
+        recent_failed.append(item)
+
+recent_running = []
+running_root = pathlib.Path(paths["running"])
+if running_root.exists():
+    for path in sorted(logical_json_files(running_root))[:5]:
+        recent_running.append(request_summary(path))
+
+recent_submitted = []
+if submitted_root.exists():
+    for path in sorted(submitted_root.rglob("*.json.slurm.json"))[:5]:
+        request_path = pathlib.Path(str(path)[:-len(".slurm.json")])
+        item = {{
+            "path": str(path),
+            "sidecar_path": str(path),
+            "request_path": str(request_path),
+            "request_exists": request_path.exists(),
+            "age_sec": age_sec(path),
+        }}
+        try:
+            payload = json.loads(path.read_text())
+        except Exception as exc:
+            item["error"] = f"unreadable: {{type(exc).__name__}}: {{exc}}"
+        else:
+            item["slurm_job_id"] = payload.get("slurm_job_id")
+            item["bucket_id"] = payload.get("bucket_id")
+            item["result_path"] = payload.get("result_path")
+        if request_path.exists():
+            try:
+                request_payload = json.loads(request_path.read_text())
+            except Exception as exc:
+                item["request_error"] = f"unreadable: {{type(exc).__name__}}: {{exc}}"
+            else:
+                item["run_id"] = request_payload.get("run_id")
+                item["bucket_id"] = item.get("bucket_id") or request_payload.get("bucket_id")
+                item["tool_key"] = request_payload.get("tool_key")
+        recent_submitted.append(item)
+
+recent_tmp = []
+for key, raw_path in paths.items():
+    root = pathlib.Path(raw_path)
+    if root.exists():
+        for path in sorted(root.rglob("*.tmp"))[:5]:
+            recent_tmp.append({{"root": key, "path": str(path), "age_sec": age_sec(path)}})
+
+recent_failed_results = []
+failed_results_root = pathlib.Path(paths["results"]) / "failed"
+if failed_results_root.exists():
+    for path in sorted(logical_json_files(failed_results_root))[:5]:
+        item = request_summary(path)
+        try:
+            payload = json.loads(path.read_text())
+        except Exception:
+            pass
+        else:
+            item["status"] = payload.get("status")
+            item["error"] = payload.get("error")
+        recent_failed_results.append(item)
+
+print(json.dumps({{"node": {node_name}, "manager": manager, "counts": counts, "sidecar_counts": sidecar_counts, "log_tail": log_tail, "recent_failed": recent_failed, "recent_running": recent_running, "recent_submitted": recent_submitted, "recent_tmp": recent_tmp, "recent_failed_results": recent_failed_results}}, sort_keys=True))
+"""
+    return "set -euo pipefail; " + f"{shlex.quote(node.python)} - <<'PY'\n{script}PY"
+
+
+def _existing_command_argv(template: list[Any], *, input_path: Path, output_dir: Path) -> list[str]:
+    """Render one existing-command argv template without invoking a shell."""
+    if not template or not all(isinstance(part, str) and part for part in template):
+        raise ValueError("existing_command.command_argv must be a non-empty list of non-empty strings")
+    return [
+        part.replace("{input}", str(input_path)).replace("{output}", str(output_dir))
+        for part in template
+    ]
+
+
+def _required_existing_artifacts(output_dir: Path, patterns: list[Any]) -> list[str]:
+    """Validate required artifact globs and return the complete output inventory."""
+    if not patterns or not all(isinstance(pattern, str) and pattern for pattern in patterns):
+        raise ValueError("existing command task required_artifacts must be a non-empty list")
+    for pattern in patterns:
+        pattern_path = PurePosixPath(pattern)
+        if pattern_path.is_absolute() or ".." in pattern_path.parts:
+            raise ValueError(f"existing command required artifact pattern must stay relative: {pattern!r}")
+        matches = sorted(path for path in output_dir.glob(pattern) if path.is_file() and path.stat().st_size > 0)
+        if not matches:
+            raise FileNotFoundError(f"required artifact missing or empty: {pattern} under {output_dir}")
+    return sorted(
+        str(path.relative_to(output_dir))
+        for path in output_dir.rglob("*")
+        if path.is_file() and path.stat().st_size > 0
+    )
+
+
+def _execute_existing_command_request(request: dict[str, Any]) -> dict[str, Any]:
+    """Execute node-resolved existing commands and preserve their native artifacts."""
+    payload = request.get("existing_command")
+    if not isinstance(payload, dict):
+        raise ValueError("existing_command request must contain an existing_command object")
+    command_argv = payload.get("command_argv")
+    if not isinstance(command_argv, list):
+        raise ValueError("existing_command.command_argv must be a list")
+    raw_env = payload.get("env") or {}
+    if not isinstance(raw_env, dict):
+        raise ValueError("existing_command.env must be an object")
+    env: dict[str, str] = {}
+    for key, value in raw_env.items():
+        if not isinstance(key, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            raise ValueError(f"invalid existing command environment variable name: {key!r}")
+        if not isinstance(value, str):
+            raise ValueError(f"existing command environment value for {key!r} must be a string")
+        env[key] = value
+    required_stdout_patterns = payload.get("required_stdout_patterns") or []
+    if not isinstance(required_stdout_patterns, list) or not all(
+        isinstance(pattern, str) and pattern for pattern in required_stdout_patterns
+    ):
+        raise ValueError("existing_command.required_stdout_patterns must be a list of non-empty strings")
+    tasks = payload.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise ValueError("existing_command.tasks must be a non-empty list")
+    if len(tasks) != len(request.get("item_indices", [])):
+        raise ValueError("existing_command.tasks must align one-to-one with item_indices")
+
+    command_results: list[dict[str, Any]] = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            raise ValueError("each existing command task must be an object")
+        task_id = _validate_path_segment("existing command task_id", str(task.get("task_id", "")))
+        input_filename = _validate_path_segment(
+            "existing command input_filename", str(task.get("input_filename", ""))
+        )
+        input_text = task.get("input_text")
+        if not isinstance(input_text, str) or not input_text:
+            raise ValueError(f"existing command task {task_id!r} input_text must be non-empty")
+        artifact_dir = Path(str(task.get("artifact_dir", "")))
+        if not artifact_dir.is_absolute():
+            raise ValueError(f"existing command task {task_id!r} artifact_dir must be absolute")
+        artifact_dir.mkdir(parents=True, exist_ok=False)
+        input_path = artifact_dir / "input" / input_filename
+        output_dir = artifact_dir / "output"
+        log_dir = artifact_dir / "logs"
+        output_dir.mkdir(parents=True)
+        log_dir.mkdir(parents=True)
+        _write_text_atomic(input_path, input_text, overwrite=False)
+
+        argv = _existing_command_argv(command_argv, input_path=input_path, output_dir=output_dir)
+        completed = subprocess.run(  # noqa: S603 -- operator-owned profile freezes argv in the manifest
+            argv,
+            check=False,
+            text=True,
+            capture_output=True,
+            env={**os.environ, **env},
+        )
+        stdout_path = log_dir / "stdout.log"
+        stderr_path = log_dir / "stderr.log"
+        _write_text_atomic(stdout_path, completed.stdout or "", overwrite=False)
+        _write_text_atomic(stderr_path, completed.stderr or "", overwrite=False)
+        if completed.returncode != 0:
+            stderr_tail = "\n".join((completed.stderr or "").splitlines()[-20:])
+            raise RuntimeError(
+                f"existing command task {task_id!r} exited {completed.returncode}; stderr_tail={stderr_tail!r}"
+            )
+        missing_stdout_patterns = [
+            pattern for pattern in required_stdout_patterns if pattern not in (completed.stdout or "")
+        ]
+        if missing_stdout_patterns:
+            raise RuntimeError(
+                f"existing command task {task_id!r} missing required stdout pattern(s): "
+                f"{missing_stdout_patterns!r}; stdout_path={stdout_path}"
+            )
+        required = task.get("required_artifacts")
+        if not isinstance(required, list):
+            raise ValueError(f"existing command task {task_id!r} required_artifacts must be a list")
+        artifacts = _required_existing_artifacts(output_dir, required)
+        result_row = {
+            "task_id": task_id,
+            "artifact_dir": str(artifact_dir),
+            "input_path": str(input_path),
+            "output_dir": str(output_dir),
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "artifacts": artifacts,
+        }
+        if required_stdout_patterns:
+            result_row["validated_stdout_patterns"] = list(required_stdout_patterns)
+        command_results.append(result_row)
+
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "status": "completed",
+        "request_kind": "existing_command",
+        "tool_key": request["tool_key"],
+        "run_id": request["run_id"],
+        "bucket_id": request["bucket_id"],
+        "item_indices": request["item_indices"],
+        "existing_command_results": command_results,
+    }
+
+
+def execute_request(request: dict[str, Any]) -> dict[str, Any]:
+    """Execute one remote request in the current process and return a result envelope."""
+    if request.get("schema_version") != _SCHEMA_VERSION:
+        raise ValueError(f"Unsupported remote request schema_version: {request.get('schema_version')!r}")
+    _request_path_segment(request, "run_id")
+    _request_path_segment(request, "bucket_id")
+    request_kind = request.get("request_kind", "tool")
+    if request_kind == "existing_command":
+        return _execute_existing_command_request(request)
+    if request_kind != "tool":
+        raise ValueError(f"Unsupported remote request kind: {request_kind!r}")
+    tool_key = str(request["tool_key"])
+    spec = ToolRegistry.get(tool_key)
+    inputs = spec.input_model.model_validate(request["inputs"])
+    config = spec.config_model.model_validate(request.get("config") or {})
+    output = spec.function(inputs, config)
+    if not isinstance(output, BaseToolOutput):
+        raise TypeError(f"Tool {tool_key!r} returned {type(output).__name__}, expected BaseToolOutput")
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "status": "completed",
+        "tool_key": tool_key,
+        "run_id": request["run_id"],
+        "bucket_id": request["bucket_id"],
+        "item_indices": request["item_indices"],
+        "output": output.model_dump(mode="json", exclude_none=True),
+    }
+
+
+def _write_text_atomic(
+    path: Path,
+    text: str,
+    *,
+    overwrite: bool = True,
+    exists_message: str | None = None,
+) -> None:
+    """Write text atomically through a sibling temporary file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not overwrite:
+        raise FileExistsError(exists_message or f"File already exists: {path}")
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp_path.write_text(text)
+        if overwrite:
+            tmp_path.replace(path)
+        else:
+            try:
+                os.link(tmp_path, path)
+            except FileExistsError as exc:
+                raise FileExistsError(exists_message or f"File already exists: {path}") from exc
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any], *, overwrite: bool = True) -> None:
+    """Write JSON atomically by replacing a sibling temporary file."""
+    _write_text_atomic(
+        path,
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        overwrite=overwrite,
+    )
+
+
+def _failure_envelope(request: dict[str, Any] | None, exc: BaseException) -> dict[str, Any]:
+    """Build a failed result envelope from a request and exception."""
+    request = request or {}
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "status": "failed",
+        "request_kind": request.get("request_kind", "tool"),
+        "tool_key": request.get("tool_key"),
+        "run_id": request.get("run_id"),
+        "bucket_id": request.get("bucket_id"),
+        "item_indices": request.get("item_indices", []),
+        "error": f"{type(exc).__name__}: {exc}",
+        "traceback": traceback.format_exc(),
+    }
+
+
+def execute_request_file(request_path: Path | str, output_path: Path | str) -> dict[str, Any]:
+    """Execute one request file and write the completed result envelope."""
+    request: dict[str, Any] | None = None
+    try:
+        request = json.loads(Path(request_path).read_text())
+        result = execute_request(request)
+        _write_json_atomic(Path(output_path), result)
+        return result
+    except Exception as exc:
+        _write_json_atomic(Path(output_path), _failure_envelope(request, exc))
+        raise
+
+
+def _request_result_path(results_root: Path, request: dict[str, Any]) -> Path:
+    """Return the safe result path for one request payload."""
+    run_id = _request_path_segment(request, "run_id")
+    bucket_id = _request_path_segment(request, "bucket_id")
+    return results_root / run_id / f"{bucket_id}.json"
+
+
+def _invalid_request_result_path(results_root: Path, request_path: Path) -> Path:
+    """Return an in-root failure path for a malformed request."""
+    return results_root / "failed" / f"{request_path.name}.json"
+
+
+def execute_request_batch(request_paths: list[Path | str], results_dir: Path | str) -> list[dict[str, Any]]:
+    """Execute many request files and write each result envelope."""
+    results: list[dict[str, Any]] = []
+    failures: list[str] = []
+    results_root = Path(results_dir)
+    for request_path in request_paths:
+        request: dict[str, Any] | None = None
+        result_path: Path | None = None
+        try:
+            path = Path(request_path)
+            request = json.loads(path.read_text())
+            result_path = _request_result_path(results_root, request)
+            results.append(execute_request_file(request_path, result_path))
+        except Exception as exc:
+            failures.append(f"{request_path}: {type(exc).__name__}: {exc}")
+            fallback_path = result_path or _invalid_request_result_path(results_root, Path(request_path))
+            _write_json_atomic(fallback_path, _failure_envelope(request, exc))
+    if failures:
+        raise RuntimeError(f"{len(failures)} remote request(s) failed: {'; '.join(failures[:3])}")
+    return results
+
+
+@dataclass(frozen=True)
+class ManagerEvent:
+    """A manager action taken for one request file."""
+
+    status: Literal["completed", "submitted", "failed"]
+    request_path: Path
+    result_path: Path
+    slurm_job_id: str | None = None
+
+
+def _move_request(src: Path, root: Path, relative: Path) -> Path:
+    """Move a request file under a state root while preserving its relative path."""
+    dst = root / relative
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.replace(dst)
+    return dst
+
+
+def _terminal_result_status_for_request(
+    envelope: dict[str, Any],
+    request: dict[str, Any],
+    result_path: Path,
+) -> Literal["completed", "failed"]:
+    """Return terminal result status after checking it belongs to a request."""
+    identity_checks = (
+        ("run_id", request.get("run_id"), envelope.get("run_id")),
+        ("bucket_id", request.get("bucket_id"), envelope.get("bucket_id")),
+        ("tool_key", request.get("tool_key"), envelope.get("tool_key")),
+        ("item_indices", list(request.get("item_indices", [])), envelope.get("item_indices")),
+    )
+    mismatches = [
+        f"{field} expected {expected!r} got {actual!r}"
+        for field, expected, actual in identity_checks
+        if actual != expected
+    ]
+    if mismatches:
+        raise RuntimeError(f"Result envelope identity mismatch at {result_path}: {'; '.join(mismatches)}")
+    status = envelope.get("status")
+    if status not in ("completed", "failed"):
+        raise RuntimeError(f"Result envelope at {result_path} is not terminal: status={status!r}")
+    return cast(Literal["completed", "failed"], status)
+
+
+def reconcile_running_requests(
+    running_dir: Path | str,
+    results_dir: Path | str,
+    *,
+    done_dir: Path | str | None = None,
+    failed_dir: Path | str | None = None,
+) -> list[ManagerEvent]:
+    """Move running requests with visible terminal result envelopes to final state roots."""
+    running_root = Path(running_dir)
+    results_root = Path(results_dir)
+    state_root = running_root.parent
+    done_root = Path(done_dir) if done_dir is not None else state_root / "done"
+    failed_root = Path(failed_dir) if failed_dir is not None else state_root / "failed"
+    events: list[ManagerEvent] = []
+    for request_path in sorted(running_root.rglob("*.json")):
+        if str(request_path).endswith(".json.slurm.json"):
+            continue
+        relative = request_path.relative_to(running_root)
+        request = cast(dict[str, Any], json.loads(request_path.read_text()))
+        result_path = _request_result_path(results_root, request)
+        if not result_path.exists():
+            continue
+        envelope = cast(dict[str, Any], json.loads(result_path.read_text()))
+        status = _terminal_result_status_for_request(envelope, request, result_path)
+        if status == "completed":
+            final_request = _move_request(request_path, done_root, relative)
+            events.append(ManagerEvent(status="completed", request_path=final_request, result_path=result_path))
+        else:
+            failed_request = _move_request(request_path, failed_root, relative)
+            events.append(ManagerEvent(status="failed", request_path=failed_request, result_path=result_path))
+    return events
+
+
+def _slurm_submit_command(
+    python: str,
+    request_paths: list[Path],
+    results_dir: Path,
+    sbatch_args: tuple[str, ...],
+) -> list[str]:
+    """Build an sbatch command that executes one group of request files."""
+    if not request_paths:
+        raise ValueError("request_paths must be non-empty")
+    request_args = " ".join(f"--request {shlex.quote(str(path))}" for path in request_paths)
+    worker_cmd = (
+        f"{shlex.quote(python)} -m proto_tools.utils.remote_execution run-request-batch "
+        f"--results-dir {shlex.quote(str(results_dir))} "
+        f"{request_args}"
+    )
+    cmd = ["sbatch"]
+    if "--parsable" not in sbatch_args:
+        cmd.append("--parsable")
+    cmd.extend(sbatch_args)
+    cmd.extend(["--wrap", worker_cmd])
+    return cmd
+
+
+def _parse_slurm_job_id(result: Any) -> str | None:
+    """Parse the first line of sbatch stdout as the job id."""
+    stdout = str(getattr(result, "stdout", "") or "").strip()
+    return stdout.splitlines()[0] if stdout else None
+
+
+def _submitted_at_epoch(sidecar_path: Path, sidecar_payload: dict[str, Any]) -> float:
+    """Return sidecar submission time, using mtime for pre-timestamp sidecars."""
+    raw_value = sidecar_payload.get("submitted_at_epoch")
+    if raw_value is None:
+        return sidecar_path.stat().st_mtime
+    try:
+        return float(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid submitted_at_epoch in {sidecar_path}: {raw_value!r}") from exc
+
+
+def _slurm_state_base(state: str | None) -> str:
+    """Return the normalized top-level Slurm state token."""
+    return str(state or "UNKNOWN").split()[0].split("+")[0].upper()
+
+
+def _query_sacct_states(job_ids: set[str], *, runner: Any = subprocess.run) -> dict[str, str]:
+    """Query Slurm accounting states for submitted job ids."""
+    if not job_ids:
+        return {}
+    cmd = [
+        "sacct",
+        "--noheader",
+        "--parsable2",
+        "--format=JobIDRaw,State",
+        "--jobs",
+        ",".join(sorted(job_ids)),
+    ]
+    result = runner(cmd, check=True, text=True, capture_output=True)
+    states_by_job: dict[str, list[str]] = {job_id: [] for job_id in job_ids}
+    for raw_line in str(getattr(result, "stdout", "") or "").splitlines():
+        if "|" not in raw_line:
+            continue
+        raw_job_id, raw_state = raw_line.split("|", 1)
+        state = _slurm_state_base(raw_state)
+        for job_id in job_ids:
+            if raw_job_id == job_id or raw_job_id.startswith(f"{job_id}."):
+                states_by_job[job_id].append(state)
+
+    collapsed: dict[str, str] = {}
+    for job_id, states in states_by_job.items():
+        if any(state in _SLURM_FAILED_STATES for state in states):
+            collapsed[job_id] = next(state for state in states if state in _SLURM_FAILED_STATES)
+        elif states and all(state in _SLURM_COMPLETED_STATES for state in states):
+            collapsed[job_id] = "COMPLETED"
+        elif any(state in _SLURM_ACTIVE_STATES for state in states):
+            collapsed[job_id] = next(state for state in states if state in _SLURM_ACTIVE_STATES)
+        elif states:
+            collapsed[job_id] = states[0]
+    return collapsed
+
+
+def _chunks(items: list[Any], size: int) -> list[list[Any]]:
+    """Split items into non-empty chunks."""
+    if size < 1:
+        raise ValueError(f"chunk size must be >= 1, got {size}")
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def _queued_request_resource_ready(
+    request: dict[str, Any],
+    *,
+    runner: Any = subprocess.run,
+) -> bool:
+    """Return whether a queued direct request passes its explicit resource admission gate."""
+    if request.get("request_kind", "tool") != "existing_command":
+        return True
+    existing_command = request.get("existing_command")
+    if not isinstance(existing_command, dict):
+        return True
+    admission = existing_command.get("resource_admission")
+    if admission is None:
+        return True
+    if not isinstance(admission, dict):
+        raise ValueError("existing_command.resource_admission must be an object")
+    if admission.get("kind") != "cuda_idle":
+        raise ValueError(
+            f"unsupported existing command resource admission kind: {admission.get('kind')!r}"
+        )
+    gpu_id = str(admission.get("gpu_id", "")).strip()
+    if not gpu_id:
+        raise ValueError("cuda_idle resource admission requires gpu_id")
+    max_utilization = int(admission["max_utilization_percent"])
+    max_memory = int(admission["max_memory_used_mib"])
+    if not 0 <= max_utilization <= 100:
+        raise ValueError("cuda_idle max_utilization_percent must be in [0, 100]")
+    if max_memory < 0:
+        raise ValueError("cuda_idle max_memory_used_mib must be >= 0")
+    command = [
+        "nvidia-smi",
+        "-i",
+        gpu_id,
+        "--query-gpu=utilization.gpu,memory.used",
+        "--format=csv,noheader,nounits",
+    ]
+    completed = runner(command, check=True, text=True, capture_output=True)
+    output = str(getattr(completed, "stdout", "") or "").strip()
+    fields = [field.strip() for field in output.splitlines()[0].split(",")] if output else []
+    if len(fields) != 2:
+        raise ValueError(f"unexpected nvidia-smi admission output: {output!r}")
+    utilization, memory = (int(field) for field in fields)
+    return utilization <= max_utilization and memory <= max_memory
+
+
+def _submit_slurm_group(
+    group: list[tuple[Path, Path, dict[str, Any], Path]],
+    *,
+    results_root: Path,
+    submitted_root: Path,
+    failed_root: Path,
+    python: str,
+    sbatch_args: tuple[str, ...],
+    runner: Any,
+) -> list[ManagerEvent]:
+    """Submit one Slurm group and return per-request manager events."""
+    events: list[ManagerEvent] = []
+    submitted_by_relative: dict[Path, Path] = {}
+    try:
+        for claimed, relative, _, _ in group:
+            submitted_by_relative[relative] = _move_request(claimed, submitted_root, relative)
+        cmd = _slurm_submit_command(
+            python,
+            [submitted_by_relative[relative] for _, relative, _, _ in group],
+            results_root,
+            sbatch_args,
+        )
+        result = runner(cmd, check=True, text=True, capture_output=True)
+        slurm_job_id = _parse_slurm_job_id(result)
+        if not slurm_job_id:
+            raise RuntimeError("sbatch did not return a Slurm job id")
+        submitted_at_epoch = time.time()
+        for _, relative, request, result_path in group:
+            final_request = submitted_by_relative[relative]
+            _write_json_atomic(
+                final_request.with_name(f"{final_request.name}.slurm.json"),
+                {
+                    "schema_version": _SCHEMA_VERSION,
+                    "status": "submitted",
+                    "tool_key": request.get("tool_key"),
+                    "run_id": request.get("run_id"),
+                    "bucket_id": request.get("bucket_id"),
+                    "item_indices": request.get("item_indices", []),
+                    "slurm_job_id": slurm_job_id,
+                    "submitted_at_epoch": submitted_at_epoch,
+                    "result_path": str(result_path),
+                },
+            )
+            events.append(
+                ManagerEvent(
+                    status="submitted",
+                    request_path=final_request,
+                    result_path=result_path,
+                    slurm_job_id=slurm_job_id,
+                )
+            )
+    except Exception as exc:
+        for claimed, relative, request, result_path in group:
+            _write_json_atomic(result_path, _failure_envelope(request, exc))
+            current_request = submitted_by_relative.get(relative, claimed)
+            failed_request = _move_request(current_request, failed_root, relative)
+            sidecar = current_request.with_name(f"{current_request.name}.slurm.json")
+            if sidecar.exists():
+                _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(ManagerEvent(status="failed", request_path=failed_request, result_path=result_path))
+    return events
+
+
+def _request_path_for_slurm_sidecar(sidecar_path: Path) -> Path:
+    """Return the request path paired with a ``.slurm.json`` sidecar."""
+    if not sidecar_path.name.endswith(".slurm.json"):
+        raise ValueError(f"Not a Slurm sidecar path: {sidecar_path}")
+    return sidecar_path.with_name(sidecar_path.name[: -len(".slurm.json")])
+
+
+def _move_slurm_sidecar(sidecar_path: Path, state_root: Path, relative_request: Path) -> Path:
+    """Move a Slurm sidecar next to a request in a state directory."""
+    dst = state_root / relative_request.parent / sidecar_path.name
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.replace(dst)
+    return dst
+
+
+def _slurm_failed_envelope(request: dict[str, Any], job_id: str | None, state: str, result_path: Path) -> dict[str, Any]:
+    """Build a failed envelope for a terminal Slurm job that wrote no result."""
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "status": "failed",
+        "tool_key": request.get("tool_key"),
+        "run_id": request.get("run_id"),
+        "bucket_id": request.get("bucket_id"),
+        "item_indices": request.get("item_indices", []),
+        "error": f"Slurm job {job_id or '<unknown>'} ended with state {state} before writing {result_path}",
+        "traceback": "",
+    }
+
+
+def reconcile_submitted_slurm_jobs(
+    submitted_dir: Path | str,
+    results_dir: Path | str,
+    *,
+    done_dir: Path | str | None = None,
+    failed_dir: Path | str | None = None,
+    slurm_accounting_grace_sec: float = _SLURM_ACCOUNTING_GRACE_SEC,
+    runner: Any = subprocess.run,
+) -> list[ManagerEvent]:
+    """Reconcile submitted Slurm requests against result files and accounting state."""
+    if slurm_accounting_grace_sec < 0:
+        raise ValueError(f"slurm_accounting_grace_sec must be >= 0, got {slurm_accounting_grace_sec}")
+    submitted_root = Path(submitted_dir)
+    results_root = Path(results_dir)
+    state_root = submitted_root.parent
+    done_root = Path(done_dir) if done_dir is not None else state_root / "done"
+    failed_root = Path(failed_dir) if failed_dir is not None else state_root / "failed"
+
+    events: list[ManagerEvent] = []
+    missing_result_entries: list[tuple[Path, Path, Path, dict[str, Any], str | None, float]] = []
+    sidecars = sorted(submitted_root.rglob("*.json.slurm.json"))
+    for sidecar in sidecars:
+        request_path = _request_path_for_slurm_sidecar(sidecar)
+        relative = request_path.relative_to(submitted_root)
+        request: dict[str, Any] | None = None
+        result_path: Path | None = None
+        try:
+            sidecar_payload = json.loads(sidecar.read_text())
+            request = json.loads(request_path.read_text())
+            result_path = _request_result_path(results_root, request)
+            recorded_result_path = sidecar_payload.get("result_path")
+            if recorded_result_path is not None and Path(str(recorded_result_path)) != result_path:
+                raise ValueError(
+                    f"Slurm sidecar result_path mismatch for {request_path}: "
+                    f"expected {result_path}, got {recorded_result_path}"
+                )
+            job_id = None if sidecar_payload.get("slurm_job_id") is None else str(sidecar_payload["slurm_job_id"])
+            submitted_at_epoch = _submitted_at_epoch(sidecar, sidecar_payload)
+        except Exception as exc:
+            result_path = result_path or _invalid_request_result_path(results_root, request_path)
+            _write_json_atomic(result_path, _failure_envelope(request, exc))
+            failed_request = _move_request(request_path, failed_root, relative)
+            _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(ManagerEvent(status="failed", request_path=failed_request, result_path=result_path))
+            continue
+
+        if result_path.exists():
+            envelope = json.loads(result_path.read_text())
+            if envelope.get("status") == "completed":
+                final_request = _move_request(request_path, done_root, relative)
+                _move_slurm_sidecar(sidecar, done_root, relative)
+                events.append(ManagerEvent(status="completed", request_path=final_request, result_path=result_path))
+            elif envelope.get("status") == "failed":
+                failed_request = _move_request(request_path, failed_root, relative)
+                _move_slurm_sidecar(sidecar, failed_root, relative)
+                events.append(ManagerEvent(status="failed", request_path=failed_request, result_path=result_path))
+            continue
+
+        missing_result_entries.append((sidecar, request_path, result_path, request, job_id, submitted_at_epoch))
+
+    job_ids = {job_id for _, _, _, _, job_id, _ in missing_result_entries if job_id}
+    states = _query_sacct_states(job_ids, runner=runner)
+    now = time.time()
+
+    for sidecar, request_path, result_path, request, job_id, submitted_at_epoch in missing_result_entries:
+        relative = request_path.relative_to(submitted_root)
+        state = states.get(job_id or "")
+        if state in _SLURM_FAILED_STATES:
+            _write_json_atomic(result_path, _slurm_failed_envelope(request, job_id, state, result_path))
+            failed_request = _move_request(request_path, failed_root, relative)
+            _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(
+                ManagerEvent(
+                    status="failed",
+                    request_path=failed_request,
+                    result_path=result_path,
+                    slurm_job_id=job_id,
+                )
+            )
+        elif state in _SLURM_COMPLETED_STATES:
+            _write_json_atomic(result_path, _slurm_failed_envelope(request, job_id, "COMPLETED_WITHOUT_RESULT", result_path))
+            failed_request = _move_request(request_path, failed_root, relative)
+            _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(
+                ManagerEvent(
+                    status="failed",
+                    request_path=failed_request,
+                    result_path=result_path,
+                    slurm_job_id=job_id,
+                )
+            )
+        elif job_id is None:
+            _write_json_atomic(result_path, _slurm_failed_envelope(request, job_id, "SLURM_JOB_ID_MISSING", result_path))
+            failed_request = _move_request(request_path, failed_root, relative)
+            _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(
+                ManagerEvent(
+                    status="failed",
+                    request_path=failed_request,
+                    result_path=result_path,
+                    slurm_job_id=job_id,
+                )
+            )
+        elif state not in _SLURM_ACTIVE_STATES and now - submitted_at_epoch >= slurm_accounting_grace_sec:
+            stale_state = "SLURM_JOB_NOT_FOUND_OR_STALE" if state is None else f"SLURM_JOB_NOT_FOUND_OR_STALE_{state}"
+            _write_json_atomic(result_path, _slurm_failed_envelope(request, job_id, stale_state, result_path))
+            failed_request = _move_request(request_path, failed_root, relative)
+            _move_slurm_sidecar(sidecar, failed_root, relative)
+            events.append(
+                ManagerEvent(
+                    status="failed",
+                    request_path=failed_request,
+                    result_path=result_path,
+                    slurm_job_id=job_id,
+                )
+            )
+    return events
+
+
+def _active_slurm_job_count(submitted_root: Path) -> int:
+    """Count submitted Slurm jobs still tracked after reconciliation."""
+    active: set[str] = set()
+    for sidecar in sorted(submitted_root.rglob("*.json.slurm.json")):
+        payload = json.loads(sidecar.read_text())
+        job_id = payload.get("slurm_job_id")
+        active.add(str(job_id) if job_id else str(sidecar))
+    return len(active)
+
+
+def run_manager_once(
+    queue_dir: Path | str,
+    results_dir: Path | str,
+    *,
+    scheduler: RemoteScheduler = "direct",
+    running_dir: Path | str | None = None,
+    done_dir: Path | str | None = None,
+    failed_dir: Path | str | None = None,
+    submitted_dir: Path | str | None = None,
+    python: str = sys.executable,
+    sbatch_args: tuple[str, ...] = (),
+    slurm_group_size: int = 10,
+    max_active_slurm_jobs: int | None = None,
+    slurm_accounting_grace_sec: float = _SLURM_ACCOUNTING_GRACE_SEC,
+    runner: Any = subprocess.run,
+) -> list[ManagerEvent]:
+    """Consume currently queued requests once."""
+    if scheduler not in ("direct", "slurm"):
+        raise ValueError(f"Unsupported scheduler {scheduler!r}")
+    if slurm_group_size < 1:
+        raise ValueError(f"slurm_group_size must be >= 1, got {slurm_group_size}")
+    if scheduler == "slurm" and max_active_slurm_jobs is None:
+        raise ValueError("max_active_slurm_jobs is required when scheduler='slurm'")
+    if max_active_slurm_jobs is not None and max_active_slurm_jobs < 1:
+        raise ValueError(f"max_active_slurm_jobs must be >= 1, got {max_active_slurm_jobs}")
+    queue_root = Path(queue_dir)
+    results_root = Path(results_dir)
+    state_root = queue_root.parent
+    running_root = Path(running_dir) if running_dir is not None else state_root / "running"
+    done_root = Path(done_dir) if done_dir is not None else state_root / "done"
+    failed_root = Path(failed_dir) if failed_dir is not None else state_root / "failed"
+    submitted_root = Path(submitted_dir) if submitted_dir is not None else state_root / "submitted"
+
+    events: list[ManagerEvent] = []
+    events.extend(
+        reconcile_running_requests(
+            running_root,
+            results_root,
+            done_dir=done_root,
+            failed_dir=failed_root,
+        )
+    )
+    if scheduler == "slurm":
+        events.extend(
+            reconcile_submitted_slurm_jobs(
+                submitted_root,
+                results_root,
+                done_dir=done_root,
+                failed_dir=failed_root,
+                slurm_accounting_grace_sec=slurm_accounting_grace_sec,
+                runner=runner,
+            )
+        )
+
+    request_files = sorted(queue_root.rglob("*.json"))
+    if scheduler == "slurm" and max_active_slurm_jobs is not None:
+        active_jobs = _active_slurm_job_count(submitted_root)
+        available_jobs = max_active_slurm_jobs - active_jobs
+        if available_jobs <= 0:
+            return events
+        request_files = request_files[: available_jobs * slurm_group_size]
+
+    slurm_pending: list[tuple[Path, Path, dict[str, Any], Path]] = []
+    for request_file in request_files:
+        queued_request: dict[str, Any] | None = None
+        admission_error: Exception | None = None
+        if scheduler == "direct":
+            try:
+                queued_request = cast(dict[str, Any], json.loads(request_file.read_text()))
+                if not _queued_request_resource_ready(queued_request, runner=runner):
+                    continue
+            except Exception as exc:
+                admission_error = exc
+        relative = request_file.relative_to(queue_root)
+        claimed = _move_request(request_file, running_root, relative)
+        request: dict[str, Any] | None = queued_request
+        result_path: Path | None = None
+        try:
+            if admission_error is not None:
+                raise admission_error
+            if request is None:
+                request = json.loads(claimed.read_text())
+            result_path = _request_result_path(results_root, request)
+            if scheduler == "direct":
+                result = execute_request(request)
+                _write_json_atomic(result_path, result)
+                final_request = _move_request(claimed, done_root, relative)
+                events.append(ManagerEvent(status="completed", request_path=final_request, result_path=result_path))
+            elif scheduler == "slurm":
+                slurm_pending.append((claimed, relative, request, result_path))
+        except Exception as exc:
+            result_path = result_path or _invalid_request_result_path(results_root, claimed)
+            _write_json_atomic(result_path, _failure_envelope(request, exc))
+            failed_request = _move_request(claimed, failed_root, relative)
+            events.append(ManagerEvent(status="failed", request_path=failed_request, result_path=result_path))
+
+    for group in _chunks(slurm_pending, slurm_group_size):
+        events.extend(
+            _submit_slurm_group(
+                group,
+                results_root=results_root,
+                submitted_root=submitted_root,
+                failed_root=failed_root,
+                python=python,
+                sbatch_args=sbatch_args,
+                runner=runner,
+            )
+        )
+    return events
+
+
+def run_manager_loop(
+    queue_dir: Path | str,
+    results_dir: Path | str,
+    *,
+    scheduler: RemoteScheduler = "direct",
+    poll_interval: float = 5.0,
+    once: bool = False,
+    python: str = sys.executable,
+    sbatch_args: tuple[str, ...] = (),
+    slurm_group_size: int = 10,
+    max_active_slurm_jobs: int | None = None,
+    slurm_accounting_grace_sec: float = _SLURM_ACCOUNTING_GRACE_SEC,
+    runner: Any = subprocess.run,
+) -> None:
+    """Run a persistent node manager loop."""
+    if poll_interval <= 0:
+        raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
+    if slurm_group_size < 1:
+        raise ValueError(f"slurm_group_size must be >= 1, got {slurm_group_size}")
+    if scheduler == "slurm" and max_active_slurm_jobs is None:
+        raise ValueError("max_active_slurm_jobs is required when scheduler='slurm'")
+    if max_active_slurm_jobs is not None and max_active_slurm_jobs < 1:
+        raise ValueError(f"max_active_slurm_jobs must be >= 1, got {max_active_slurm_jobs}")
+
+    persist_ctx = ToolInstance.persist() if scheduler == "direct" else None
+    if persist_ctx is not None:
+        persist_ctx.__enter__()
+    try:
+        while True:
+            try:
+                run_manager_once(
+                    queue_dir,
+                    results_dir,
+                    scheduler=scheduler,
+                    python=python,
+                    sbatch_args=sbatch_args,
+                    slurm_group_size=slurm_group_size,
+                    max_active_slurm_jobs=max_active_slurm_jobs,
+                    slurm_accounting_grace_sec=slurm_accounting_grace_sec,
+                    runner=runner,
+                )
+            except Exception:
+                traceback.print_exc()
+                if once:
+                    raise
+            if once:
+                return
+            time.sleep(poll_interval)
+    finally:
+        if persist_ctx is not None:
+            persist_ctx.__exit__(None, None, None)
+
+
+def collect_plan_outputs(plan: RemoteDispatchPlan, results_dir: Path | str) -> BaseToolOutput:
+    """Merge completed bucket result files into the tool's output model."""
+    spec = ToolRegistry.get(plan.tool_key)
+    output_items: dict[int, Any] = {}
+    warnings: list[str] = []
+    errors: list[str] = []
+    metadata: dict[str, Any] = {"remote_dispatch": {"run_id": plan.run_id, "buckets": len(plan.assignments)}}
+
+    for assignment in plan.assignments:
+        result_path = Path(results_dir) / assignment.node.name / plan.run_id / f"{assignment.bucket.bucket_id}.json"
+        envelope = json.loads(result_path.read_text())
+        if envelope.get("status") != "completed":
+            trace_tail = str(envelope.get("traceback", "")).splitlines()[-1:] or [""]
+            raise RuntimeError(
+                f"Remote bucket {assignment.node.name}/{assignment.bucket.bucket_id} did not complete: "
+                f"{envelope.get('error')} (result_path={result_path}; trace_tail={trace_tail[0]})"
+            )
+        output = spec.output_model.model_validate(envelope["output"])
+        bucket_outputs = list(getattr(output, plan.iterable_output_field))
+        if len(bucket_outputs) != len(assignment.bucket.item_indices):
+            raise RuntimeError(
+                f"Remote bucket {assignment.bucket.bucket_id} returned {len(bucket_outputs)} "
+                f"{plan.iterable_output_field} for {len(assignment.bucket.item_indices)} input item(s)"
+            )
+        output_items.update(dict(zip(assignment.bucket.item_indices, bucket_outputs, strict=True)))
+        warnings.extend(output.warnings)
+        errors.extend(output.errors)
+
+    expected = set(range(sum(len(assignment.bucket.item_indices) for assignment in plan.assignments)))
+    missing = sorted(expected - set(output_items))
+    if missing:
+        raise RuntimeError(f"Missing remote output item(s): {missing}")
+    merged = [output_items[index] for index in sorted(output_items)]
+    output_payload: dict[str, Any] = {
+        plan.iterable_output_field: merged,
+        "warnings": warnings,
+        "errors": errors,
+        "metadata": metadata,
+    }
+    return cast(BaseToolOutput, spec.output_model.model_validate(output_payload))
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the remote manager CLI parser."""
+    parser = argparse.ArgumentParser(prog="python -m proto_tools.utils.remote_execution")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_request = sub.add_parser("run-request")
+    run_request.add_argument("--request", required=True)
+    run_request.add_argument("--output", required=True)
+
+    run_request_batch = sub.add_parser("run-request-batch")
+    run_request_batch.add_argument("--request", action="append", required=True)
+    run_request_batch.add_argument("--results-dir", required=True)
+
+    loop = sub.add_parser("manager-loop")
+    loop.add_argument("--queue-dir", required=True)
+    loop.add_argument("--results-dir", required=True)
+    loop.add_argument("--scheduler", choices=("direct", "slurm"), default="direct")
+    loop.add_argument("--poll-interval", type=float, default=5.0)
+    loop.add_argument("--once", action="store_true")
+    loop.add_argument("--python", default=sys.executable)
+    loop.add_argument("--sbatch-arg", action="append", default=[])
+    loop.add_argument("--slurm-group-size", type=int, default=10)
+    loop.add_argument(
+        "--slurm-accounting-grace-sec",
+        type=float,
+        default=_SLURM_ACCOUNTING_GRACE_SEC,
+        help="Seconds to wait before failing submitted Slurm jobs missing from accounting.",
+    )
+    loop.add_argument(
+        "--max-active-slurm-jobs",
+        type=int,
+        help="Required with --scheduler slurm; caps active submitted Slurm jobs.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for node-side request execution and manager loops."""
+    args = _build_arg_parser().parse_args(argv)
+    if args.command == "run-request":
+        execute_request_file(args.request, args.output)
+        return 0
+    if args.command == "run-request-batch":
+        execute_request_batch(args.request, args.results_dir)
+        return 0
+    if args.command == "manager-loop":
+        run_manager_loop(
+            args.queue_dir,
+            args.results_dir,
+            scheduler=args.scheduler,
+            poll_interval=args.poll_interval,
+            once=args.once,
+            python=args.python,
+            sbatch_args=tuple(args.sbatch_arg),
+            slurm_group_size=args.slurm_group_size,
+            max_active_slurm_jobs=args.max_active_slurm_jobs,
+            slurm_accounting_grace_sec=args.slurm_accounting_grace_sec,
+        )
+        return 0
+    raise ValueError(f"Unsupported command {args.command!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tool_infra_tests/test_cli.py
+++ b/tests/tool_infra_tests/test_cli.py
@@ -14,11 +14,15 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
 
 import pytest
 
+from proto_tools import cli as cli_mod
 from proto_tools.cli import main
+from proto_tools.utils.remote_execution import ExistingRemoteBatchNode, ExistingRemoteCommandNode, RemoteNode
 
 
 def _run(*argv: str) -> tuple[int, str, str]:
@@ -28,6 +32,18 @@ def _run(*argv: str) -> tuple[int, str, str]:
     with redirect_stdout(out), redirect_stderr(err):
         code = main(list(argv))
     return code, out.getvalue(), err.getvalue()
+
+
+def _init_git_repo(path: Path) -> Path:
+    """Create a minimal git checkout for deploy CLI tests."""
+    path.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(path), "init"], check=True, text=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Proto Tests"], check=True)
+    (path / "tracked.txt").write_text("clean\n")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "initial"], check=True, text=True, capture_output=True)
+    return path
 
 
 # ── Discovery verbs ─────────────────────────────────────────────────────────
@@ -78,6 +94,1572 @@ def test_agent_context_prints_primer() -> None:
     assert code == 0
     assert "Input -> Config -> run_*() -> Output" in out
     assert "github.com/evo-design/proto-tools/tree/main/notes" in out
+
+
+# ── Remote execution verbs ─────────────────────────────────────────────────
+
+
+def test_remote_profile_list_filters_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="h100", host="h100", work_dir="/remote/h100", scheduler="slurm", weight=3.0),
+    ]
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    code, out, _ = _run("remote", "profile", "list", "--profile", "nodes.json", "--node", "h100")
+
+    assert code == 0
+    assert out.splitlines() == ["h100\th100\tslurm\tweight=3.0\tmax_concurrent_buckets=1"]
+
+
+def test_remote_profile_scaffold_and_validate(tmp_path: Path) -> None:
+    profile_path = tmp_path / "remote-nodes.json"
+
+    code, out, _ = _run(
+        "remote",
+        "profile",
+        "scaffold",
+        "--output",
+        str(profile_path),
+        "--direct",
+        "ty=/sfs/home/zengzhengpeng",
+        "--direct",
+        "ty3=/mnt/sfs/zengzhengpeng",
+        "--slurm",
+        "h100=/public/home/zengzhengpeng",
+        "--slurm-weight",
+        "3",
+        "--slurm-max-active-jobs",
+        "2",
+        "--slurm-sbatch-arg=--partition=gpu",
+        "--slurm-sbatch-arg=--gres=gpu:h100:1",
+    )
+    validate_code, validate_out, _ = _run(
+        "remote",
+        "profile",
+        "validate",
+        "--profile",
+        str(profile_path),
+        "--json",
+    )
+
+    payload = json.loads(profile_path.read_text())
+    assert code == 0
+    assert f"profile\t{profile_path}" in out
+    assert [node["name"] for node in payload["nodes"]] == ["ty", "ty3", "h100"]
+    assert payload["nodes"][0]["worker_device"] == "cuda:0"
+    assert payload["nodes"][2]["scheduler"] == "slurm"
+    assert payload["nodes"][2]["weight"] == 3.0
+    assert payload["nodes"][2]["max_active_slurm_jobs"] == 2
+    assert payload["nodes"][2]["sbatch_args"] == ["--partition=gpu", "--gres=gpu:h100:1"]
+    assert validate_code == 0
+    assert json.loads(validate_out) == {"ok": True, "node_count": 3, "issues": []}
+
+
+def test_remote_profile_scaffold_ty_directs_and_h100_slurm_golden(tmp_path: Path) -> None:
+    profile_path = tmp_path / "remote-nodes.json"
+
+    code, out, _ = _run(
+        "remote",
+        "profile",
+        "scaffold",
+        "--output",
+        str(profile_path),
+        "--direct",
+        "ty=/sfs/home/zengzhengpeng",
+        "--direct",
+        "ty2=/mnt/sfs/zengzhengpeng",
+        "--direct",
+        "ty3=/mnt/sfs/zengzhengpeng",
+        "--work-name-template",
+        "proto_remote_{node}",
+        "--slurm",
+        "h100=/public/home/zengzhengpeng",
+        "--slurm-weight",
+        "3",
+        "--slurm-max-active-jobs",
+        "2",
+        "--slurm-sbatch-arg=--partition=gpu",
+        "--slurm-sbatch-arg=--gres=gpu:h100:1",
+    )
+    validate_code, validate_out, _ = _run("remote", "profile", "validate", "--profile", str(profile_path), "--json")
+
+    profile = json.loads(profile_path.read_text())
+    nodes = {node["name"]: node for node in profile["nodes"]}
+    issues = json.loads(validate_out)["issues"]
+    warning_pairs = {(issue["field"], issue["node_name"]) for issue in issues}
+
+    assert code == 0
+    assert [node["name"] for node in profile["nodes"]] == ["ty", "ty2", "ty3", "h100"]
+    assert nodes["ty"]["work_dir"] == "/sfs/home/zengzhengpeng/proto_remote_ty"
+    assert nodes["ty2"]["work_dir"] == "/mnt/sfs/zengzhengpeng/proto_remote_ty2"
+    assert nodes["ty3"]["work_dir"] == "/mnt/sfs/zengzhengpeng/proto_remote_ty3"
+    assert nodes["h100"]["scheduler"] == "slurm"
+    assert nodes["h100"]["weight"] == 3.0
+    assert nodes["h100"]["max_active_slurm_jobs"] == 2
+    assert nodes["h100"]["sbatch_args"] == ["--partition=gpu", "--gres=gpu:h100:1"]
+    assert validate_code == 0
+    assert warning_pairs == {("repo_dir", "ty2,ty3"), ("venv_dir", "ty2,ty3")}
+    assert "warning\tty2,ty3\trepo_dir\tremote repo_dir is shared by multiple nodes" in out
+    assert "warning\tty2,ty3\tvenv_dir\tremote venv_dir is shared by multiple nodes" in out
+
+
+def test_remote_profile_scaffold_supports_work_name_template(tmp_path: Path) -> None:
+    profile_path = tmp_path / "remote-nodes.json"
+
+    code, _, _ = _run(
+        "remote",
+        "profile",
+        "scaffold",
+        "--output",
+        str(profile_path),
+        "--direct",
+        "ty2=/mnt/sfs/zengzhengpeng",
+        "--direct",
+        "ty3=/mnt/sfs/zengzhengpeng",
+        "--work-name-template",
+        "proto_remote_{node}",
+    )
+    validate_code, validate_out, _ = _run("remote", "profile", "validate", "--profile", str(profile_path), "--json")
+
+    payload = json.loads(profile_path.read_text())
+    assert code == 0
+    assert [node["work_dir"] for node in payload["nodes"]] == [
+        "/mnt/sfs/zengzhengpeng/proto_remote_ty2",
+        "/mnt/sfs/zengzhengpeng/proto_remote_ty3",
+    ]
+    assert validate_code == 0
+    assert json.loads(validate_out)["ok"] is True
+
+
+def test_remote_profile_validate_returns_one_for_static_errors(tmp_path: Path) -> None:
+    profile_path = tmp_path / "bad-remote-nodes.json"
+    profile_path.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {"name": "ty", "host": "ty", "work_dir": "/remote/ty"},
+                    {"name": "ty", "host": "ty2", "work_dir": "relative/work"},
+                ]
+            }
+        )
+    )
+
+    code, out, _ = _run("remote", "profile", "validate", "--profile", str(profile_path), "--json")
+
+    payload = json.loads(out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert {"level": "error", "node_name": "ty", "field": "name", "message": "duplicate node name appears 2 times"} in payload[
+        "issues"
+    ]
+
+
+def test_remote_profile_validate_rejects_unsafe_node_name(tmp_path: Path) -> None:
+    profile_path = tmp_path / "bad-remote-nodes.json"
+    profile_path.write_text(json.dumps({"nodes": [{"name": "../escape", "host": "ty", "work_dir": "/remote/ty"}]}))
+
+    code, _, err = _run("remote", "profile", "validate", "--profile", str(profile_path), "--json")
+
+    assert code == 2
+    assert "RemoteNode.name" in err
+
+
+def test_remote_smoke_cli_uses_smoke_api(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="h100", host="h100", work_dir="/remote/h100", scheduler="slurm"),
+    ]
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class FakeReport:
+        def __init__(self) -> None:
+            self.ok = True
+            self.profile_issues = ()
+            self.preflight = {"h100": {"ok": True}}
+
+        def to_dict(self):
+            return {
+                "ok": True,
+                "preflight": self.preflight,
+                "manager_status": {"h100": "stopped"},
+                "diagnostics": {},
+                "rsync_pull_commands": [["rsync"]],
+            }
+
+    def fake_smoke(smoke_nodes, *, local_results_dir, timeout_sec):
+        calls.append((smoke_nodes, local_results_dir, timeout_sec))
+        return FakeReport()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "smoke_remote_nodes", fake_smoke)
+    monkeypatch.setattr(cli_mod.subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError()))
+
+    code, out, _ = _run(
+        "remote",
+        "smoke",
+        "--profile",
+        "nodes.json",
+        "--node",
+        "h100",
+        "--local-results-dir",
+        str(tmp_path / "results"),
+        "--timeout-sec",
+        "45",
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out)["ok"] is True
+    assert calls == [([nodes[1]], str(tmp_path / "results"), 45.0)]
+
+
+def test_remote_existing_plan_cli_renders_existing_command_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "input.fa"
+    input_path.write_text(">x\nAAAA\n")
+    collect_dir = tmp_path / "collect"
+    node = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+    )
+    monkeypatch.setattr(cli_mod.remote_exec, "load_existing_remote_command_nodes_json", lambda path: [node])
+
+    code, out, _ = _run(
+        "remote",
+        "existing",
+        "plan",
+        "--profile",
+        "existing.json",
+        "--node",
+        "ty",
+        "--input",
+        str(input_path),
+        "--run-id",
+        "run-cli",
+        "--local-collect-dir",
+        str(collect_dir),
+        "--json",
+    )
+
+    payload = json.loads(out)
+    assert code == 0
+    assert payload["node_name"] == "ty"
+    assert payload["remote_input_path"] == "/remote/existing/run-cli/input/input.fa"
+    assert payload["remote_output_dir"] == "/remote/existing/run-cli/output"
+    assert payload["commands"]["execute"][:4] == ["ssh", "ty", "bash", "-lc"]
+
+
+def test_remote_existing_run_cli_uses_existing_command_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "input.fa"
+    input_path.write_text(">x\nAAAA\n")
+    collect_dir = tmp_path / "collect"
+    node = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+    )
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_existing_remote_command_nodes_json", lambda path: [node])
+
+    class FakePlan:
+        node_name = "ty"
+        run_id = "run-cli"
+
+        def to_dict(self):
+            return {"node_name": self.node_name, "run_id": self.run_id}
+
+    class FakeResult:
+        plan = FakePlan()
+        collected_files = ("scores.json",)
+
+        def to_dict(self):
+            return {"plan": self.plan.to_dict(), "collected_files": list(self.collected_files)}
+
+    def fake_run(existing_node, *, local_input_path, run_id, local_collect_dir, timeout_sec):
+        calls.append((existing_node, local_input_path, run_id, local_collect_dir, timeout_sec))
+        return FakeResult()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "run_existing_remote_command", fake_run)
+
+    code, out, _ = _run(
+        "remote",
+        "existing",
+        "run",
+        "--profile",
+        "existing.json",
+        "--node",
+        "ty",
+        "--input",
+        str(input_path),
+        "--run-id",
+        "run-cli",
+        "--local-collect-dir",
+        str(collect_dir),
+        "--timeout-sec",
+        "12.5",
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {"plan": {"node_name": "ty", "run_id": "run-cli"}, "collected_files": ["scores.json"]}
+    assert calls == [(node, str(input_path), "run-cli", str(collect_dir), 12.5)]
+
+
+def test_remote_existing_launch_cli_runs_manifest_backed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One launch command should derive run paths and invoke the manager-backed API."""
+    input_path = tmp_path / "random_protein.fasta"
+    input_path.write_text(">one\nAAAA\n")
+    run_dir = tmp_path / "af3-run"
+    batch_node = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/manager",
+            worker_device="cuda:7",
+        ),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3",
+            command_argv=("/env/python", "/scripts/007_run_af3_direct.py", "-i", "{input}", "-o", "{output}"),
+            status="ready",
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+        ),
+    )
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_existing_remote_batch_nodes_json", lambda path: [batch_node])
+
+    class FakeResult:
+        def to_dict(self):
+            return {
+                "run_id": "af3-run",
+                "task_count": 1,
+                "assignment": {"ty": 1},
+                "summary": str(run_dir / "summary.json"),
+            }
+
+    def fake_launch(nodes, **kwargs):
+        calls.append((nodes, kwargs))
+        return FakeResult()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "launch_existing_remote_command_batch", fake_launch)
+
+    code, out, _ = _run(
+        "remote",
+        "existing",
+        "launch",
+        "alphafold3",
+        "--profile",
+        "af3-batch.json",
+        "--input",
+        str(input_path),
+        "--run-dir",
+        str(run_dir),
+        "--bucket-size",
+        "1",
+        "--slurm-group-size",
+        "10",
+        "--wait-poll-interval",
+        "7",
+        "--timeout-sec",
+        "86400",
+        "--remote-check-timeout-sec",
+        "120",
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {
+        "run_id": "af3-run",
+        "task_count": 1,
+        "assignment": {"ty": 1},
+        "summary": str(run_dir / "summary.json"),
+    }
+    assert calls == [
+        (
+            [batch_node],
+            {
+                "input_fasta": str(input_path),
+                "software": "alphafold3",
+                "run_dir": str(run_dir),
+                "bucket_size": 1,
+                "slurm_group_size": 10,
+                "wait_poll_interval": 7.0,
+                "timeout_sec": 86400.0,
+                "remote_check_timeout_sec": 120.0,
+            },
+        )
+    ]
+
+
+def test_remote_compute_cli_resolves_profile_and_runs_manifest_backed_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The simple command should resolve the maintained AF3 profile and reuse the existing launcher."""
+    input_path = tmp_path / "random_protein.fasta"
+    input_path.write_text(">one\nAAAA\n")
+    run_dir = tmp_path / "af3-run"
+    profile_path = tmp_path / "profiles" / "af3.json"
+    profile_path.parent.mkdir()
+    profile_path.write_text('{"profile_schema_version": 1, "nodes": []}\n')
+    registry_path = tmp_path / "runtime_registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "software": {
+                    "alphafold3": {
+                        "aliases": ["af3"],
+                        "status": "ready",
+                        "profile": "profiles/af3.json",
+                        "defaults": {
+                            "bucket_size": 1,
+                            "slurm_group_size": 10,
+                            "wait_poll_interval": 5,
+                            "timeout_sec": 7200,
+                            "remote_check_timeout_sec": 60,
+                        },
+                    }
+                },
+            }
+        )
+    )
+    batch_node = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/manager",
+            worker_device="cuda:7",
+        ),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3",
+            command_argv=("/env/python", "/scripts/007_run_af3_direct.py", "-i", "{input}", "-o", "{output}"),
+            status="ready",
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+        ),
+    )
+    calls = []
+    receipts = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_existing_remote_batch_nodes_json", lambda path: [batch_node])
+    monkeypatch.setattr(
+        cli_mod.remote_exec,
+        "write_remote_compute_receipt",
+        lambda payload, path: receipts.append((payload, path)),
+    )
+
+    class FakeResult:
+        def to_dict(self):
+            return {
+                "run_id": "af3-run",
+                "task_count": 1,
+                "assignment": {"ty": 1},
+                "summary": str(run_dir / "summary.json"),
+            }
+
+    def fake_launch(nodes, **kwargs):
+        calls.append((nodes, kwargs))
+        return FakeResult()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "launch_existing_remote_command_batch", fake_launch)
+
+    code, out, _ = _run(
+        "remote",
+        "compute",
+        "af3",
+        str(input_path),
+        str(run_dir),
+        "--registry",
+        str(registry_path),
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {
+        "software": "alphafold3",
+        "registry": str(registry_path.resolve()),
+        "profile": str(profile_path.resolve()),
+        "receipt": str(run_dir.resolve() / "compute.json"),
+        "run_id": "af3-run",
+        "task_count": 1,
+        "assignment": {"ty": 1},
+        "summary": str(run_dir / "summary.json"),
+    }
+    assert calls == [
+        (
+            [batch_node],
+            {
+                "input_fasta": input_path.resolve(),
+                "software": "alphafold3",
+                "run_dir": run_dir.resolve(),
+                "bucket_size": 1,
+                "slurm_group_size": 10,
+                "wait_poll_interval": 5.0,
+                "timeout_sec": 7200.0,
+                "remote_check_timeout_sec": 60.0,
+            },
+        )
+    ]
+    assert receipts == [(json.loads(out), run_dir.resolve() / "compute.json")]
+
+
+def test_remote_deploy_render_outputs_commands_without_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", repo_dir="/remote/repo"),
+        RemoteNode(name="h100", host="h100", work_dir="/remote/h100", repo_dir="/remote/repo-h100"),
+    ]
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    def fake_render(node, local_repo_dir):
+        calls.append((node.name, local_repo_dir))
+        return [["ssh", node.host, "mkdir"], ["rsync", str(local_repo_dir), node.repo_dir]]
+
+    class ForbiddenDeploymentClient:
+        def __init__(self):
+            raise AssertionError("render must not instantiate the deployment client")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "render_deploy_commands", fake_render)
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", ForbiddenDeploymentClient)
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "render",
+        "--profile",
+        "nodes.json",
+        "--node",
+        "ty",
+        "--local-repo-dir",
+        str(repo),
+        "--json",
+    )
+
+    payload = json.loads(out)
+    assert code == 0
+    assert payload["schema_version"] == 1
+    assert payload["ok"] is True
+    assert payload["local_repo_dir"] == str(repo.resolve())
+    assert payload["node_count"] == 1
+    assert payload["command_count"] == 2
+    assert payload["nodes"][0]["name"] == "ty"
+    assert [command["step"] for command in payload["nodes"][0]["commands"]] == ["mkdir", "rsync_upload"]
+    assert [command["argv"] for command in payload["nodes"][0]["commands"]] == [
+        ["ssh", "ty", "mkdir"],
+        ["rsync", str(repo), "/remote/repo"],
+    ]
+    assert calls == [("ty", str(repo))]
+
+    text_code, text_out, _ = _run(
+        "remote",
+        "deploy",
+        "render",
+        "--profile",
+        "nodes.json",
+        "--node",
+        "ty",
+        "--local-repo-dir",
+        str(repo),
+    )
+
+    assert text_code == 0
+    assert text_out.splitlines() == [
+        "deploy-command\tty\tssh ty mkdir",
+        f"deploy-command\tty\trsync {repo} /remote/repo",
+    ]
+    assert calls == [("ty", str(repo)), ("ty", str(repo))]
+
+
+def test_remote_deploy_render_reports_dirty_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    (repo / "tracked.txt").write_text("dirty\n")
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", repo_dir="/remote/repo")
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+    monkeypatch.setattr(cli_mod.remote_exec, "render_deploy_commands", lambda node, local_repo_dir: [["ssh", "ty"]])
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "render",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+        "--json",
+    )
+
+    payload = json.loads(out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert payload["command_count"] == 1
+    assert payload["local_checkout"]["dirty_count"] == 1
+    assert payload["blockers"] == ["local checkout has 1 tracked and 0 untracked changed paths"]
+
+
+def test_remote_deploy_render_canonical_profile_reports_shared_ty2_ty3_install_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    nodes = [
+        RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/sfs/home/zengzhengpeng/proto_remote_ty",
+            repo_dir="/sfs/home/zengzhengpeng/proto-tools",
+        ),
+        RemoteNode(
+            name="ty2",
+            host="ty2",
+            work_dir="/mnt/sfs/zengzhengpeng/proto_remote_ty2",
+            repo_dir="/mnt/sfs/zengzhengpeng/proto-tools",
+        ),
+        RemoteNode(
+            name="ty3",
+            host="ty3",
+            work_dir="/mnt/sfs/zengzhengpeng/proto_remote_ty3",
+            repo_dir="/mnt/sfs/zengzhengpeng/proto-tools",
+        ),
+        RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/public/home/zengzhengpeng/proto_remote_h100",
+            repo_dir="/public/home/zengzhengpeng/proto-tools",
+            scheduler="slurm",
+            sbatch_args=("--partition=gpu", "--gres=gpu:h100:1"),
+        ),
+    ]
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "render",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+        "--json",
+    )
+
+    payload = json.loads(out)
+    assert code == 1
+    assert payload["ok"] is False
+    assert "repo_dir /mnt/sfs/zengzhengpeng/proto-tools shared by ty2,ty3" in payload["blockers"]
+    assert "venv_dir /mnt/sfs/zengzhengpeng/proto-tools/.venv shared by ty2,ty3" in payload["blockers"]
+    assert "select one shared-root node or pass --allow-shared-install-root before deploy apply" in payload["actions"]
+
+
+def test_remote_deploy_apply_uses_deployment_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", repo_dir="/remote/repo"),
+        RemoteNode(name="h100", host="h100", work_dir="/remote/h100", repo_dir="/remote/repo-h100"),
+    ]
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class FakeCompleted:
+        returncode = 0
+
+    class FakeDeploymentClient:
+        def deploy_node(self, node, local_repo_dir):
+            calls.append((node.name, local_repo_dir))
+            return [FakeCompleted(), FakeCompleted(), FakeCompleted()]
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", FakeDeploymentClient)
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "apply",
+        "--profile",
+        "nodes.json",
+        "--node",
+        "h100",
+        "--local-repo-dir",
+        str(repo),
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {"h100": {"command_count": 3, "returncodes": [0, 0, 0]}}
+    assert calls == [("h100", str(repo))]
+
+
+def test_remote_deploy_apply_rejects_dirty_checkout_before_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    (repo / "untracked.txt").write_text("new\n")
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", repo_dir="/remote/repo")
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class ForbiddenDeploymentClient:
+        def __init__(self):
+            raise AssertionError("dirty checkout should be rejected before deployment")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", ForbiddenDeploymentClient)
+
+    code, _, err = _run(
+        "remote",
+        "deploy",
+        "apply",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+    )
+
+    assert code == 2
+    assert "local checkout has 0 tracked and 1 untracked changed paths" in err
+
+
+def test_remote_deploy_apply_can_allow_dirty_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    (repo / "untracked.txt").write_text("new\n")
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", repo_dir="/remote/repo")
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class FakeCompleted:
+        returncode = 0
+
+    class FakeDeploymentClient:
+        def deploy_node(self, deploy_node, local_repo_dir):
+            calls.append((deploy_node.name, local_repo_dir))
+            return [FakeCompleted()]
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", FakeDeploymentClient)
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "apply",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+        "--allow-dirty-checkout",
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {"ty": {"command_count": 1, "returncodes": [0]}}
+    assert calls == [("ty", str(repo))]
+
+
+def test_remote_deploy_apply_rejects_shared_install_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    nodes = [
+        RemoteNode(
+            name="ty2",
+            host="ty2",
+            work_dir="/remote/ty2",
+            repo_dir="/remote/shared-repo",
+            venv_dir="/remote/shared-repo/.venv",
+        ),
+        RemoteNode(
+            name="ty3",
+            host="ty3",
+            work_dir="/remote/ty3",
+            repo_dir="/remote/shared-repo",
+            venv_dir="/remote/shared-repo/.venv",
+        ),
+    ]
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class ForbiddenDeploymentClient:
+        def __init__(self):
+            raise AssertionError("shared roots should be rejected before deployment")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", ForbiddenDeploymentClient)
+
+    code, _, err = _run(
+        "remote",
+        "deploy",
+        "apply",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+    )
+
+    assert code == 2
+    assert "shared install roots" in err
+    assert "repo_dir /remote/shared-repo shared by ty2,ty3" in err
+    assert "venv_dir /remote/shared-repo/.venv shared by ty2,ty3" in err
+
+
+def test_remote_deploy_apply_can_allow_shared_install_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo = _init_git_repo(tmp_path / "repo")
+    nodes = [
+        RemoteNode(
+            name="ty2",
+            host="ty2",
+            work_dir="/remote/ty2",
+            repo_dir="/remote/shared-repo",
+            venv_dir="/remote/shared-repo/.venv",
+        ),
+        RemoteNode(
+            name="ty3",
+            host="ty3",
+            work_dir="/remote/ty3",
+            repo_dir="/remote/shared-repo",
+            venv_dir="/remote/shared-repo/.venv",
+        ),
+    ]
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class FakeCompleted:
+        returncode = 0
+
+    class FakeDeploymentClient:
+        def deploy_node(self, node, local_repo_dir):
+            calls.append((node.name, local_repo_dir))
+            return [FakeCompleted()]
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDeploymentClient", FakeDeploymentClient)
+
+    code, out, _ = _run(
+        "remote",
+        "deploy",
+        "apply",
+        "--profile",
+        "nodes.json",
+        "--local-repo-dir",
+        str(repo),
+        "--allow-shared-install-root",
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == {
+        "ty2": {"command_count": 1, "returncodes": [0]},
+        "ty3": {"command_count": 1, "returncodes": [0]},
+    }
+    assert calls == [("ty2", str(repo)), ("ty3", str(repo))]
+
+
+def test_remote_manager_status_uses_manager_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3"),
+    ]
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class FakeManagerClient:
+        def status_node(self, node):
+            return f"running:{node.name}"
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteManagerClient", FakeManagerClient)
+
+    code, out, _ = _run("remote", "manager", "status", "--profile", "nodes.json", "--json")
+
+    assert code == 0
+    assert json.loads(out) == {"ty": "running:ty", "ty3": "running:ty3"}
+
+
+@pytest.mark.parametrize(
+    ("verb", "extra_args", "expected_call", "expected_output"),
+    [
+        (
+            "start",
+            ["--poll-interval", "2", "--slurm-group-size", "7"],
+            ("start", "ty", 2.0, 7, 12.5),
+            {"ty": "started:ty"},
+        ),
+        ("status", [], ("status", "ty", 12.5), {"ty": "running:ty"}),
+        ("preflight", [], ("preflight", "ty", 12.5), {"ty": {"ok": True, "node": "ty"}}),
+        ("diagnostics", [], ("diagnostics", "ty", 12.5), {"ty": {"counts": {}, "node": "ty"}}),
+    ],
+)
+def test_remote_manager_commands_pass_timeout_to_client(
+    monkeypatch: pytest.MonkeyPatch,
+    verb: str,
+    extra_args: list[str],
+    expected_call: tuple,
+    expected_output: dict[str, object],
+) -> None:
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class FakeManagerClient:
+        def start_node(self, node, *, poll_interval, slurm_group_size, timeout_sec):
+            calls.append(("start", node.name, poll_interval, slurm_group_size, timeout_sec))
+            return f"started:{node.name}"
+
+        def status_node(self, node, *, timeout_sec):
+            calls.append(("status", node.name, timeout_sec))
+            return f"running:{node.name}"
+
+        def preflight_node(self, node, *, timeout_sec):
+            calls.append(("preflight", node.name, timeout_sec))
+            return {"ok": True, "node": node.name}
+
+        def diagnostics_node(self, node, *, timeout_sec):
+            calls.append(("diagnostics", node.name, timeout_sec))
+            return {"counts": {}, "node": node.name}
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteManagerClient", FakeManagerClient)
+
+    code, out, _ = _run(
+        "remote",
+        "manager",
+        verb,
+        "--profile",
+        "nodes.json",
+        "--timeout-sec",
+        "12.5",
+        *extra_args,
+        "--json",
+    )
+
+    assert code == 0
+    assert json.loads(out) == expected_output
+    assert calls == [expected_call]
+
+
+@pytest.mark.parametrize("verb", ["start", "preflight", "status", "diagnostics"])
+def test_remote_manager_commands_reject_static_profile_errors_before_client(
+    monkeypatch: pytest.MonkeyPatch,
+    verb: str,
+) -> None:
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/shared"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/shared"),
+    ]
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class ForbiddenManagerClient:
+        def __init__(self) -> None:
+            raise AssertionError("invalid profile should stop before manager client setup")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteManagerClient", ForbiddenManagerClient)
+
+    code, _, err = _run("remote", "manager", verb, "--profile", "nodes.json")
+
+    assert code == 2
+    assert "Invalid remote profile: ty,ty3 work_dir" in err
+    assert "remote work_dir is shared by multiple nodes" in err
+
+
+def test_remote_rsync_pull_start_uses_local_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class FakeRsyncClient:
+        def start(self, nodes, local_results_dir, *, pid_path, log_path, interval_sec):
+            calls.append((nodes, local_results_dir, pid_path, log_path, interval_sec))
+            return "started 123"
+
+    monkeypatch.setattr(cli_mod.remote_exec, "LocalRsyncPullClient", FakeRsyncClient)
+
+    code, out, _ = _run(
+        "remote",
+        "rsync",
+        "pull",
+        "start",
+        "--profile",
+        "nodes.json",
+        "--local-results-dir",
+        "remote_results",
+        "--pid-file",
+        "remote-rsync.pid",
+        "--log-file",
+        "remote-rsync.log",
+        "--interval-sec",
+        "3",
+    )
+
+    assert code == 0
+    assert out == "started 123\n"
+    assert calls == [([node], "remote_results", "remote-rsync.pid", "remote-rsync.log", 3)]
+
+
+def test_remote_rsync_pull_once_runs_rendered_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+    monkeypatch.setattr(
+        cli_mod.remote_exec,
+        "render_rsync_pull_commands",
+        lambda nodes, local_results_dir: [["rsync", "ty:/remote/ty/results/", str(Path(local_results_dir) / "ty")]],
+    )
+
+    def fake_run(cmd, check=False):
+        calls.append({"cmd": cmd, "check": check})
+
+    monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+
+    code, out, _ = _run(
+        "remote",
+        "rsync",
+        "pull",
+        "once",
+        "--profile",
+        "nodes.json",
+        "--local-results-dir",
+        "remote_results",
+    )
+
+    assert code == 0
+    assert out == ""
+    assert calls == [{"cmd": ["rsync", "ty:/remote/ty/results/", "remote_results/ty"], "check": True}]
+
+
+def test_remote_run_plan_writes_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    input_json = tmp_path / "input.json"
+    config_json = tmp_path / "config.json"
+    manifest_path = tmp_path / "run.manifest.json"
+    results_dir = tmp_path / "results"
+    input_json.write_text('{"sequences":["AA"]}\n')
+    config_json.write_text('{"device":"remote"}\n')
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class FakePlanner:
+        def __init__(self, nodes, bucket_size):
+            calls.append(("planner", nodes, bucket_size))
+
+        def build_plan(self, tool, inputs, config, *, run_id=None):
+            calls.append(("build", tool, inputs, config, run_id))
+            return object()
+
+    class FakeManifest:
+        run_id = "run-cli"
+        requests = (object(), object())
+        local_results_dir = str(results_dir.resolve())
+
+    def fake_from_plan(plan, *, nodes, bucket_size, local_results_dir):
+        calls.append(("manifest", nodes, bucket_size, str(local_results_dir)))
+        return FakeManifest()
+
+    def fake_write(manifest, path, *, overwrite=False):
+        calls.append(("write", manifest, path, overwrite))
+
+    def forbidden_diagnostics(nodes):
+        raise AssertionError("plan should not read diagnostics without the flag")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDispatchPlanner", FakePlanner)
+    monkeypatch.setattr(cli_mod.remote_exec.RemoteRunManifest, "from_plan", staticmethod(fake_from_plan))
+    monkeypatch.setattr(cli_mod.remote_exec, "write_remote_run_manifest", fake_write)
+    monkeypatch.setattr(cli_mod.remote_exec, "remote_run_diagnostics_backlog_loads", forbidden_diagnostics)
+
+    code, out, _ = _run(
+        "remote",
+        "run",
+        "plan",
+        "remote-mock",
+        "--profile",
+        "nodes.json",
+        "--input-json",
+        str(input_json),
+        "--config-json",
+        str(config_json),
+        "--bucket-size",
+        "50",
+        "--local-results-dir",
+        str(results_dir),
+        "--manifest",
+        str(manifest_path),
+        "--run-id",
+        "run-cli",
+    )
+
+    assert code == 0
+    assert "run_id\trun-cli" in out
+    assert calls[0] == ("planner", [node], 50)
+    assert calls[1] == ("build", "remote-mock", {"sequences": ["AA"]}, {"device": "remote"}, "run-cli")
+    assert calls[2] == ("manifest", [node], 50, str(results_dir.resolve()))
+    assert calls[3] == ("write", calls[3][1], str(manifest_path), False)
+
+
+def test_remote_run_plan_can_use_diagnostics_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3"),
+    ]
+    calls = []
+    input_json = tmp_path / "input.json"
+    manifest_path = tmp_path / "run.manifest.json"
+    results_dir = tmp_path / "results"
+    input_json.write_text('{"sequences":["AA","BB"]}\n')
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    def fake_backlog(backlog_nodes, *, timeout_sec=None):
+        calls.append(("backlog", backlog_nodes, timeout_sec))
+        return (
+            {"ty": {"counts": {"queue": 10}}, "ty3": {"counts": {}}},
+            {"ty": 10.0, "ty3": 0.0},
+        )
+
+    class FakePlanner:
+        def __init__(self, planner_nodes, bucket_size, *, initial_node_loads=None):
+            calls.append(("planner", planner_nodes, bucket_size, initial_node_loads))
+
+        def build_plan(self, tool, inputs, config, *, run_id=None):
+            calls.append(("build", tool, inputs, config, run_id))
+            return object()
+
+    class FakeManifest:
+        run_id = "run-cli"
+        requests = (object(),)
+        local_results_dir = str(results_dir.resolve())
+
+    def fake_from_plan(plan, *, nodes, bucket_size, local_results_dir):
+        calls.append(("manifest", nodes, bucket_size, str(local_results_dir)))
+        return FakeManifest()
+
+    def fake_write(manifest, path, *, overwrite=False):
+        calls.append(("write", manifest, path, overwrite))
+
+    monkeypatch.setattr(cli_mod.remote_exec, "remote_run_diagnostics_backlog_loads", fake_backlog)
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDispatchPlanner", FakePlanner)
+    monkeypatch.setattr(cli_mod.remote_exec.RemoteRunManifest, "from_plan", staticmethod(fake_from_plan))
+    monkeypatch.setattr(cli_mod.remote_exec, "write_remote_run_manifest", fake_write)
+
+    code, out, _ = _run(
+        "remote",
+        "run",
+        "plan",
+        "remote-mock",
+        "--profile",
+        "nodes.json",
+        "--input-json",
+        str(input_json),
+        "--bucket-size",
+        "50",
+        "--local-results-dir",
+        str(results_dir),
+        "--manifest",
+        str(manifest_path),
+        "--run-id",
+        "run-cli",
+        "--use-diagnostics-backlog",
+        "--remote-check-timeout-sec",
+        "12.5",
+        "--json",
+    )
+
+    payload = json.loads(out)
+    assert code == 0
+    assert payload["initial_node_loads"] == {"ty": 10.0, "ty3": 0.0}
+    assert payload["diagnostics"] == {"ty": {"counts": {"queue": 10}}, "ty3": {"counts": {}}}
+    assert calls[0] == ("backlog", nodes, 12.5)
+    assert calls[1] == ("planner", nodes, 50, {"ty": 10.0, "ty3": 0.0})
+    assert calls[2] == ("build", "remote-mock", {"sequences": ["AA", "BB"]}, None, "run-cli")
+    assert calls[3] == ("manifest", nodes, 50, str(results_dir.resolve()))
+    assert calls[4] == ("write", calls[4][1], str(manifest_path), False)
+
+
+def test_remote_run_plan_rejects_static_profile_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    nodes = [
+        RemoteNode(name="ty2", host="ty2", work_dir="/remote/shared"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/shared"),
+    ]
+    input_json = tmp_path / "input.json"
+    manifest_path = tmp_path / "run.manifest.json"
+    input_json.write_text('{"sequences":["AA"]}\n')
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: nodes)
+
+    class ForbiddenPlanner:
+        def __init__(self, nodes, bucket_size):
+            raise AssertionError("invalid profile should stop before planning")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "RemoteDispatchPlanner", ForbiddenPlanner)
+
+    code, _, err = _run(
+        "remote",
+        "run",
+        "plan",
+        "remote-mock",
+        "--profile",
+        "nodes.json",
+        "--input-json",
+        str(input_json),
+        "--bucket-size",
+        "50",
+        "--local-results-dir",
+        str(tmp_path / "results"),
+        "--manifest",
+        str(manifest_path),
+    )
+
+    assert code == 2
+    assert "Invalid remote profile: ty2,ty3 work_dir" in err
+    assert "remote work_dir is shared by multiple nodes" in err
+    assert not manifest_path.exists()
+
+
+def test_remote_run_launch_uses_launch_api(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    input_json = tmp_path / "input.json"
+    config_json = tmp_path / "config.json"
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+    results_dir = tmp_path / "results"
+    input_json.write_text('{"sequences":["AA"]}\n')
+    config_json.write_text('{"device":"remote"}\n')
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_nodes_json", lambda path: [node])
+
+    class FakeLaunchResult:
+        def __init__(self) -> None:
+            self.run_id = "run-cli"
+            self.manifest_path = str(manifest_path)
+            self.output_path = str(output_path)
+            self.bucket_count = 1
+
+        def to_dict(self):
+            return {"run_id": self.run_id, "manifest": self.manifest_path, "output": self.output_path}
+
+    def fake_launch(tool, nodes, inputs, config, **kwargs):
+        calls.append((tool, nodes, inputs, config, kwargs))
+        return FakeLaunchResult()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "launch_remote_run", fake_launch)
+
+    code, out, _ = _run(
+        "remote",
+        "run",
+        "launch",
+        "remote-mock",
+        "--profile",
+        "nodes.json",
+        "--input-json",
+        str(input_json),
+        "--config-json",
+        str(config_json),
+        "--bucket-size",
+        "50",
+        "--local-results-dir",
+        str(results_dir),
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+        "--run-id",
+        "run-cli",
+        "--overwrite",
+        "--manager-poll-interval",
+        "2",
+        "--slurm-group-size",
+        "7",
+        "--wait-poll-interval",
+        "3",
+        "--timeout-sec",
+        "30",
+        "--rsync-mode",
+        "background",
+        "--rsync-pid-file",
+        "remote-rsync.pid",
+        "--rsync-log-file",
+        "remote-rsync.log",
+        "--rsync-interval-sec",
+        "4",
+        "--use-diagnostics-backlog",
+        "--remote-check-timeout-sec",
+        "12.5",
+    )
+
+    assert code == 0
+    assert out.splitlines() == [
+        "completed\trun-cli",
+        f"manifest\t{manifest_path}",
+        f"output\t{output_path}",
+        "bucket_count\t1",
+    ]
+    assert calls == [
+        (
+            "remote-mock",
+            [node],
+            {"sequences": ["AA"]},
+            {"device": "remote"},
+            {
+                "bucket_size": 50,
+                "local_results_dir": str(results_dir),
+                "manifest_path": str(manifest_path),
+                "output_path": str(output_path),
+                "run_id": "run-cli",
+                "overwrite": True,
+                "manager_poll_interval": 2.0,
+                "slurm_group_size": 7,
+                "wait_poll_interval": 3.0,
+                "timeout_sec": 30.0,
+                "rsync_mode": "background",
+                "rsync_pid_path": "remote-rsync.pid",
+                "rsync_log_path": "remote-rsync.log",
+                "rsync_interval_sec": 4,
+                "use_diagnostics_backlog": True,
+                "overwrite_output": False,
+                "remote_check_timeout_sec": 12.5,
+            },
+        )
+    ]
+
+
+def test_remote_run_resume_uses_manifest_resume_api(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls = []
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+
+    class FakeManifest:
+        run_id = "run-cli"
+
+    class FakeResumeResult:
+        def __init__(self) -> None:
+            self.run_id = "run-cli"
+            self.manifest_path = str(manifest_path)
+            self.output_path = str(output_path)
+            self.bucket_count = 1
+
+        def to_dict(self):
+            return {"run_id": self.run_id, "manifest": self.manifest_path, "output": self.output_path}
+
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_run_manifest", lambda path: FakeManifest())
+
+    def fake_resume(manifest, **kwargs):
+        calls.append((manifest.run_id, kwargs))
+        return FakeResumeResult()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "resume_remote_run_manifest", fake_resume)
+
+    code, out, _ = _run(
+        "remote",
+        "run",
+        "resume",
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+        "--manager-poll-interval",
+        "2",
+        "--slurm-group-size",
+        "7",
+        "--wait-poll-interval",
+        "3",
+        "--timeout-sec",
+        "30",
+        "--rsync-mode",
+        "background",
+        "--rsync-pid-file",
+        "remote-rsync.pid",
+        "--rsync-log-file",
+        "remote-rsync.log",
+        "--rsync-interval-sec",
+        "4",
+        "--overwrite-output",
+        "--remote-check-timeout-sec",
+        "12.5",
+    )
+
+    assert code == 0
+    assert out.splitlines() == [
+        "completed\trun-cli",
+        f"manifest\t{manifest_path}",
+        f"output\t{output_path}",
+        "bucket_count\t1",
+    ]
+    assert calls == [
+        (
+            "run-cli",
+            {
+                "manifest_path": str(manifest_path),
+                "output_path": str(output_path),
+                "manager_poll_interval": 2.0,
+                "slurm_group_size": 7,
+                "wait_poll_interval": 3.0,
+                "timeout_sec": 30.0,
+                "rsync_mode": "background",
+                "rsync_pid_path": "remote-rsync.pid",
+                "rsync_log_path": "remote-rsync.log",
+                "rsync_interval_sec": 4,
+                "overwrite_output": True,
+                "remote_check_timeout_sec": 12.5,
+            },
+        )
+    ]
+
+
+def test_remote_run_submit_wait_collect_use_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls = []
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+
+    class FakeManifest:
+        run_id = "run-cli"
+
+    class FakeOutput:
+        def model_dump_json(self, indent=None):
+            assert indent == 2
+            return '{"results":["ok"]}'
+
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_run_manifest", lambda path: FakeManifest())
+
+    def fake_submit(manifest):
+        calls.append(("submit", manifest.run_id))
+        return ["/remote/queue/bucket-00000.json"]
+
+    def fake_wait(manifest, *, poll_interval, timeout_sec, pull_results, rsync_pid_path, rsync_log_path):
+        calls.append(("wait", manifest.run_id, poll_interval, timeout_sec, pull_results, rsync_pid_path, rsync_log_path))
+
+    def fake_collect(manifest):
+        calls.append(("collect", manifest.run_id))
+        return FakeOutput()
+
+    monkeypatch.setattr(cli_mod.remote_exec, "submit_remote_run_manifest", fake_submit)
+    monkeypatch.setattr(cli_mod.remote_exec, "wait_remote_run_manifest", fake_wait)
+    monkeypatch.setattr(cli_mod.remote_exec, "collect_remote_run_manifest", fake_collect)
+
+    submit_code, submit_out, _ = _run("remote", "run", "submit", "--manifest", str(manifest_path))
+    wait_code, wait_out, _ = _run(
+        "remote",
+        "run",
+        "wait",
+        "--manifest",
+        str(manifest_path),
+        "--poll-interval",
+        "2.5",
+        "--timeout-sec",
+        "10",
+        "--no-pull",
+        "--rsync-pid-file",
+        "remote-rsync.pid",
+        "--rsync-log-file",
+        "remote-rsync.log",
+    )
+    collect_code, collect_out, _ = _run(
+        "remote",
+        "run",
+        "collect",
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert submit_code == 0
+    assert submit_out == "submitted\trun-cli\tbucket_count=1\n"
+    assert wait_code == 0
+    assert wait_out == "completed\trun-cli\n"
+    assert collect_code == 0
+    assert collect_out == f"output\t{output_path}\n"
+    assert json.loads(output_path.read_text()) == {"results": ["ok"]}
+    assert calls == [
+        ("submit", "run-cli"),
+        ("wait", "run-cli", 2.5, 10.0, False, "remote-rsync.pid", "remote-rsync.log"),
+        ("collect", "run-cli"),
+    ]
+
+
+def test_remote_run_collect_rejects_existing_output_before_collect(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+    output_path.write_text("sentinel\n")
+
+    def fake_collect(manifest):
+        raise AssertionError("collect should not run")
+
+    monkeypatch.setattr(cli_mod.remote_exec, "collect_remote_run_manifest", fake_collect)
+
+    code, _, err = _run(
+        "remote",
+        "run",
+        "collect",
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+    )
+
+    assert code == 2
+    assert "Remote run output already exists" in err
+    assert output_path.read_text() == "sentinel\n"
+
+
+def test_remote_run_collect_overwrite_output_replaces_existing_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+    output_path.write_text("sentinel\n")
+
+    class FakeManifest:
+        run_id = "run-cli"
+
+    class FakeOutput:
+        def model_dump_json(self, indent=None):
+            assert indent == 2
+            return '{"results":["ok"]}'
+
+    monkeypatch.setattr(cli_mod.remote_exec, "load_remote_run_manifest", lambda path: FakeManifest())
+    monkeypatch.setattr(cli_mod.remote_exec, "collect_remote_run_manifest", lambda manifest: FakeOutput())
+
+    code, out, _ = _run(
+        "remote",
+        "run",
+        "collect",
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(output_path),
+        "--overwrite-output",
+    )
+
+    assert code == 0
+    assert out == f"output\t{output_path}\n"
+    assert json.loads(output_path.read_text()) == {"results": ["ok"]}
 
 
 # ── Per-tool docs ───────────────────────────────────────────────────────────

--- a/tests/tool_infra_tests/test_remote_execution.py
+++ b/tests/tool_infra_tests/test_remote_execution.py
@@ -1,0 +1,4835 @@
+"""Tests for remote execution planning and manager helpers."""
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import Field
+
+from proto_tools.tools.tool_registry import ToolRegistry
+from proto_tools.utils import BaseConfig, ConfigField
+from proto_tools.utils import remote_execution as remote_execution_mod
+from proto_tools.utils.remote_execution import (
+    ExistingRemoteBatchNode,
+    ExistingRemoteCommandNode,
+    LocalRsyncPullClient,
+    RemoteDeploymentClient,
+    RemoteDispatchPlanner,
+    RemoteManagerClient,
+    RemoteNode,
+    RemoteRunManifest,
+    RemoteSubmissionClient,
+    RemoteToolDispatcher,
+    build_deploy_render_report,
+    collect_existing_remote_command_manifest,
+    collect_plan_outputs,
+    collect_remote_run_manifest,
+    execute_request,
+    execute_request_file,
+    inspect_local_checkout,
+    launch_remote_run,
+    load_existing_remote_batch_nodes_json,
+    load_existing_remote_command_nodes_json,
+    load_remote_nodes_json,
+    load_remote_run_manifest,
+    plan_existing_remote_command_batch,
+    read_fasta_records,
+    reconcile_submitted_slurm_jobs,
+    remote_run_diagnostics_backlog_loads,
+    render_continuous_rsync_script,
+    render_deploy_commands,
+    render_existing_artifact_pull_commands,
+    render_existing_remote_shell_command,
+    render_manager_diagnostics_script,
+    render_manager_loop_command,
+    render_manager_status_script,
+    render_preflight_script,
+    render_rsync_pull_commands,
+    render_rsync_pull_status_script,
+    render_start_manager_script,
+    render_start_rsync_pull_script,
+    render_stop_rsync_pull_script,
+    resume_remote_run_manifest,
+    run_existing_remote_command,
+    run_manager_loop,
+    run_manager_once,
+    scaffold_remote_node,
+    select_existing_remote_command_node,
+    smoke_remote_nodes,
+    submit_remote_run_manifest,
+    validate_remote_nodes,
+    wait_remote_run_manifest,
+    write_existing_remote_batch_nodes_json,
+    write_existing_remote_command_nodes_json,
+    write_remote_nodes_json,
+    write_remote_run_manifest,
+)
+from proto_tools.utils.tool_io import BaseToolInput
+from tests.tool_infra_tests.test_export_functionality import MockToolOutputBase
+
+
+@pytest.fixture
+def clean_registry():
+    """Provide a clean registry for each test."""
+    original_registry = ToolRegistry._registry.copy()
+    original_backend = ToolRegistry._dispatch_backend
+    ToolRegistry._registry.clear()
+    ToolRegistry.clear_dispatch_backend()
+    yield ToolRegistry
+    ToolRegistry._registry = original_registry
+    ToolRegistry._dispatch_backend = original_backend
+
+
+class RemoteMockInput(BaseToolInput):
+    """Mock iterable input with sequence-length scheduling cost."""
+
+    sequences: list[str] = Field(description="Sequences to process")
+
+    @classmethod
+    def item_cost(cls, item):
+        return float(len(item))
+
+
+class RemoteMockConfig(BaseConfig):
+    """Mock remote config."""
+
+    device: str = ConfigField(default="remote", title="Device", description="Execution device")
+    suffix: str = ConfigField(default="x", title="Suffix", description="Suffix to append")
+
+
+class RemoteMockOutput(MockToolOutputBase):
+    """Mock iterable output."""
+
+    results: list[str] = Field(description="Processed results")
+
+
+def _register_remote_mock_tool(registry):
+    """Register a mock iterable tool."""
+
+    @registry.register(
+        key="remote-mock",
+        label="Remote Mock",
+        category="testing",
+        input_class=RemoteMockInput,
+        config_class=RemoteMockConfig,
+        output_class=RemoteMockOutput,
+        description="Mock remote iterable tool",
+        iterable_input_fields=["sequences"],
+        iterable_output_field="results",
+    )
+    def run_remote_mock(inputs, config=None, instance=None):
+        del instance
+        return RemoteMockOutput(results=[f"{seq}:{config.device}:{config.suffix}" for seq in inputs.sequences])
+
+    return run_remote_mock
+
+
+@pytest.mark.parametrize("name", ["", "../x", "/x", ".", "..", ".hidden", "a/b", r"a\b"])
+def test_remote_node_rejects_unsafe_path_segment_names(name: str) -> None:
+    """Node names become local result path components and must be single safe segments."""
+    with pytest.raises(ValueError, match=r"RemoteNode\.name"):
+        RemoteNode(name=name, host="ty", work_dir="/remote/ty")
+
+
+def test_remote_node_accepts_safe_path_segment_name() -> None:
+    """Node names can keep common run-label characters."""
+    node = RemoteNode(name="ty-01.a_b", host="ty", work_dir="/remote/ty")
+
+    assert node.name == "ty-01.a_b"
+
+
+def test_existing_remote_command_profile_roundtrip(tmp_path: Path) -> None:
+    """Existing-command profiles should roundtrip without using manager fields."""
+    profile_path = tmp_path / "existing-nodes.json"
+    nodes = [
+        ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/existing",
+            command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            env={"CUDA_VISIBLE_DEVICES": "0"},
+            gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+            ssh_args=("-p", "2222"),
+            rsync_ssh_args=("-i", "key.pem"),
+        )
+    ]
+
+    write_existing_remote_command_nodes_json(nodes, profile_path)
+    loaded = load_existing_remote_command_nodes_json(profile_path)
+
+    assert loaded == nodes
+    payload = json.loads(profile_path.read_text())
+    assert payload["profile_schema_version"] == 1
+    assert payload["nodes"][0]["command_argv"] == [
+        "/env/bin/python",
+        "/scripts/run.py",
+        "-i",
+        "{input}",
+        "-o",
+        "{output}",
+    ]
+    assert select_existing_remote_command_node(loaded, "ty") == nodes[0]
+
+
+def test_existing_remote_batch_profile_roundtrip(tmp_path: Path) -> None:
+    """One profile file should freeze both manager and existing-command contracts."""
+    profile_path = tmp_path / "af3-batch.json"
+    node = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/manager",
+            worker_device="cuda:7",
+        ),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3",
+            command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            status="ready",
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+            env={"CUDA_VISIBLE_DEVICES": "7"},
+            gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+        ),
+    )
+
+    write_existing_remote_batch_nodes_json([node], profile_path)
+
+    assert load_existing_remote_batch_nodes_json(profile_path) == [node]
+    payload = json.loads(profile_path.read_text())
+    assert payload["nodes"][0]["manager"]["worker_device"] == "cuda:7"
+    assert payload["nodes"][0]["command"]["software"] == "alphafold3"
+    assert payload["nodes"][0]["command"]["required_stdout_patterns"] == ["CudaDevice"]
+    assert payload["nodes"][0]["command"]["gpu_admission"] == {
+        "max_memory_used_mib": 1024,
+        "max_utilization_percent": 5,
+    }
+
+
+def test_existing_remote_command_batch_plans_thirty_fasta_records_by_weight(tmp_path: Path) -> None:
+    """The real 30-record shape should freeze one GPU command per weighted assignment."""
+    fasta = tmp_path / "random_protein.fasta"
+    fasta.write_text("".join(f">random_protein_{idx}\n{'A' * 50}\n" for idx in range(1, 31)))
+    manager_nodes = [
+        RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/sfs/home/user/proto_remote_af3_ty",
+            weight=1,
+            worker_device="cuda:7",
+        ),
+        RemoteNode(
+            name="ty3",
+            host="ty3",
+            work_dir="/mnt/sfs/user/proto_remote_af3_ty3",
+            weight=1,
+            worker_device="cuda:0",
+        ),
+        RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/public/home/user/proto_remote_af3_h100",
+            weight=3,
+            scheduler="slurm",
+            worker_device="cuda",
+            sbatch_args=("--partition=gpu_special", "--gres=gpu:h100:1"),
+            max_active_slurm_jobs=2,
+        ),
+    ]
+    command_nodes = [
+        ExistingRemoteCommandNode(
+            name=node.name,
+            host=node.host,
+            work_dir=f"/{node.name}/remote_runs/alphafold3",
+            command_argv=(f"/{node.name}/env/bin/python", f"/{node.name}/007_run_af3_direct.py", "-i", "{input}", "-o", "{output}"),
+            env={} if node.name == "h100" else {"CUDA_VISIBLE_DEVICES": "7" if node.name == "ty" else "0"},
+            gpu_admission=(
+                None
+                if node.name == "h100"
+                else {"max_utilization_percent": 5, "max_memory_used_mib": 1024}
+            ),
+            status="ready",
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif", "**/*_summary_confidences.json"),
+            required_stdout_patterns=("CudaDevice",),
+        )
+        for node in manager_nodes
+    ]
+    nodes = [
+        ExistingRemoteBatchNode(manager=manager, command=command)
+        for manager, command in zip(manager_nodes, command_nodes, strict=True)
+    ]
+
+    records = read_fasta_records(fasta)
+    manifest = plan_existing_remote_command_batch(
+        nodes,
+        input_fasta=fasta,
+        run_id="af3-random30",
+        bucket_size=1,
+        local_results_dir=tmp_path / "results",
+        software="alphafold3",
+    )
+
+    assert len(records) == 30
+    assert records[0].header == "random_protein_1"
+    assert records[0].sequence == "A" * 50
+    counts = {
+        node_name: sum(request.node_name == node_name for request in manifest.requests)
+        for node_name in ("ty", "ty3", "h100")
+    }
+    assert counts == {"ty": 6, "ty3": 6, "h100": 18}
+    assert all(request.request["request_kind"] == "existing_command" for request in manifest.requests)
+    assert all("device" not in request.request for request in manifest.requests)
+    assert len(
+        {
+            task["artifact_dir"]
+            for request in manifest.requests
+            for task in request.request["existing_command"]["tasks"]
+        }
+    ) == 30
+    first = manifest.requests[0].request["existing_command"]
+    assert first["env"] == {"CUDA_VISIBLE_DEVICES": "7"}
+    assert first["resource_admission"] == {
+        "kind": "cuda_idle",
+        "gpu_id": "7",
+        "max_utilization_percent": 5,
+        "max_memory_used_mib": 1024,
+    }
+    assert first["required_stdout_patterns"] == ["CudaDevice"]
+    assert first["tasks"][0]["input_text"] == f">random_protein_1\n{'A' * 50}\n"
+
+
+def test_existing_remote_command_batch_rejects_partial_profile(tmp_path: Path) -> None:
+    """A partial runtime must stop planning before any SSH side effect."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty3", host="ty3", work_dir="/remote/manager", worker_device="cuda:0")
+    command = ExistingRemoteCommandNode(
+        name="ty3",
+        host="ty3",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="partial",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+    )
+
+    with pytest.raises(ValueError, match="status='partial'"):
+        plan_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            run_id="partial-run",
+            bucket_size=1,
+            local_results_dir=tmp_path / "results",
+            software="alphafold3",
+        )
+
+
+def test_existing_remote_command_batch_requires_cuda_stdout_evidence_for_af3(tmp_path: Path) -> None:
+    """AF3 batch planning must reject profiles that cannot prove CUDA execution."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:7")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        env={"CUDA_VISIBLE_DEVICES": "7"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+
+    with pytest.raises(ValueError, match=r"required_stdout_patterns.*CudaDevice"):
+        plan_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            run_id="unsafe-af3",
+            bucket_size=1,
+            local_results_dir=tmp_path / "results",
+            software="alphafold3",
+        )
+
+
+def test_resolve_remote_compute_config_uses_alias_relative_profile_and_defaults(tmp_path: Path) -> None:
+    """The hand-compute registry should resolve one ready profile without caller path knowledge."""
+    profile = tmp_path / "profiles" / "af3.json"
+    profile.parent.mkdir()
+    profile.write_text('{"profile_schema_version": 1, "nodes": []}\n')
+    registry = tmp_path / "runtime_registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "software": {
+                    "alphafold3": {
+                        "aliases": ["af3"],
+                        "status": "ready",
+                        "profile": "profiles/af3.json",
+                        "defaults": {
+                            "bucket_size": 1,
+                            "slurm_group_size": 20,
+                            "wait_poll_interval": 2,
+                            "timeout_sec": 7200,
+                            "remote_check_timeout_sec": 60,
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    config = remote_execution_mod.resolve_remote_compute_config("af3", registry_path=registry)
+
+    assert config.software == "alphafold3"
+    assert config.registry_path == registry.resolve()
+    assert config.profile_path == profile.resolve()
+    assert config.bucket_size == 1
+    assert config.slurm_group_size == 20
+    assert config.wait_poll_interval == 2.0
+    assert config.timeout_sec == 7200.0
+    assert config.remote_check_timeout_sec == 60.0
+
+
+def test_resolve_remote_compute_config_finds_bundled_codex_skill(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / "codex"
+    registry = (
+        codex_home
+        / "skills"
+        / "02_molaison"
+        / "hand-compute"
+        / "references"
+        / "runtime_registry.json"
+    )
+    registry.parent.mkdir(parents=True)
+    profile = registry.parent / "profiles" / "af3.json"
+    profile.parent.mkdir()
+    profile.write_text('{"profile_schema_version": 1, "nodes": []}\n')
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "software": {
+                    "alphafold3": {
+                        "aliases": ["af3"],
+                        "status": "ready",
+                        "profile": "profiles/af3.json",
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.delenv("PROTO_TOOLS_REMOTE_COMPUTE_REGISTRY", raising=False)
+
+    config = remote_execution_mod.resolve_remote_compute_config("af3")
+
+    assert config.registry_path == registry.resolve()
+    assert config.profile_path == profile.resolve()
+
+
+def test_resolve_remote_compute_config_rejects_non_ready_runtime(tmp_path: Path) -> None:
+    """A configured runtime must never silently fall back from blocked to another execution mode."""
+    registry = tmp_path / "runtime_registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "software": {
+                    "alphafold3": {
+                        "aliases": ["af3"],
+                        "status": "blocked",
+                        "profile": "profiles/af3.json",
+                    }
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"not ready.*status='blocked'"):
+        remote_execution_mod.resolve_remote_compute_config("af3", registry_path=registry)
+
+
+def test_resolve_remote_compute_config_rejects_non_finite_timeout(tmp_path: Path) -> None:
+    """Registry timing values must be finite so foreground supervision cannot hang unpredictably."""
+    profile = tmp_path / "af3.json"
+    profile.write_text('{"profile_schema_version": 1, "nodes": []}\n')
+    registry = tmp_path / "runtime_registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "software": {
+                    "alphafold3": {
+                        "aliases": ["af3"],
+                        "status": "ready",
+                        "profile": "af3.json",
+                        "defaults": {"timeout_sec": float("nan")},
+                    }
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match=r"defaults.timeout_sec must be positive or null"):
+        remote_execution_mod.resolve_remote_compute_config("af3", registry_path=registry)
+
+
+def test_existing_remote_command_batch_launch_rejects_cpu_gpu_profile(tmp_path: Path) -> None:
+    """The old CPU substrate profile must never launch AlphaFold3."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cpu")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+    )
+
+    with pytest.raises(ValueError, match="must use a CUDA worker_device"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=tmp_path / "run",
+        )
+
+
+def test_existing_remote_command_batch_launch_rejects_cpu_gpu_profile_for_af3_alias(tmp_path: Path) -> None:
+    """The short AF3 name must enforce the same GPU-only contract as alphafold3."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cpu")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="af3",
+        required_artifacts=("**/*_model.cif",),
+    )
+
+    with pytest.raises(ValueError, match="must use a CUDA worker_device"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            software="af3",
+            run_dir=tmp_path / "run",
+        )
+
+
+def test_existing_remote_command_batch_launch_creates_result_pull_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline result rsync must receive an existing node destination directory."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:7")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        required_stdout_patterns=("CudaDevice",),
+        env={"CUDA_VISIBLE_DEVICES": "7"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+    monkeypatch.setattr(
+        remote_execution_mod,
+        "_manager_preflight_node",
+        lambda *args, **kwargs: {"ok": True},
+    )
+    monkeypatch.setattr(
+        remote_execution_mod,
+        "_manager_start_node",
+        lambda *args, **kwargs: "running",
+    )
+    monkeypatch.setattr(remote_execution_mod, "submit_remote_run_manifest", lambda *args, **kwargs: [])
+
+    def assert_pull_destination(manifest, **kwargs):
+        del kwargs
+        assert (Path(manifest.local_results_dir) / "ty").is_dir()
+        raise RuntimeError("stop after result directory assertion")
+
+    monkeypatch.setattr(remote_execution_mod, "wait_remote_run_manifest", assert_pull_destination)
+
+    def successful_preflight_runner(command_argv, **kwargs):
+        if any("utilization.gpu,memory.used" in part for part in command_argv):
+            return subprocess.CompletedProcess(command_argv, 0, stdout="0, 0\n", stderr="")
+        return subprocess.CompletedProcess(command_argv, 0, stdout="runtime-ready\n", stderr="")
+
+    with pytest.raises(RuntimeError, match="stop after result directory assertion"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=tmp_path / "run",
+            runner=successful_preflight_runner,
+        )
+
+
+def test_existing_remote_command_batch_launch_resumes_matching_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-running launch should resume the exact frozen manifest without duplicate work."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    run_dir = tmp_path / "run"
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:7")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        required_stdout_patterns=("CudaDevice",),
+        env={"CUDA_VISIBLE_DEVICES": "7"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+    batch_nodes = [ExistingRemoteBatchNode(manager=manager, command=command)]
+    frozen = plan_existing_remote_command_batch(
+        batch_nodes,
+        input_fasta=fasta,
+        run_id="run",
+        bucket_size=1,
+        local_results_dir=run_dir / "remote_results",
+        software="alphafold3",
+    )
+    write_remote_run_manifest(frozen, run_dir / "run.manifest.json")
+    monkeypatch.setattr(remote_execution_mod, "_manager_preflight_node", lambda *args, **kwargs: {"ok": True})
+    monkeypatch.setattr(remote_execution_mod, "_manager_start_node", lambda *args, **kwargs: "running")
+    monkeypatch.setattr(remote_execution_mod, "submit_remote_run_manifest", lambda *args, **kwargs: [])
+
+    def assert_resumed(manifest, **kwargs):
+        del kwargs
+        assert manifest.to_dict() == frozen.to_dict()
+        raise RuntimeError("matching manifest resumed")
+
+    monkeypatch.setattr(remote_execution_mod, "wait_remote_run_manifest", assert_resumed)
+
+    def successful_preflight_runner(command_argv, **kwargs):
+        if any("utilization.gpu,memory.used" in part for part in command_argv):
+            return subprocess.CompletedProcess(command_argv, 0, stdout="0, 0\n", stderr="")
+        return subprocess.CompletedProcess(command_argv, 0, stdout="runtime-ready\n", stderr="")
+
+    with pytest.raises(RuntimeError, match="matching manifest resumed"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            batch_nodes,
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=run_dir,
+            runner=successful_preflight_runner,
+        )
+
+
+def test_existing_remote_command_batch_launch_rejects_mismatched_existing_manifest(tmp_path: Path) -> None:
+    """An existing run directory must not be resumed with changed scientific inputs."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    run_dir = tmp_path / "run"
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:7")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        required_stdout_patterns=("CudaDevice",),
+        env={"CUDA_VISIBLE_DEVICES": "7"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+    batch_nodes = [ExistingRemoteBatchNode(manager=manager, command=command)]
+    frozen = plan_existing_remote_command_batch(
+        batch_nodes,
+        input_fasta=fasta,
+        run_id="run",
+        bucket_size=1,
+        local_results_dir=run_dir / "remote_results",
+        software="alphafold3",
+    )
+    write_remote_run_manifest(frozen, run_dir / "run.manifest.json")
+    fasta.write_text(">one\nBBBB\n")
+
+    with pytest.raises(ValueError, match="does not match the existing manifest"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            batch_nodes,
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=run_dir,
+            runner=lambda *args, **kwargs: pytest.fail("SSH must not run for a mismatched manifest"),
+        )
+
+
+def test_existing_batch_launch_adopts_empty_run_dir_and_freezes_manifest_before_manager(
+    tmp_path: Path,
+) -> None:
+    """A preflight retry must use the manifest written before manager state changes."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    run_dir = tmp_path / "run"
+    (run_dir / "remote_results").mkdir(parents=True)
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:0")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        required_stdout_patterns=("CudaDevice",),
+        env={"CUDA_VISIBLE_DEVICES": "0"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+
+    class FailingManager:
+        def preflight_node(self, node, **kwargs):
+            assert (run_dir / "run.manifest.json").is_file()
+            raise RuntimeError("manager preflight stopped")
+
+    def fake_runner(command_argv, **kwargs):
+        if any("utilization.gpu,memory.used" in part for part in command_argv):
+            return subprocess.CompletedProcess(command_argv, 0, stdout="0, 0\n", stderr="")
+        return subprocess.CompletedProcess(command_argv, 0, stdout="runtime-ready\n", stderr="")
+
+    with pytest.raises(RuntimeError, match="manager preflight stopped"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [ExistingRemoteBatchNode(manager=manager, command=command)],
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=run_dir,
+            manager_client=FailingManager(),
+            runner=fake_runner,
+        )
+
+    frozen = load_remote_run_manifest(run_dir / "run.manifest.json")
+    assert frozen.run_id == "run"
+    assert len(frozen.requests) == 1
+
+
+def test_existing_batch_launch_assigns_new_work_only_to_live_admitted_nodes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A busy direct GPU must not receive new buckets when a Slurm GPU node is ready."""
+    fasta = tmp_path / "four.fasta"
+    fasta.write_text("".join(f">p{index}\nAAAA\n" for index in range(4)))
+    direct = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/manager-ty",
+            worker_device="cuda:7",
+        ),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3-ty",
+            command_argv=("/ty/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+            env={"CUDA_VISIBLE_DEVICES": "7"},
+            gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+        ),
+    )
+    slurm = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/manager-h100",
+            scheduler="slurm",
+            worker_device="cuda",
+            sbatch_args=("--partition=gpu_special", "--gres=gpu:h100:1"),
+            max_active_slurm_jobs=2,
+        ),
+        command=ExistingRemoteCommandNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/af3-h100",
+            command_argv=("/h100/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+        ),
+    )
+
+    class FakeManager:
+        def preflight_node(self, node, **kwargs):
+            return {"node": node.name, "ok": True}
+
+        def start_node(self, node, **kwargs):
+            return f"running {node.name}"
+
+    def fake_runner(command, **kwargs):
+        del kwargs
+        if any("utilization.gpu,memory.used" in part for part in command):
+            return subprocess.CompletedProcess(command, 0, stdout="100, 6302\n", stderr="")
+        if "sbatch --test-only" in command[-1]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="sbatch: Job 1 to start at 2000-01-01T00:00:00 using h100\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="runtime-ready\n", stderr="")
+
+    monkeypatch.setattr(remote_execution_mod, "submit_remote_run_manifest", lambda *args, **kwargs: [])
+
+    def assert_live_assignment(manifest, **kwargs):
+        del kwargs
+        assert {request.node_name for request in manifest.requests} == {"h100"}
+        raise RuntimeError("live assignment reached wait")
+
+    monkeypatch.setattr(remote_execution_mod, "wait_remote_run_manifest", assert_live_assignment)
+
+    with pytest.raises(RuntimeError, match="live assignment reached wait"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [direct, slurm],
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=tmp_path / "run",
+            manager_client=FakeManager(),
+            runner=fake_runner,
+        )
+
+
+def test_existing_batch_launch_initializes_profile_owned_manager_state() -> None:
+    """Launch setup should create manager state roots without deploying code or runtimes."""
+    node = RemoteNode(
+        name="f101-gpu0",
+        host="f101",
+        work_dir="/remote/manager-f101-gpu0",
+        ssh_args=("-o", "BatchMode=yes"),
+    )
+    calls = []
+
+    def fake_runner(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    remote_execution_mod._ensure_existing_batch_manager_state(
+        node,
+        timeout_sec=60,
+        runner=fake_runner,
+    )
+
+    assert calls[0][0][:-1] == ["ssh", "-o", "BatchMode=yes", "f101"]
+    assert shlex.split(calls[0][0][-1]) == [
+        "mkdir",
+        "-p",
+        "/remote/manager-f101-gpu0",
+        "/remote/manager-f101-gpu0/queue",
+        "/remote/manager-f101-gpu0/results",
+        "/remote/manager-f101-gpu0/logs",
+        "/remote/manager-f101-gpu0/running",
+        "/remote/manager-f101-gpu0/done",
+        "/remote/manager-f101-gpu0/failed",
+        "/remote/manager-f101-gpu0/submitted",
+        "/remote/manager-f101-gpu0/cancelled",
+    ]
+    assert calls[0][1]["timeout"] == 60
+
+
+def test_existing_batch_launch_rebalances_queued_work_without_command_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wait loop must move unclaimed work when live GPU availability changes."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">p0\nAAAA\n")
+
+    def batch_node(name: str) -> ExistingRemoteBatchNode:
+        return ExistingRemoteBatchNode(
+            manager=RemoteNode(
+                name=name,
+                host=name,
+                work_dir=f"/remote/manager-{name}",
+                worker_device="cuda:0",
+            ),
+            command=ExistingRemoteCommandNode(
+                name=name,
+                host=name,
+                work_dir=f"/remote/af3-{name}",
+                command_argv=(
+                    f"/{name}/python",
+                    "/scripts/run.py",
+                    "-i",
+                    "{input}",
+                    "-o",
+                    "{output}",
+                ),
+                software="alphafold3",
+                required_artifacts=("**/*_model.cif",),
+                required_stdout_patterns=("CudaDevice",),
+                env={"CUDA_VISIBLE_DEVICES": "0"},
+                gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+            ),
+        )
+
+    source = batch_node("ty")
+    target = batch_node("f101")
+    live_phase = {"changed": False}
+    submitted = []
+
+    class FakeManager:
+        def preflight_node(self, node, **kwargs):
+            return {"node": node.name, "ok": True}
+
+        def start_node(self, node, **kwargs):
+            return f"running {node.name}"
+
+    def fake_runner(command, **kwargs):
+        del kwargs
+        if any("utilization.gpu,memory.used" in part for part in command):
+            host = command[command.index("nvidia-smi") - 1]
+            ready = (host == "ty") != live_phase["changed"]
+            usage = "0, 0\n" if ready else "100, 6302\n"
+            return subprocess.CompletedProcess(command, 0, stdout=usage, stderr="")
+        if command[-1].startswith(source.manager.python + " -c"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"status": "withdrawn"}\n',
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="runtime-ready\n", stderr="")
+
+    monkeypatch.setattr(
+        remote_execution_mod,
+        "submit_remote_run_manifest",
+        lambda manifest, **kwargs: submitted.append(manifest) or [],
+    )
+
+    def assert_live_move(manifest, **kwargs):
+        live_phase["changed"] = True
+        updated = kwargs["poll_hook"](manifest)
+        assert {request.node_name for request in updated.requests} == {"f101"}
+        raise RuntimeError("same launcher followed live move")
+
+    monkeypatch.setattr(remote_execution_mod, "wait_remote_run_manifest", assert_live_move)
+
+    with pytest.raises(RuntimeError, match="same launcher followed live move"):
+        remote_execution_mod.launch_existing_remote_command_batch(
+            [source, target],
+            input_fasta=fasta,
+            software="alphafold3",
+            run_dir=tmp_path / "run",
+            manager_client=FakeManager(),
+            runner=fake_runner,
+        )
+
+    assert [manifest.requests[0].node_name for manifest in submitted] == ["ty", "f101"]
+
+
+def test_existing_batch_launch_reports_initial_and_latest_admission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The result must not overwrite initial planning evidence with the last live probe."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">p0\nAAAA\n")
+    node = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/manager-ty",
+            worker_device="cuda:0",
+        ),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3-ty",
+            command_argv=("/ty/python", "/run.py", "-i", "{input}", "-o", "{output}"),
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+            env={"CUDA_VISIBLE_DEVICES": "0"},
+            gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+        ),
+    )
+    probe_count = 0
+
+    def fake_runner(command, **kwargs):
+        nonlocal probe_count
+        del kwargs
+        if any("utilization.gpu,memory.used" in part for part in command):
+            probe_count += 1
+            usage = "0, 0\n" if probe_count == 1 else "100, 4096\n"
+            return subprocess.CompletedProcess(command, 0, stdout=usage, stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="runtime-ready\n", stderr="")
+
+    monkeypatch.setattr(remote_execution_mod, "_manager_preflight_node", lambda *args, **kwargs: {"ok": True})
+    monkeypatch.setattr(remote_execution_mod, "_manager_start_node", lambda *args, **kwargs: "running")
+    monkeypatch.setattr(remote_execution_mod, "submit_remote_run_manifest", lambda *args, **kwargs: [])
+
+    def finish_after_live_probe(manifest, **kwargs):
+        kwargs["poll_hook"](manifest)
+        return manifest
+
+    monkeypatch.setattr(remote_execution_mod, "wait_remote_run_manifest", finish_after_live_probe)
+    monkeypatch.setattr(remote_execution_mod, "render_existing_artifact_pull_commands", lambda *args: [])
+    monkeypatch.setattr(
+        remote_execution_mod,
+        "collect_existing_remote_command_manifest",
+        lambda *args: {"task_count": 1},
+    )
+
+    result = remote_execution_mod.launch_existing_remote_command_batch(
+        [node],
+        input_fasta=fasta,
+        software="alphafold3",
+        run_dir=tmp_path / "run",
+        runner=fake_runner,
+    )
+
+    assert result.preflight["ty"]["admission"]["ready"] is True
+    assert result.admission["ty"]["ready"] is False
+
+
+def test_existing_batch_rebalance_fills_each_ready_direct_device_once(tmp_path: Path) -> None:
+    """An idle target must claim one bucket before it can receive another move."""
+    fasta = tmp_path / "three.fasta"
+    fasta.write_text("".join(f">p{index}\nAAAA\n" for index in range(3)))
+
+    def batch_node(name: str) -> ExistingRemoteBatchNode:
+        return ExistingRemoteBatchNode(
+            manager=RemoteNode(
+                name=name,
+                host=name,
+                work_dir=f"/remote/manager-{name}",
+                worker_device="cuda:0",
+            ),
+            command=ExistingRemoteCommandNode(
+                name=name,
+                host=name,
+                work_dir=f"/remote/af3-{name}",
+                command_argv=(f"/{name}/python", "/run.py", "-i", "{input}", "-o", "{output}"),
+                software="alphafold3",
+                required_artifacts=("**/*_model.cif",),
+                required_stdout_patterns=("CudaDevice",),
+                env={"CUDA_VISIBLE_DEVICES": "0"},
+                gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+            ),
+        )
+
+    source = batch_node("source")
+    target = batch_node("target")
+    run_dir = tmp_path / "run"
+    manifest_path = run_dir / "run.manifest.json"
+    manifest = plan_existing_remote_command_batch(
+        [source],
+        input_fasta=fasta,
+        run_id="run",
+        bucket_size=1,
+        local_results_dir=run_dir / "remote_results",
+        software="alphafold3",
+    )
+    write_remote_run_manifest(manifest, manifest_path)
+    kwargs = {
+        "batch_nodes": [source, target],
+        "input_fasta": fasta,
+        "software": "alphafold3",
+        "admission": {
+            "source": {"ready": False, "kind": "cuda_idle"},
+            "target": {"ready": True, "kind": "cuda_idle"},
+        },
+        "manifest_path": manifest_path,
+        "withdrawer": lambda *args, **kwargs: {"status": "withdrawn"},
+        "runner": lambda *args, **kwargs: None,
+    }
+
+    updated, first_moves = remote_execution_mod._rebalance_unclaimed_existing_batch_manifest(
+        manifest,
+        **kwargs,
+    )
+    unchanged, second_moves = remote_execution_mod._rebalance_unclaimed_existing_batch_manifest(
+        updated,
+        **kwargs,
+    )
+
+    assert len(first_moves) == 1
+    assert [request.node_name for request in updated.requests].count("target") == 1
+    assert unchanged == updated
+    assert second_moves == []
+
+
+def test_existing_batch_slurm_future_start_uses_direct_queue_as_holding_pool() -> None:
+    """A far-future Slurm allocation must not absorb work from reassignable direct queues."""
+    command = ExistingRemoteCommandNode(
+        name="h100",
+        host="h100",
+        work_dir="/remote/af3-h100",
+        command_argv=("/python", "/run.py", "-i", "{input}", "-o", "{output}"),
+    )
+    slurm = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/manager-h100",
+            scheduler="slurm",
+            sbatch_args=("--partition=gpu_special", "--gres=gpu:h100:1"),
+            max_active_slurm_jobs=2,
+        ),
+        command=command,
+    )
+    direct = ExistingRemoteBatchNode(
+        manager=RemoteNode(name="ty", host="ty", work_dir="/remote/manager-ty"),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3-ty",
+            command_argv=("/python", "/run.py", "-i", "{input}", "-o", "{output}"),
+        ),
+    )
+
+    def future_runner(command_argv, **kwargs):
+        del kwargs
+        return subprocess.CompletedProcess(
+            command_argv,
+            0,
+            stdout="sbatch: Job 1 to start at 2099-01-01T00:00:00 using h100\n",
+            stderr="",
+        )
+
+    slurm_admission = remote_execution_mod._probe_existing_batch_admission(
+        slurm,
+        timeout_sec=60,
+        runner=future_runner,
+    )
+    selected = remote_execution_mod._select_existing_batch_planning_nodes(
+        [direct, slurm],
+        {
+            "ty": {"kind": "cuda_idle", "ready": False},
+            "h100": slurm_admission,
+        },
+    )
+
+    assert slurm_admission["ready"] is False
+    assert selected == [direct]
+
+
+def test_existing_batch_resume_rebalances_unclaimed_request_and_journals_move(tmp_path: Path) -> None:
+    """Resume should recover after only part of a busy-node batch was moved."""
+    fasta = tmp_path / "four.fasta"
+    fasta.write_text("".join(f">p{index}\nAAAA\n" for index in range(4)))
+    direct = ExistingRemoteBatchNode(
+        manager=RemoteNode(name="ty", host="ty", work_dir="/remote/manager-ty", worker_device="cuda:7"),
+        command=ExistingRemoteCommandNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/af3-ty",
+            command_argv=("/ty/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+            env={"CUDA_VISIBLE_DEVICES": "7"},
+            gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+        ),
+    )
+    slurm = ExistingRemoteBatchNode(
+        manager=RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/manager-h100",
+            scheduler="slurm",
+            worker_device="cuda",
+            sbatch_args=("--partition=gpu_special", "--gres=gpu:h100:1"),
+            max_active_slurm_jobs=2,
+        ),
+        command=ExistingRemoteCommandNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/af3-h100",
+            command_argv=("/h100/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+            software="alphafold3",
+            required_artifacts=("**/*_model.cif",),
+            required_stdout_patterns=("CudaDevice",),
+        ),
+    )
+    run_dir = tmp_path / "run"
+    manifest_path = run_dir / "run.manifest.json"
+    manifest = plan_existing_remote_command_batch(
+        [direct, slurm],
+        input_fasta=fasta,
+        run_id="run",
+        bucket_size=1,
+        local_results_dir=run_dir / "remote_results",
+        software="alphafold3",
+    )
+    write_remote_run_manifest(manifest, manifest_path)
+    direct_requests = [request for request in manifest.requests if request.node_name == "ty"]
+    assert len(direct_requests) == 2
+    for request in manifest.requests:
+        if request.node_name != "h100":
+            continue
+        result_path = manifest.local_result_path(request)
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(
+            json.dumps(
+                {
+                    "status": "completed",
+                    "run_id": manifest.run_id,
+                    "bucket_id": request.bucket_id,
+                    "tool_key": manifest.tool_key,
+                    "item_indices": list(request.item_indices),
+                }
+            )
+        )
+    moved = []
+
+    def interrupted_withdraw(node, request, *, cancellation_id, timeout_sec, runner):
+        del cancellation_id, timeout_sec, runner
+        moved.append((node.name, request.bucket_id))
+        if len(moved) == 1:
+            return {"status": "withdrawn"}
+        raise RuntimeError("local interruption after remote cancellation")
+
+    kwargs = {
+        "batch_nodes": [direct, slurm],
+        "input_fasta": fasta,
+        "software": "alphafold3",
+        "admission": {
+            "ty": {"ready": False, "kind": "cuda_idle"},
+            "h100": {"ready": True, "kind": "slurm"},
+        },
+        "manifest_path": manifest_path,
+        "runner": lambda *args, **kwargs: None,
+    }
+    with pytest.raises(RuntimeError, match="local interruption"):
+        remote_execution_mod._rebalance_unclaimed_existing_batch_manifest(
+            manifest,
+            withdrawer=interrupted_withdraw,
+            **kwargs,
+        )
+
+    completed_journal = (
+        run_dir
+        / "rebalances"
+        / f"{direct_requests[0].bucket_id}.move-00001.ty-to-h100.json"
+    )
+    planned_journal = (
+        run_dir
+        / "rebalances"
+        / f"{direct_requests[1].bucket_id}.move-00001.ty-to-h100.json"
+    )
+    assert json.loads(completed_journal.read_text())["status"] == "completed"
+    assert json.loads(planned_journal.read_text())["status"] == "planned"
+    partial = load_remote_run_manifest(manifest_path)
+    assert partial != manifest
+    remote_execution_mod._validate_existing_batch_resume_manifest(
+        partial,
+        batch_nodes=[direct, slurm],
+        input_fasta=fasta,
+        software="alphafold3",
+    )
+
+    def recovered_withdraw(node, request, *, cancellation_id, timeout_sec, runner):
+        del node, request, cancellation_id, timeout_sec, runner
+        return {"status": "already_cancelled"}
+
+    updated, moves = remote_execution_mod._rebalance_unclaimed_existing_batch_manifest(
+        partial,
+        withdrawer=recovered_withdraw,
+        **kwargs,
+    )
+
+    assert moved == [("ty", request.bucket_id) for request in direct_requests]
+    assert {request.node_name for request in updated.requests} == {"h100"}
+    assert moves == [
+        {
+            "bucket_id": direct_requests[1].bucket_id,
+            "from_node": "ty",
+            "to_node": "h100",
+        }
+    ]
+    journal = json.loads(planned_journal.read_text())
+    assert journal["status"] == "completed"
+    assert load_remote_run_manifest(manifest_path) == updated
+
+
+def test_existing_batch_queue_withdrawal_quotes_remote_python_command() -> None:
+    """SSH must receive one quoted command so multiline Python reaches the remote interpreter."""
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/manager",
+        python="/remote/venv/bin/python",
+        ssh_args=("-o", "BatchMode=yes"),
+    )
+    request = remote_execution_mod.RemoteRunRequest(
+        node_name="ty",
+        bucket_id="bucket-00000",
+        item_indices=(0,),
+        total_cost=4.0,
+        request={"run_id": "run", "bucket_id": "bucket-00000"},
+    )
+
+    def fake_runner(command, **kwargs):
+        assert command[:-1] == ["ssh", "-o", "BatchMode=yes", "ty"]
+        remote_argv = shlex.split(command[-1])
+        assert remote_argv[0:2] == ["/remote/venv/bin/python", "-c"]
+        assert remote_argv[2] == remote_execution_mod._WITHDRAW_QUEUED_REQUEST_PY
+        assert remote_argv[3:] == [
+            "/remote/manager/queue/run/bucket-00000.json",
+            "/remote/manager/cancelled/run/bucket-00000/move-00001-ty-to-h100.json",
+        ]
+        assert json.loads(kwargs["input"]) == request.request
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='{"status": "withdrawn"}\n',
+            stderr="",
+        )
+
+    result = remote_execution_mod._withdraw_queued_manifest_request(
+        node,
+        request,
+        cancellation_id="move-00001-ty-to-h100",
+        runner=fake_runner,
+    )
+
+    assert result == {"status": "withdrawn"}
+
+
+def test_existing_batch_queue_withdrawal_retries_ssh_transport_failure() -> None:
+    """A transient SSH exit 255 must recover inside the one launch command."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/manager")
+    request = remote_execution_mod.RemoteRunRequest(
+        node_name="ty",
+        bucket_id="bucket-00000",
+        item_indices=(0,),
+        total_cost=4.0,
+        request={"run_id": "run", "bucket_id": "bucket-00000"},
+    )
+    attempts = []
+
+    def flaky_runner(command, **kwargs):
+        attempts.append((command, kwargs))
+        if len(attempts) == 1:
+            raise subprocess.CalledProcessError(
+                255,
+                command,
+                output="",
+                stderr="kex_exchange_identification: Connection closed by remote host",
+            )
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='{"status": "withdrawn"}\n',
+            stderr="",
+        )
+
+    result = remote_execution_mod._withdraw_queued_manifest_request(
+        node,
+        request,
+        cancellation_id="move-00001-ty-to-h100",
+        timeout_sec=10,
+        retry_interval=0,
+        runner=flaky_runner,
+    )
+
+    assert result == {"status": "withdrawn"}
+    assert len(attempts) == 2
+
+
+def test_existing_batch_queue_withdrawal_uses_fresh_tombstone_for_each_move(
+    tmp_path: Path,
+) -> None:
+    """Returning a bucket to one node must not reuse an older cancellation tombstone."""
+    queue_path = tmp_path / "queue" / "run" / "bucket-00000.json"
+    request = {"run_id": "run", "bucket_id": "bucket-00000"}
+    queue_path.parent.mkdir(parents=True)
+
+    statuses = []
+    for move_id in ("move-00001-ty-to-f101", "move-00002-ty-to-f102"):
+        queue_path.write_text(json.dumps(request))
+        cancelled_path = tmp_path / "cancelled" / "run" / "bucket-00000" / f"{move_id}.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                remote_execution_mod._WITHDRAW_QUEUED_REQUEST_PY,
+                str(queue_path),
+                str(cancelled_path),
+            ],
+            input=json.dumps(request),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        statuses.append(json.loads(completed.stdout)["status"])
+        assert cancelled_path.is_file()
+        assert not queue_path.exists()
+
+    assert statuses == ["withdrawn", "withdrawn"]
+
+
+def test_existing_remote_command_manifest_pulls_and_validates_native_artifacts(tmp_path: Path) -> None:
+    """Artifact collection must validate the local mirror, not trust process exit alone."""
+    fasta = tmp_path / "one.fasta"
+    fasta.write_text(">one\nAAAA\n")
+    manager = RemoteNode(name="ty", host="ty", work_dir="/remote/manager", worker_device="cuda:0")
+    command = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/af3",
+        command_argv=("/env/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        status="ready",
+        software="alphafold3",
+        required_artifacts=("**/*_model.cif",),
+        required_stdout_patterns=("CudaDevice",),
+        env={"CUDA_VISIBLE_DEVICES": "0"},
+        gpu_admission={"max_utilization_percent": 5, "max_memory_used_mib": 1024},
+    )
+    manifest = plan_existing_remote_command_batch(
+        [ExistingRemoteBatchNode(manager=manager, command=command)],
+        input_fasta=fasta,
+        run_id="artifact-run",
+        bucket_size=1,
+        local_results_dir=tmp_path / "results",
+        software="alphafold3",
+    )
+    request = manifest.requests[0]
+    remote_task = request.request["existing_command"]["tasks"][0]
+    local_artifacts = tmp_path / "artifacts"
+    local_task = local_artifacts / "ty" / "task_00000" / "attempt_ty"
+    (local_task / "output" / "sample").mkdir(parents=True)
+    (local_task / "output" / "sample" / "sample_model.cif").write_text("data_model\n")
+    result_path = manifest.local_result_path(request)
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "completed",
+                "request_kind": "existing_command",
+                "tool_key": manifest.tool_key,
+                "run_id": manifest.run_id,
+                "bucket_id": request.bucket_id,
+                "item_indices": [0],
+                "existing_command_results": [
+                    {
+                        "task_id": "task_00000",
+                        "artifact_dir": remote_task["artifact_dir"],
+                        "input_path": f"{remote_task['artifact_dir']}/input/task_00000.fasta",
+                        "output_dir": f"{remote_task['artifact_dir']}/output",
+                        "stdout_path": f"{remote_task['artifact_dir']}/logs/stdout.log",
+                        "stderr_path": f"{remote_task['artifact_dir']}/logs/stderr.log",
+                        "artifacts": ["sample/sample_model.cif"],
+                        "validated_stdout_patterns": ["CudaDevice"],
+                    }
+                ],
+            }
+        )
+    )
+
+    pull_commands = render_existing_artifact_pull_commands(manifest, local_artifacts)
+    summary = collect_existing_remote_command_manifest(manifest, local_artifacts)
+
+    assert pull_commands == [
+        [
+            "rsync",
+            "-a",
+            "ty:/remote/af3/artifact-run/artifacts/",
+            str(local_artifacts / "ty") + "/",
+        ]
+    ]
+    assert summary["task_count"] == 1
+    assert summary["tasks"][0]["header"] == "one"
+    assert summary["tasks"][0]["node"] == "ty"
+    assert summary["tasks"][0]["local_artifact_dir"] == str(local_task)
+    assert summary["tasks"][0]["artifacts"] == ["sample/sample_model.cif"]
+    assert summary["tasks"][0]["validated_stdout_patterns"] == ["CudaDevice"]
+
+
+def test_existing_remote_command_renders_direct_env_and_placeholders() -> None:
+    """Direct existing-command rendering should preserve env and input/output paths."""
+    node = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "predict", "-i", "{input}", "-o", "{output}"),
+        env={"CUDA_VISIBLE_DEVICES": "0"},
+    )
+
+    script = render_existing_remote_shell_command(
+        node,
+        remote_input_path="/remote/existing/run-1/input/input.fa",
+        remote_output_dir="/remote/existing/run-1/output",
+    )
+
+    assert script.startswith("set -euo pipefail; mkdir -p /remote/existing/run-1/output")
+    assert "export CUDA_VISIBLE_DEVICES=0" in script
+    assert (
+        "/env/bin/python /scripts/run.py predict -i /remote/existing/run-1/input/input.fa "
+        "-o /remote/existing/run-1/output"
+    ) in script
+
+
+def test_existing_remote_command_renders_srun_wrapper() -> None:
+    """Slurm-backed existing commands should run inside the rendered srun shell."""
+    node = ExistingRemoteCommandNode(
+        name="h100",
+        host="h100",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        scheduler="srun",
+        srun_args=("-p", "gpu_special", "--gres=gpu:h100:1", "--immediate=60"),
+    )
+
+    script = render_existing_remote_shell_command(
+        node,
+        remote_input_path="/remote/existing/run-1/input/input.fa",
+        remote_output_dir="/remote/existing/run-1/output",
+    )
+
+    assert script.startswith("srun -p gpu_special --gres=gpu:h100:1 --immediate=60 bash -lc ")
+    assert "set -euo pipefail" in script
+    assert "/env/bin/python /scripts/run.py" in script
+
+
+def test_existing_remote_command_plan_builds_stage_execute_collect_commands(tmp_path: Path) -> None:
+    """Planning should render SSH prepare/execute plus rsync upload/collect."""
+    input_path = tmp_path / "input.fa"
+    collect_dir = tmp_path / "collect"
+    input_path.write_text(">x\nAAAA\n")
+    node = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty-submit",
+        rsync_host="ty-sync",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+        ssh_args=("-p", "2222"),
+        rsync_ssh_args=("-i", "key.pem"),
+    )
+
+    plan = remote_execution_mod.plan_existing_remote_command(
+        node,
+        local_input_path=input_path,
+        run_id="run-1",
+        local_collect_dir=collect_dir,
+    )
+
+    assert plan.prepare_command[:6] == ("ssh", "-p", "2222", "ty-submit", "bash", "-lc")
+    assert plan.execute_command[:6] == ("ssh", "-p", "2222", "ty-submit", "bash", "-lc")
+    assert plan.remote_input_path == "/remote/existing/run-1/input/input.fa"
+    assert plan.remote_output_dir == "/remote/existing/run-1/output"
+    assert plan.upload_command == (
+        "rsync",
+        "-a",
+        "-e",
+        "ssh -i key.pem",
+        str(input_path),
+        "ty-sync:/remote/existing/run-1/input/input.fa",
+    )
+    assert plan.collect_command == (
+        "rsync",
+        "-a",
+        "-e",
+        "ssh -i key.pem",
+        "ty-sync:/remote/existing/run-1/output/",
+        str(collect_dir) + "/",
+    )
+
+
+def test_existing_remote_command_run_calls_steps_and_lists_collected_files(tmp_path: Path) -> None:
+    """The run helper should execute prepare/upload/execute/collect in order."""
+    input_path = tmp_path / "input.fa"
+    collect_dir = tmp_path / "collect"
+    input_path.write_text(">x\nAAAA\n")
+    node = ExistingRemoteCommandNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/existing",
+        command_argv=("/env/bin/python", "/scripts/run.py", "-i", "{input}", "-o", "{output}"),
+    )
+    calls = []
+
+    def fake_runner(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[:2] == ["rsync", "-a"] and str(cmd[-2]).endswith("/output/"):
+            (collect_dir / "scores.json").write_text("{}\n")
+            nested = collect_dir / "model"
+            nested.mkdir()
+            (nested / "structure.pdb").write_text("MODEL\n")
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"stdout:{cmd[0]}", stderr=f"stderr:{cmd[0]}")
+
+    result = run_existing_remote_command(
+        node,
+        local_input_path=input_path,
+        run_id="run-1",
+        local_collect_dir=collect_dir,
+        runner=fake_runner,
+        timeout_sec=12.5,
+    )
+
+    assert [cmd[0] for cmd, _ in calls] == ["ssh", "rsync", "ssh", "rsync"]
+    assert all(kwargs["check"] is True for _, kwargs in calls)
+    assert all(kwargs["text"] is True and kwargs["capture_output"] is True for _, kwargs in calls)
+    assert [kwargs["timeout"] for _, kwargs in calls] == [12.5, 12.5, 12.5, 12.5]
+    assert result.collected_files == ("model/structure.pdb", "scores.json")
+    assert [step.step for step in result.command_results] == ["prepare", "upload", "execute", "collect"]
+    assert result.command_results[2].stdout == "stdout:ssh"
+    assert result.command_results[2].stderr == "stderr:ssh"
+    assert result.to_dict()["command_results"][2]["step"] == "execute"
+
+
+def _init_git_repo(path: Path) -> Path:
+    """Create a minimal git checkout for local deployment tests."""
+    path.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(path), "init"], check=True, text=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Proto Tests"], check=True)
+    (path / "tracked.txt").write_text("clean\n")
+    subprocess.run(["git", "-C", str(path), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "initial"], check=True, text=True, capture_output=True)
+    return path
+
+
+def test_remote_dispatch_planner_buckets_and_weights(clean_registry):
+    """Planner should form contiguous buckets and send more cost to stronger nodes."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/proto-ty", weight=1.0, worker_device="cuda:0"),
+        RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/proto-h100",
+            weight=3.0,
+            scheduler="slurm",
+            worker_device="cuda",
+        ),
+    ]
+    inputs = RemoteMockInput(sequences=["A", "AA", "AAA", "AAAA", "AAAAA"])
+
+    plan = RemoteDispatchPlanner(nodes, bucket_size=2).build_plan(
+        "remote-mock",
+        inputs,
+        RemoteMockConfig(suffix="fold"),
+        run_id="run-1",
+    )
+
+    assert [assignment.bucket.item_indices for assignment in plan.assignments] == [(0, 1), (2, 3), (4,)]
+    h100_cost = sum(assignment.bucket.total_cost for assignment in plan.assignments_for_node("h100"))
+    ty_cost = sum(assignment.bucket.total_cost for assignment in plan.assignments_for_node("ty"))
+    assert h100_cost > ty_cost
+
+    request = plan.request_for(plan.assignments[0])
+    assert request["tool_key"] == "remote-mock"
+    assert request["config"]["device"] == plan.assignments[0].node.worker_device
+    assert request["inputs"]["sequences"] == ["A", "AA"]
+
+
+def test_remote_dispatch_planner_uses_initial_node_loads(clean_registry):
+    """Planner should avoid assigning new buckets to nodes with existing backlog."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", weight=1.0, worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", weight=1.0, worker_device="cuda:1"),
+    ]
+
+    plan = RemoteDispatchPlanner(nodes, bucket_size=1, initial_node_loads={"ty": 100.0}).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["A", "B"]),
+        run_id="run-initial-load",
+    )
+
+    assert [assignment.node.name for assignment in plan.assignments] == ["ty3", "ty3"]
+
+
+def test_remote_submission_stages_node_buckets_over_one_ssh(clean_registry):
+    """Submission should stage every bucket for one node through one SSH command."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/proto", ssh_args=("-p", "2222"))
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["A", "B"]),
+        run_id="run-2",
+    )
+    calls = []
+
+    def fake_runner(cmd, input=None, text=False, check=False):
+        calls.append({"cmd": cmd, "input": input, "text": text, "check": check})
+
+    staged = RemoteSubmissionClient().submit_plan(plan, runner=fake_runner)
+
+    assert staged == [
+        node.queue_root / "run-2" / "bucket-00000.json",
+        node.queue_root / "run-2" / "bucket-00001.json",
+    ]
+    assert len(calls) == 1
+    assert calls[0]["cmd"][:4] == ["ssh", "-p", "2222", "ty"]
+    assert "proto_tools.utils.remote_execution" not in calls[0]["cmd"][4]
+    payload = json.loads(calls[0]["input"])
+    assert [item["filename"] for item in payload["requests"]] == ["bucket-00000.json", "bucket-00001.json"]
+    assert payload["requests"][0]["request"]["bucket_id"] == "bucket-00000"
+    assert calls[0]["text"] is True
+    assert calls[0]["check"] is True
+
+
+def test_execute_request_runs_registered_tool(clean_registry):
+    """A manager request should execute the registered tool locally on that node."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/proto", worker_device="cuda:1")
+    plan = RemoteDispatchPlanner([node], bucket_size=2).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        RemoteMockConfig(suffix="done"),
+        run_id="run-3",
+    )
+
+    result = execute_request(plan.request_for(plan.assignments[0]))
+
+    assert result["status"] == "completed"
+    assert result["item_indices"] == [0, 1]
+    assert result["output"]["results"] == ["AA:cuda:1:done", "BB:cuda:1:done"]
+
+
+def test_execute_request_runs_existing_command_without_tool_registry(tmp_path: Path) -> None:
+    """Existing-command requests should stage input, run argv, and inventory artifacts."""
+    artifact_dir = (tmp_path / "artifacts" / "task_00000" / "attempt_ty").resolve()
+    request = {
+        "schema_version": 1,
+        "request_kind": "existing_command",
+        "tool_key": "existing-alphafold3",
+        "run_id": "af3-existing-test",
+        "bucket_id": "bucket-00000",
+        "item_indices": [0],
+        "existing_command": {
+            "command_argv": [
+                sys.executable,
+                "-c",
+                (
+                    "from pathlib import Path; import sys; "
+                    "inp=Path(sys.argv[1]); out=Path(sys.argv[2]); "
+                    "out.mkdir(parents=True, exist_ok=True); "
+                    "(out/'model.cif').write_text(inp.read_text()); "
+                    "(out/'summary_confidences.json').write_text('{\"ptm\": 0.5}\\n'); "
+                    "print('gpu command completed')"
+                ),
+                "{input}",
+                "{output}",
+            ],
+            "env": {"CUDA_VISIBLE_DEVICES": "7"},
+            "tasks": [
+                {
+                    "task_id": "task_00000",
+                    "input_filename": "random_protein_1.fasta",
+                    "input_text": ">random_protein_1\nAAAA\n",
+                    "artifact_dir": str(artifact_dir),
+                    "required_artifacts": ["model.cif", "summary_confidences.json"],
+                }
+            ],
+        },
+    }
+
+    result = execute_request(request)
+
+    assert result["status"] == "completed"
+    assert result["request_kind"] == "existing_command"
+    assert result["item_indices"] == [0]
+    assert result["existing_command_results"] == [
+        {
+            "task_id": "task_00000",
+            "artifact_dir": str(artifact_dir),
+            "input_path": str(artifact_dir / "input" / "random_protein_1.fasta"),
+            "output_dir": str(artifact_dir / "output"),
+            "stdout_path": str(artifact_dir / "logs" / "stdout.log"),
+            "stderr_path": str(artifact_dir / "logs" / "stderr.log"),
+            "artifacts": ["model.cif", "summary_confidences.json"],
+        }
+    ]
+    assert (artifact_dir / "input" / "random_protein_1.fasta").read_text() == ">random_protein_1\nAAAA\n"
+    assert (artifact_dir / "logs" / "stdout.log").read_text() == "gpu command completed\n"
+    assert (artifact_dir / "logs" / "stderr.log").read_text() == ""
+    assert (artifact_dir / "output" / "model.cif").stat().st_size > 0
+
+
+def test_execute_request_rejects_missing_required_stdout_device_evidence(tmp_path: Path) -> None:
+    """A zero-exit command with artifacts must fail when CUDA log evidence is absent."""
+    artifact_dir = (tmp_path / "artifacts" / "task_00000" / "attempt_h100").resolve()
+    request = {
+        "schema_version": 1,
+        "request_kind": "existing_command",
+        "tool_key": "existing-alphafold3",
+        "run_id": "af3-device-proof-failed",
+        "bucket_id": "bucket-00000",
+        "item_indices": [0],
+        "existing_command": {
+            "command_argv": [
+                sys.executable,
+                "-c",
+                (
+                    "from pathlib import Path; import sys; "
+                    "out=Path(sys.argv[2]); out.mkdir(parents=True, exist_ok=True); "
+                    "(out/'model.cif').write_text('model'); print('CpuDevice(id=0)')"
+                ),
+                "{input}",
+                "{output}",
+            ],
+            "required_stdout_patterns": ["CudaDevice"],
+            "tasks": [
+                {
+                    "task_id": "task_00000",
+                    "input_filename": "random_protein_1.fasta",
+                    "input_text": ">random_protein_1\nAAAA\n",
+                    "artifact_dir": str(artifact_dir),
+                    "required_artifacts": ["model.cif"],
+                }
+            ],
+        },
+    }
+
+    with pytest.raises(RuntimeError, match=r"required stdout pattern.*CudaDevice"):
+        execute_request(request)
+
+    assert (artifact_dir / "logs" / "stdout.log").read_text() == "CpuDevice(id=0)\n"
+
+
+def test_execute_request_file_writes_failed_existing_command_envelope_for_missing_artifact(
+    tmp_path: Path,
+) -> None:
+    """A zero-exit command without required artifacts must remain a visible failure."""
+    artifact_dir = (tmp_path / "artifacts" / "task_00000" / "attempt_ty").resolve()
+    request = {
+        "schema_version": 1,
+        "request_kind": "existing_command",
+        "tool_key": "existing-alphafold3",
+        "run_id": "af3-existing-failed",
+        "bucket_id": "bucket-00000",
+        "item_indices": [0],
+        "existing_command": {
+            "command_argv": [sys.executable, "-c", "print('no model')", "{input}", "{output}"],
+            "tasks": [
+                {
+                    "task_id": "task_00000",
+                    "input_filename": "random_protein_1.fasta",
+                    "input_text": ">random_protein_1\nAAAA\n",
+                    "artifact_dir": str(artifact_dir),
+                    "required_artifacts": ["model.cif"],
+                }
+            ],
+        },
+    }
+    request_path = tmp_path / "request.json"
+    result_path = tmp_path / "result.json"
+    request_path.write_text(json.dumps(request))
+
+    with pytest.raises(FileNotFoundError, match="required artifact"):
+        execute_request_file(request_path, result_path)
+
+    envelope = json.loads(result_path.read_text())
+    assert envelope["status"] == "failed"
+    assert envelope["request_kind"] == "existing_command"
+    assert envelope["tool_key"] == "existing-alphafold3"
+    assert "required artifact" in envelope["error"]
+    assert (artifact_dir / "logs" / "stdout.log").read_text() == "no model\n"
+
+
+def test_run_manager_once_direct_writes_result_and_done_request(clean_registry, tmp_path):
+    """Direct manager mode should claim queued work, run it, and write a result."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/proto", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-4",
+    )
+    request_dir = tmp_path / "queue" / "run-4"
+    request_dir.mkdir(parents=True)
+    (request_dir / "bucket-00000.json").write_text(json.dumps(plan.request_for(plan.assignments[0])))
+
+    events = run_manager_once(tmp_path / "queue", tmp_path / "results")
+
+    assert [event.status for event in events] == ["completed"]
+    result_path = tmp_path / "results" / "run-4" / "bucket-00000.json"
+    assert json.loads(result_path.read_text())["output"]["results"] == ["AA:cuda:0:x"]
+    assert (tmp_path / "done" / "run-4" / "bucket-00000.json").exists()
+    assert not (tmp_path / "queue" / "run-4" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_leaves_existing_request_queued_while_gpu_is_busy(tmp_path: Path) -> None:
+    """A direct manager must not claim an existing GPU command until its GPU is idle."""
+    request_dir = tmp_path / "queue" / "af3-busy"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "request_kind": "existing_command",
+                "tool_key": "existing-alphafold3",
+                "run_id": "af3-busy",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "existing_command": {
+                    "command_argv": [sys.executable, "-c", "raise SystemExit('must not run')"],
+                    "env": {"CUDA_VISIBLE_DEVICES": "7"},
+                    "resource_admission": {
+                        "kind": "cuda_idle",
+                        "gpu_id": "7",
+                        "max_utilization_percent": 5,
+                        "max_memory_used_mib": 1024,
+                    },
+                    "tasks": [],
+                },
+            }
+        )
+    )
+    calls: list[list[str]] = []
+
+    def busy_gpu_runner(command, **kwargs):
+        calls.append(list(command))
+        return subprocess.CompletedProcess(command, 0, stdout="100, 6302\n", stderr="")
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        runner=busy_gpu_runner,
+    )
+
+    assert events == []
+    assert request_path.exists()
+    assert not (tmp_path / "running").exists()
+    assert not (tmp_path / "results").exists()
+    assert calls == [
+        [
+            "nvidia-smi",
+            "-i",
+            "7",
+            "--query-gpu=utilization.gpu,memory.used",
+            "--format=csv,noheader,nounits",
+        ]
+    ]
+
+
+def test_run_manager_once_fails_existing_request_when_gpu_probe_is_invalid(tmp_path: Path) -> None:
+    """A broken admission probe must become a failed envelope instead of an endless queue."""
+    request_dir = tmp_path / "queue" / "af3-probe-error"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "request_kind": "existing_command",
+                "tool_key": "existing-alphafold3",
+                "run_id": "af3-probe-error",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "existing_command": {
+                    "command_argv": [sys.executable, "-c", "raise SystemExit('must not run')"],
+                    "resource_admission": {
+                        "kind": "cuda_idle",
+                        "gpu_id": "7",
+                        "max_utilization_percent": 5,
+                        "max_memory_used_mib": 1024,
+                    },
+                    "tasks": [],
+                },
+            }
+        )
+    )
+
+    def invalid_gpu_runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout="not-a-gpu-sample\n", stderr="")
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        runner=invalid_gpu_runner,
+    )
+
+    assert [event.status for event in events] == ["failed"]
+    envelope = json.loads(
+        (tmp_path / "results" / "failed" / "bucket-00000.json.json").read_text()
+    )
+    assert envelope["status"] == "failed"
+    assert "unexpected nvidia-smi admission output" in envelope["error"]
+    assert (tmp_path / "failed" / "af3-probe-error" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_rejects_unsafe_request_path_segments(clean_registry, tmp_path):
+    """Malformed queue payloads must not write outside the results root."""
+    _register_remote_mock_tool(clean_registry)
+    request_dir = tmp_path / "queue" / "bad-run"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bad.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "tool_key": "remote-mock",
+                "run_id": "../escape",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "inputs": {"sequences": ["AA"]},
+                "config": {"device": "cuda:0"},
+            }
+        )
+    )
+
+    events = run_manager_once(tmp_path / "queue", tmp_path / "results")
+
+    assert [event.status for event in events] == ["failed"]
+    assert not (tmp_path / "escape").exists()
+    failed_result = tmp_path / "results" / "failed" / "bad.json.json"
+    assert json.loads(failed_result.read_text())["status"] == "failed"
+    assert (tmp_path / "failed" / "bad-run" / "bad.json").exists()
+
+
+def test_run_manager_once_slurm_groups_requests_and_tracks_job_id(clean_registry, tmp_path):
+    """SLURM mode should group queued buckets and record the sbatch job id."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB", "CC"]),
+        run_id="run-5",
+    )
+    request_dir = tmp_path / "queue" / "run-5"
+    request_dir.mkdir(parents=True)
+    for assignment in plan.assignments:
+        (request_dir / f"{assignment.bucket.bucket_id}.json").write_text(json.dumps(plan.request_for(assignment)))
+    calls = []
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append({"cmd": cmd, "check": check, "text": text, "capture_output": capture_output})
+        request_paths = [
+            Path(args[index + 1])
+            for args in [shlex.split(cmd[-1])]
+            for index, arg in enumerate(args)
+            if arg == "--request"
+        ]
+        assert request_paths
+        assert all("submitted" in path.parts for path in request_paths)
+        assert not any("running" in path.parts for path in request_paths)
+        assert all(path.exists() for path in request_paths)
+        return FakeCompleted(f"job-{len(calls)}\n")
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        python="/env/bin/python",
+        sbatch_args=("--partition", "gpu", "--gres", "gpu:h100:1"),
+        slurm_group_size=2,
+        max_active_slurm_jobs=10,
+        runner=fake_runner,
+    )
+
+    assert [event.status for event in events] == ["submitted", "submitted", "submitted"]
+    assert [event.slurm_job_id for event in events] == ["job-1", "job-1", "job-2"]
+    assert len(calls) == 2
+    assert calls[0]["cmd"][:6] == ["sbatch", "--parsable", "--partition", "gpu", "--gres", "gpu:h100:1"]
+    assert "proto_tools.utils.remote_execution run-request-batch" in calls[0]["cmd"][-1]
+    assert calls[0]["cmd"][-1].count("--request") == 2
+    assert calls[0]["check"] is True
+    assert calls[0]["text"] is True
+    assert calls[0]["capture_output"] is True
+    assert (tmp_path / "submitted" / "run-5" / "bucket-00000.json").exists()
+    assert not (tmp_path / "running" / "run-5" / "bucket-00000.json").exists()
+    sidecar = tmp_path / "submitted" / "run-5" / "bucket-00000.json.slurm.json"
+    sidecar_payload = json.loads(sidecar.read_text())
+    assert sidecar_payload["slurm_job_id"] == "job-1"
+    assert sidecar_payload["submitted_at_epoch"] > 0
+
+
+def test_run_manager_once_slurm_submit_failure_moves_claims_to_failed(clean_registry, tmp_path):
+    """SLURM submit failures should not strand claimed requests in running/submitted."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        run_id="run-submit-fail",
+    )
+    request_dir = tmp_path / "queue" / "run-submit-fail"
+    request_dir.mkdir(parents=True)
+    for assignment in plan.assignments:
+        (request_dir / f"{assignment.bucket.bucket_id}.json").write_text(json.dumps(plan.request_for(assignment)))
+
+    def failing_runner(cmd, check=False, text=False, capture_output=False):
+        request_paths = [
+            Path(args[index + 1])
+            for args in [shlex.split(cmd[-1])]
+            for index, arg in enumerate(args)
+            if arg == "--request"
+        ]
+        assert all("submitted" in path.parts for path in request_paths)
+        assert all(path.exists() for path in request_paths)
+        raise subprocess.CalledProcessError(1, cmd, stderr="sbatch unavailable")
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        python="/env/bin/python",
+        slurm_group_size=2,
+        max_active_slurm_jobs=10,
+        runner=failing_runner,
+    )
+
+    assert [event.status for event in events] == ["failed", "failed"]
+    assert not (tmp_path / "running" / "run-submit-fail" / "bucket-00000.json").exists()
+    assert not (tmp_path / "submitted" / "run-submit-fail" / "bucket-00000.json").exists()
+    assert (tmp_path / "failed" / "run-submit-fail" / "bucket-00000.json").exists()
+    envelope = json.loads((tmp_path / "results" / "run-submit-fail" / "bucket-00000.json").read_text())
+    assert envelope["status"] == "failed"
+    assert "sbatch unavailable" in envelope["traceback"]
+
+
+def test_run_manager_once_slurm_empty_sbatch_job_id_fails_visible(clean_registry, tmp_path):
+    """Slurm submission must not leave an untrackable submitted sidecar."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-empty-job",
+    )
+    request_dir = tmp_path / "queue" / "run-slurm-empty-job"
+    request_dir.mkdir(parents=True)
+    (request_dir / "bucket-00000.json").write_text(json.dumps(plan.request_for(plan.assignments[0])))
+
+    class FakeSubmittedWithoutJobId:
+        stdout = "\n"
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        max_active_slurm_jobs=1,
+        runner=lambda *args, **kwargs: FakeSubmittedWithoutJobId(),
+    )
+
+    assert [event.status for event in events] == ["failed"]
+    result_path = tmp_path / "results" / "run-slurm-empty-job" / "bucket-00000.json"
+    envelope = json.loads(result_path.read_text())
+    assert envelope["status"] == "failed"
+    assert "sbatch did not return a Slurm job id" in envelope["error"]
+    assert (tmp_path / "failed" / "run-slurm-empty-job" / "bucket-00000.json").exists()
+    assert not list((tmp_path / "submitted").glob("**/*.slurm.json"))
+
+
+def test_run_manager_once_slurm_requires_active_job_cap_before_submit(clean_registry, tmp_path):
+    """Slurm manager mode should fail before sbatch when active-job cap is missing."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-missing-cap",
+    )
+    request_dir = tmp_path / "queue" / "run-missing-cap"
+    request_dir.mkdir(parents=True)
+    (request_dir / "bucket-00000.json").write_text(json.dumps(plan.request_for(plan.assignments[0])))
+
+    def forbidden_runner(*args, **kwargs):
+        raise AssertionError("missing cap should stop before sacct or sbatch")
+
+    with pytest.raises(ValueError, match="max_active_slurm_jobs is required"):
+        run_manager_once(
+            tmp_path / "queue",
+            tmp_path / "results",
+            scheduler="slurm",
+            runner=forbidden_runner,
+        )
+
+    assert (tmp_path / "queue" / "run-missing-cap" / "bucket-00000.json").exists()
+    assert not (tmp_path / "running").exists()
+    assert not (tmp_path / "submitted").exists()
+
+
+def test_run_manager_once_slurm_caps_active_jobs_and_leaves_queue(clean_registry, tmp_path):
+    """SLURM mode should not claim more queued groups than active-job capacity allows."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB", "CC"]),
+        run_id="run-cap",
+    )
+    request_dir = tmp_path / "queue" / "run-cap"
+    request_dir.mkdir(parents=True)
+    for assignment in plan.assignments:
+        (request_dir / f"{assignment.bucket.bucket_id}.json").write_text(json.dumps(plan.request_for(assignment)))
+
+    active_request_dir = tmp_path / "submitted" / "run-active"
+    active_request_dir.mkdir(parents=True)
+    active_request = active_request_dir / "bucket-00000.json"
+    active_request.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "tool_key": "remote-mock",
+                "run_id": "run-active",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "inputs": {"sequences": ["DD"]},
+                "config": {"device": "cuda"},
+            }
+        )
+    )
+    active_request.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "slurm_job_id": "active-1",
+                "result_path": str(tmp_path / "results" / "run-active" / "bucket-00000.json"),
+            }
+        )
+    )
+    calls = []
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append(cmd)
+        if cmd[0] == "sacct":
+            return FakeCompleted("active-1|RUNNING\n")
+        return FakeCompleted("new-1\n")
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        python="/env/bin/python",
+        slurm_group_size=2,
+        max_active_slurm_jobs=2,
+        runner=fake_runner,
+    )
+
+    assert [event.status for event in events] == ["submitted", "submitted"]
+    assert [event.slurm_job_id for event in events] == ["new-1", "new-1"]
+    assert [call[0] for call in calls] == ["sacct", "sbatch"]
+    assert calls[1][-1].count("--request") == 2
+    assert (tmp_path / "queue" / "run-cap" / "bucket-00002.json").exists()
+    assert not (tmp_path / "running" / "run-cap" / "bucket-00002.json").exists()
+    assert (tmp_path / "submitted" / "run-active" / "bucket-00000.json.slurm.json").exists()
+
+
+def test_run_manager_once_slurm_stale_missing_job_releases_active_slot(clean_registry, tmp_path):
+    """Missing old Slurm jobs should fail visibly so queued buckets can use the freed slot."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    old_plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-stale",
+    )
+    old_request_dir = tmp_path / "submitted" / "run-slurm-stale"
+    old_request_dir.mkdir(parents=True)
+    old_request_path = old_request_dir / "bucket-00000.json"
+    old_request = old_plan.request_for(old_plan.assignments[0])
+    old_request_path.write_text(json.dumps(old_request))
+    old_result_path = tmp_path / "results" / "run-slurm-stale" / "bucket-00000.json"
+    old_request_path.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "slurm_job_id": "404",
+                "submitted_at_epoch": 1.0,
+                "result_path": str(old_result_path),
+            }
+        )
+    )
+    new_plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["BB"]),
+        run_id="run-slurm-new",
+    )
+    new_request_dir = tmp_path / "queue" / "run-slurm-new"
+    new_request_dir.mkdir(parents=True)
+    (new_request_dir / "bucket-00000.json").write_text(json.dumps(new_plan.request_for(new_plan.assignments[0])))
+    calls = []
+
+    class EmptySacct:
+        stdout = ""
+
+    class Submitted:
+        stdout = "200\n"
+
+    def fake_runner(cmd, **kwargs):
+        calls.append(cmd[0])
+        if cmd[0] == "sacct":
+            return EmptySacct()
+        if cmd[0] == "sbatch":
+            return Submitted()
+        raise AssertionError(cmd)
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        max_active_slurm_jobs=1,
+        slurm_accounting_grace_sec=10.0,
+        runner=fake_runner,
+    )
+
+    assert [event.status for event in events] == ["failed", "submitted"]
+    assert [event.slurm_job_id for event in events] == ["404", "200"]
+    assert calls == ["sacct", "sbatch"]
+    old_envelope = json.loads(old_result_path.read_text())
+    assert old_envelope["status"] == "failed"
+    assert "SLURM_JOB_NOT_FOUND_OR_STALE" in old_envelope["error"]
+    assert (tmp_path / "failed" / "run-slurm-stale" / "bucket-00000.json").exists()
+    assert (tmp_path / "submitted" / "run-slurm-new" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_slurm_fresh_missing_job_keeps_active_slot(clean_registry, tmp_path):
+    """Recent jobs missing from sacct should keep their active slot during the grace window."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    old_plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-fresh",
+    )
+    old_request_dir = tmp_path / "submitted" / "run-slurm-fresh"
+    old_request_dir.mkdir(parents=True)
+    old_request_path = old_request_dir / "bucket-00000.json"
+    old_request_path.write_text(json.dumps(old_plan.request_for(old_plan.assignments[0])))
+    old_result_path = tmp_path / "results" / "run-slurm-fresh" / "bucket-00000.json"
+    old_request_path.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "slurm_job_id": "405",
+                "submitted_at_epoch": remote_execution_mod.time.time(),
+                "result_path": str(old_result_path),
+            }
+        )
+    )
+    new_plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["BB"]),
+        run_id="run-slurm-waiting",
+    )
+    new_request_dir = tmp_path / "queue" / "run-slurm-waiting"
+    new_request_dir.mkdir(parents=True)
+    (new_request_dir / "bucket-00000.json").write_text(json.dumps(new_plan.request_for(new_plan.assignments[0])))
+
+    class EmptySacct:
+        stdout = ""
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        max_active_slurm_jobs=1,
+        slurm_accounting_grace_sec=3600.0,
+        runner=lambda *args, **kwargs: EmptySacct(),
+    )
+
+    assert events == []
+    assert old_request_path.exists()
+    assert not old_result_path.exists()
+    assert (tmp_path / "queue" / "run-slurm-waiting" / "bucket-00000.json").exists()
+
+
+def test_reconcile_submitted_slurm_failed_job_writes_failed_envelope(clean_registry, tmp_path):
+    """Slurm reconciliation should expose terminal job failure as a failed bucket."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-failed",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-failed"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(json.dumps(plan.request_for(plan.assignments[0])))
+    sidecar = request_path.with_name("bucket-00000.json.slurm.json")
+    result_path = tmp_path / "results" / "run-slurm-failed" / "bucket-00000.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "slurm_job_id": "123",
+                "run_id": "run-slurm-failed",
+                "bucket_id": "bucket-00000",
+                "result_path": str(result_path),
+            }
+        )
+    )
+
+    class FakeCompleted:
+        stdout = "123|FAILED\n123.batch|COMPLETED\n"
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        assert cmd[:4] == ["sacct", "--noheader", "--parsable2", "--format=JobIDRaw,State"]
+        assert check is True
+        assert text is True
+        assert capture_output is True
+        return FakeCompleted()
+
+    events = reconcile_submitted_slurm_jobs(tmp_path / "submitted", tmp_path / "results", runner=fake_runner)
+
+    assert [event.status for event in events] == ["failed"]
+    assert events[0].slurm_job_id == "123"
+    envelope = json.loads(result_path.read_text())
+    assert envelope["status"] == "failed"
+    assert "Slurm job 123 ended with state FAILED" in envelope["error"]
+    assert (tmp_path / "failed" / "run-slurm-failed" / "bucket-00000.json").exists()
+    assert (tmp_path / "failed" / "run-slurm-failed" / "bucket-00000.json.slurm.json").exists()
+    assert not request_path.exists()
+    assert not sidecar.exists()
+
+
+def test_reconcile_submitted_slurm_rejects_unsafe_sidecar_result_path(clean_registry, tmp_path):
+    """Slurm sidecars cannot redirect result reconciliation outside the results root."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-sidecar-path",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-sidecar-path"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(json.dumps(plan.request_for(plan.assignments[0])))
+    sidecar = request_path.with_name("bucket-00000.json.slurm.json")
+    outside_path = tmp_path / "outside.json"
+    safe_result_path = tmp_path / "results" / "run-slurm-sidecar-path" / "bucket-00000.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "slurm_job_id": "126",
+                "result_path": str(outside_path),
+            }
+        )
+    )
+
+    events = reconcile_submitted_slurm_jobs(
+        tmp_path / "submitted",
+        tmp_path / "results",
+        runner=lambda *args, **kwargs: None,
+    )
+
+    assert [event.status for event in events] == ["failed"]
+    assert not outside_path.exists()
+    envelope = json.loads(safe_result_path.read_text())
+    assert envelope["status"] == "failed"
+    assert "result_path mismatch" in envelope["error"]
+    assert (tmp_path / "failed" / "run-slurm-sidecar-path" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_slurm_reconciles_completed_result(clean_registry, tmp_path):
+    """Slurm manager should move submitted requests to done after result appears."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-completed",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-completed"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request = plan.request_for(plan.assignments[0])
+    request_path.write_text(json.dumps(request))
+    result_path = tmp_path / "results" / "run-slurm-completed" / "bucket-00000.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(execute_request(request)))
+    request_path.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps({"schema_version": 1, "status": "submitted", "slurm_job_id": "124", "result_path": str(result_path)})
+    )
+
+    events = run_manager_once(
+        tmp_path / "queue",
+        tmp_path / "results",
+        scheduler="slurm",
+        max_active_slurm_jobs=1,
+        runner=lambda *args, **kwargs: None,
+    )
+
+    assert [event.status for event in events] == ["completed"]
+    assert (tmp_path / "done" / "run-slurm-completed" / "bucket-00000.json").exists()
+    assert (tmp_path / "done" / "run-slurm-completed" / "bucket-00000.json.slurm.json").exists()
+    assert not request_path.exists()
+
+
+def test_run_manager_once_reconciles_running_completed_result(clean_registry, tmp_path):
+    """Manager restart should finalize a running request when its completed result is visible."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-completed",
+    )
+    request = plan.request_for(plan.assignments[0])
+    request_path = tmp_path / "running" / "run-running-completed" / "bucket-00000.json"
+    request_path.parent.mkdir(parents=True)
+    request_path.write_text(json.dumps(request))
+    result_path = tmp_path / "results" / "run-running-completed" / "bucket-00000.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(execute_request(request)))
+
+    events = run_manager_once(tmp_path / "queue", tmp_path / "results")
+
+    assert [(event.status, event.request_path, event.result_path) for event in events] == [
+        (
+            "completed",
+            tmp_path / "done" / "run-running-completed" / "bucket-00000.json",
+            result_path,
+        )
+    ]
+    assert not request_path.exists()
+    assert (tmp_path / "done" / "run-running-completed" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_reconciles_running_failed_result(clean_registry, tmp_path):
+    """Manager restart should finalize a running request when its failed result is visible."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-failed",
+    )
+    request = plan.request_for(plan.assignments[0])
+    request_path = tmp_path / "running" / "run-running-failed" / "bucket-00000.json"
+    request_path.parent.mkdir(parents=True)
+    request_path.write_text(json.dumps(request))
+    result_path = tmp_path / "results" / "run-running-failed" / "bucket-00000.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "tool_key": "remote-mock",
+                "run_id": "run-running-failed",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "error": "boom",
+            }
+        )
+    )
+
+    events = run_manager_once(tmp_path / "queue", tmp_path / "results")
+
+    assert [(event.status, event.request_path, event.result_path) for event in events] == [
+        (
+            "failed",
+            tmp_path / "failed" / "run-running-failed" / "bucket-00000.json",
+            result_path,
+        )
+    ]
+    assert not request_path.exists()
+    assert (tmp_path / "failed" / "run-running-failed" / "bucket-00000.json").exists()
+
+
+def test_run_manager_once_leaves_running_request_without_result(clean_registry, tmp_path):
+    """Manager restart should not guess that a result-less running request is stale."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-no-result",
+    )
+    request_path = tmp_path / "running" / "run-running-no-result" / "bucket-00000.json"
+    request_path.parent.mkdir(parents=True)
+    request_path.write_text(json.dumps(plan.request_for(plan.assignments[0])))
+
+    events = run_manager_once(tmp_path / "queue", tmp_path / "results")
+
+    assert events == []
+    assert request_path.exists()
+    assert not (tmp_path / "done").exists()
+    assert not (tmp_path / "failed").exists()
+
+
+def test_reconcile_submitted_slurm_completed_result_does_not_query_sacct(clean_registry, tmp_path):
+    """Visible result envelopes should reconcile without depending on Slurm accounting."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-result-first",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-result-first"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request = plan.request_for(plan.assignments[0])
+    request_path.write_text(json.dumps(request))
+    result_path = tmp_path / "results" / "run-slurm-result-first" / "bucket-00000.json"
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(execute_request(request)))
+    request_path.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps({"schema_version": 1, "status": "submitted", "slurm_job_id": "126", "result_path": str(result_path)})
+    )
+
+    def forbidden_runner(*args, **kwargs):
+        raise AssertionError("sacct should not run when the result envelope is already visible")
+
+    events = reconcile_submitted_slurm_jobs(tmp_path / "submitted", tmp_path / "results", runner=forbidden_runner)
+
+    assert [event.status for event in events] == ["completed"]
+    assert (tmp_path / "done" / "run-slurm-result-first" / "bucket-00000.json").exists()
+    assert (tmp_path / "done" / "run-slurm-result-first" / "bucket-00000.json.slurm.json").exists()
+
+
+def test_run_manager_loop_logs_transient_slurm_reconcile_failure_and_continues(
+    clean_registry,
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    """Persistent manager loops should log transient accounting failures and keep polling."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-sacct-down",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-sacct-down"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(json.dumps(plan.request_for(plan.assignments[0])))
+    result_path = tmp_path / "results" / "run-slurm-sacct-down" / "bucket-00000.json"
+    request_path.with_name("bucket-00000.json.slurm.json").write_text(
+        json.dumps({"schema_version": 1, "status": "submitted", "slurm_job_id": "127", "result_path": str(result_path)})
+    )
+
+    def failing_runner(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr="sacct unavailable")
+
+    def stop_after_first_tick(interval):
+        assert interval == 0.01
+        raise RuntimeError("stop-after-first-tick")
+
+    monkeypatch.setattr(remote_execution_mod.time, "sleep", stop_after_first_tick)
+
+    with pytest.raises(RuntimeError, match="stop-after-first-tick"):
+        run_manager_loop(
+            tmp_path / "queue",
+            tmp_path / "results",
+            scheduler="slurm",
+            poll_interval=0.01,
+            max_active_slurm_jobs=1,
+            runner=failing_runner,
+        )
+
+    captured = capsys.readouterr()
+    assert "CalledProcessError" in captured.err
+    assert "sacct unavailable" in captured.err
+    assert request_path.exists()
+    assert not result_path.exists()
+
+
+def test_reconcile_submitted_slurm_completed_without_result_fails_visible(clean_registry, tmp_path):
+    """Completed Slurm jobs that write no envelope should become explicit failures."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/proto", scheduler="slurm")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-slurm-missing-result",
+    )
+    request_dir = tmp_path / "submitted" / "run-slurm-missing-result"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "bucket-00000.json"
+    request_path.write_text(json.dumps(plan.request_for(plan.assignments[0])))
+    sidecar = request_path.with_name("bucket-00000.json.slurm.json")
+    result_path = tmp_path / "results" / "run-slurm-missing-result" / "bucket-00000.json"
+    sidecar.write_text(
+        json.dumps({"schema_version": 1, "status": "submitted", "slurm_job_id": "125", "result_path": str(result_path)})
+    )
+
+    class FakeCompleted:
+        stdout = "125|COMPLETED\n"
+
+    events = reconcile_submitted_slurm_jobs(
+        tmp_path / "submitted",
+        tmp_path / "results",
+        runner=lambda *args, **kwargs: FakeCompleted(),
+    )
+
+    assert [event.status for event in events] == ["failed"]
+    envelope = json.loads(result_path.read_text())
+    assert envelope["status"] == "failed"
+    assert "COMPLETED_WITHOUT_RESULT" in envelope["error"]
+
+
+def test_execute_request_file_writes_failed_envelope(clean_registry, tmp_path):
+    """Request-file execution should leave a failed envelope before raising."""
+    _register_remote_mock_tool(clean_registry)
+    request_path = tmp_path / "request.json"
+    output_path = tmp_path / "result.json"
+    request_path.write_text(
+        json.dumps({"schema_version": 1, "tool_key": "missing-tool", "run_id": "r", "bucket_id": "b"})
+    )
+
+    with pytest.raises(ValueError):
+        execute_request_file(request_path, output_path)
+
+    envelope = json.loads(output_path.read_text())
+    assert envelope["status"] == "failed"
+    assert envelope["tool_key"] == "missing-tool"
+    assert "missing-tool" in envelope["traceback"]
+
+
+def test_execute_request_batch_rejects_unsafe_result_path_segments(clean_registry, tmp_path):
+    """Batch workers must keep malformed request failures inside the results root."""
+    _register_remote_mock_tool(clean_registry)
+    request_path = tmp_path / "bad.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "tool_key": "remote-mock",
+                "run_id": "run-safe",
+                "bucket_id": "../escape",
+                "item_indices": [0],
+                "inputs": {"sequences": ["AA"]},
+                "config": {"device": "cuda:0"},
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=r"request\.bucket_id"):
+        remote_execution_mod.execute_request_batch([request_path], tmp_path / "results")
+
+    assert not (tmp_path / "escape.json").exists()
+    failed_result = tmp_path / "results" / "failed" / "bad.json.json"
+    envelope = json.loads(failed_result.read_text())
+    assert envelope["status"] == "failed"
+    assert "request.bucket_id" in envelope["error"]
+
+
+def test_collect_plan_outputs_merges_node_results(clean_registry, tmp_path):
+    """Collected result files should merge back in original input order."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", weight=1.0, worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", weight=1.0, worker_device="cuda:1"),
+    ]
+    plan = RemoteDispatchPlanner(nodes, bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        run_id="run-6",
+    )
+    for assignment in plan.assignments:
+        result = execute_request(plan.request_for(assignment))
+        result_path = tmp_path / assignment.node.name / "run-6" / f"{assignment.bucket.bucket_id}.json"
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(result))
+
+    merged = collect_plan_outputs(plan, tmp_path)
+
+    assert merged.results == ["AA:cuda:0:x", "BB:cuda:1:x"]
+    assert merged.metadata["remote_dispatch"]["run_id"] == "run-6"
+
+
+def test_remote_run_manifest_round_trips_and_collects_results(clean_registry, tmp_path):
+    """Run manifests should survive process boundaries and collect results."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", worker_device="cuda:1"),
+    ]
+    plan = RemoteDispatchPlanner(nodes, bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        run_id="run-manifest",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=nodes, bucket_size=1, local_results_dir=tmp_path)
+    manifest_path = tmp_path / "run.manifest.json"
+
+    write_remote_run_manifest(manifest, manifest_path)
+    loaded = load_remote_run_manifest(manifest_path)
+
+    assert loaded.to_dict() == manifest.to_dict()
+    assert [request.bucket_id for request in loaded.requests] == ["bucket-00000", "bucket-00001"]
+    for request in loaded.requests:
+        result = execute_request(request.request)
+        result_path = loaded.local_result_path(request)
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(result))
+
+    merged = collect_remote_run_manifest(loaded)
+
+    assert merged.results == ["AA:cuda:0:x", "BB:cuda:1:x"]
+    assert merged.metadata["remote_dispatch"]["run_id"] == "run-manifest"
+
+
+def test_launch_remote_run_preflights_starts_submits_waits_and_collects(clean_registry, tmp_path):
+    """Launch should compose manager startup, manifest submission, wait, and collect."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", worker_device="cuda:1"),
+    ]
+    events = []
+    local_results_dir = tmp_path / "results"
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            events.append(("preflight", node.name))
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            del runner
+            events.append(("start", node.name, poll_interval, slurm_group_size))
+            return f"started {node.name}"
+
+    class FakeCompleted:
+        stdout = ""
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del text, check, capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        payload = json.loads(input)
+        for item in payload["requests"]:
+            request = item["request"]
+            result = execute_request(request)
+            result_path = local_results_dir / cmd[1] / request["run_id"] / item["filename"]
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps(result))
+        return FakeCompleted()
+
+    result = launch_remote_run(
+        "remote-mock",
+        nodes,
+        RemoteMockInput(sequences=["AA", "BB"]),
+        RemoteMockConfig(device="remote"),
+        bucket_size=1,
+        local_results_dir=local_results_dir,
+        manifest_path=tmp_path / "run.manifest.json",
+        output_path=tmp_path / "output.json",
+        run_id="run-launch",
+        manager_poll_interval=2.0,
+        slurm_group_size=7,
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    assert result.run_id == "run-launch"
+    assert result.bucket_count == 2
+    assert result.staged_count == 2
+    assert result.managers == {"ty": "started ty", "ty3": "started ty3"}
+    assert (tmp_path / "run.manifest.json").exists()
+    assert json.loads((tmp_path / "output.json").read_text())["results"] == ["AA:cuda:0:x", "BB:cuda:1:x"]
+    assert events[:4] == [
+        ("preflight", "ty"),
+        ("preflight", "ty3"),
+        ("start", "ty", 2.0, 7),
+        ("start", "ty3", 2.0, 7),
+    ]
+    assert ("runner", "ssh", "ty") in events
+    assert ("runner", "ssh", "ty3") in events
+
+
+def test_launch_remote_run_skips_completed_result_beside_running_request(clean_registry, tmp_path):
+    """Launch should survive submit immediately after manager start when running already has a result."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir=str(tmp_path / "remote" / "ty"),
+        worker_device="cuda:0",
+        python=sys.executable,
+    )
+    local_results_dir = tmp_path / "results"
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        RemoteMockConfig(device="remote"),
+        run_id="run-launch-running-result",
+    )
+    request = plan.request_for(plan.assignments[0])
+    result_payload = execute_request(request)
+    remote_running = Path(node.work_dir) / "running" / "run-launch-running-result" / "bucket-00000.json"
+    remote_running.parent.mkdir(parents=True)
+    remote_running.write_text(json.dumps(request, sort_keys=True) + "\n")
+    remote_result = Path(node.work_dir) / "results" / "run-launch-running-result" / "bucket-00000.json"
+    remote_result.parent.mkdir(parents=True)
+    remote_result.write_text(json.dumps(result_payload, sort_keys=True) + "\n")
+    local_result = local_results_dir / "ty" / "run-launch-running-result" / "bucket-00000.json"
+    local_result.parent.mkdir(parents=True)
+    local_result.write_text(json.dumps(result_payload, sort_keys=True) + "\n")
+    events = []
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            events.append(("preflight", node.name))
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            del poll_interval, slurm_group_size, runner
+            events.append(("start", node.name))
+            return f"started {node.name}"
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        proc = subprocess.run(
+            ["bash", "-lc", cmd[-1]],
+            input=input,
+            text=text,
+            capture_output=True,
+            check=False,
+        )
+        if check and proc.returncode:
+            raise subprocess.CalledProcessError(proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr)
+        return proc
+
+    result = launch_remote_run(
+        "remote-mock",
+        [node],
+        RemoteMockInput(sequences=["AA"]),
+        RemoteMockConfig(device="remote"),
+        bucket_size=1,
+        local_results_dir=local_results_dir,
+        manifest_path=tmp_path / "run.manifest.json",
+        output_path=tmp_path / "output.json",
+        run_id="run-launch-running-result",
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    assert result.run_id == "run-launch-running-result"
+    assert json.loads((tmp_path / "output.json").read_text())["results"] == ["AA:cuda:0:x"]
+    assert events == [("preflight", "ty"), ("start", "ty"), ("runner", "ssh", "ty")]
+    assert remote_running.exists()
+    assert not (Path(node.work_dir) / "queue" / "run-launch-running-result" / "bucket-00000.json").exists()
+
+
+def test_launch_remote_run_rejects_existing_output_before_remote_side_effects(clean_registry, tmp_path):
+    """Launch should not preflight, write a manifest, or submit when output exists."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    manifest_path = tmp_path / "run.manifest.json"
+    output_path = tmp_path / "output.json"
+    output_path.write_text("sentinel\n")
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            raise AssertionError("preflight should not run")
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            raise AssertionError("manager start should not run")
+
+    def fake_runner(*args, **kwargs):
+        raise AssertionError("submission should not run")
+
+    with pytest.raises(FileExistsError, match="Remote run output already exists"):
+        launch_remote_run(
+            "remote-mock",
+            [node],
+            RemoteMockInput(sequences=["AA"]),
+            RemoteMockConfig(device="remote"),
+            bucket_size=1,
+            local_results_dir=tmp_path / "results",
+            manifest_path=manifest_path,
+            output_path=output_path,
+            manager_client=FakeManager(),
+            runner=fake_runner,
+        )
+
+    assert output_path.read_text() == "sentinel\n"
+    assert not manifest_path.exists()
+
+
+def test_launch_remote_run_overwrite_output_allows_existing_output(clean_registry, tmp_path):
+    """Explicit overwrite_output should allow launch to replace an existing output."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    local_results_dir = tmp_path / "results"
+    output_path = tmp_path / "output.json"
+    output_path.write_text("sentinel\n")
+    events = []
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            del poll_interval, slurm_group_size, runner
+            return f"started {node.name}"
+
+    class FakeCompleted:
+        stdout = ""
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del text, check, capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        payload = json.loads(input)
+        for item in payload["requests"]:
+            request = item["request"]
+            result = execute_request(request)
+            result_path = local_results_dir / cmd[1] / request["run_id"] / item["filename"]
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps(result))
+        return FakeCompleted()
+
+    launch_remote_run(
+        "remote-mock",
+        [node],
+        RemoteMockInput(sequences=["AA"]),
+        RemoteMockConfig(device="remote"),
+        bucket_size=1,
+        local_results_dir=local_results_dir,
+        manifest_path=tmp_path / "run.manifest.json",
+        output_path=output_path,
+        run_id="run-overwrite-output",
+        overwrite_output=True,
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    assert json.loads(output_path.read_text())["results"] == ["AA:cuda:0:x"]
+    assert ("runner", "ssh", "ty") in events
+
+
+def test_remote_run_diagnostics_backlog_loads_counts_visible_backlog() -> None:
+    """Diagnostics backlog loads should count only pending manager states."""
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3"),
+    ]
+    calls = []
+
+    class FakeManager:
+        def diagnostics_node(self, node, *, timeout_sec, runner):
+            calls.append((node.name, timeout_sec, runner))
+            counts = {"queue": 2, "running": 3, "submitted": 5, "done": 99} if node.name == "ty" else {}
+            return {"node": node.name, "counts": counts}
+
+    diagnostics, loads = remote_run_diagnostics_backlog_loads(
+        nodes,
+        manager_client=FakeManager(),
+        timeout_sec=12.0,
+        runner="runner",
+    )
+
+    assert diagnostics == {
+        "ty": {"node": "ty", "counts": {"queue": 2, "running": 3, "submitted": 5, "done": 99}},
+        "ty3": {"node": "ty3", "counts": {}},
+    }
+    assert loads == {"ty": 10.0, "ty3": 0.0}
+    assert calls == [("ty", 12.0, "runner"), ("ty3", 12.0, "runner")]
+
+
+def test_remote_dispatch_planner_rejects_unsafe_run_id(clean_registry) -> None:
+    """User-provided run_id values should not become nested remote/local paths."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+
+    with pytest.raises(ValueError, match="run_id"):
+        RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+            "remote-mock",
+            RemoteMockInput(sequences=["AA"]),
+            run_id="../escape",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutator", "pattern"),
+    [
+        (lambda data: data.update({"run_id": "../escape"}), "run_id"),
+        (lambda data: data["requests"][0].update({"node_name": "../escape"}), "node_name"),
+        (lambda data: data["requests"][0].update({"bucket_id": "../escape"}), "bucket_id"),
+        (lambda data: data["requests"][0].update({"node_name": "missing"}), "unknown node"),
+        (lambda data: data["requests"].append(dict(data["requests"][0])), "duplicate bucket"),
+        (lambda data: data["requests"][0]["request"].update({"run_id": "other-run"}), "identity mismatch"),
+        (lambda data: data["requests"][0]["request"].update({"bucket_id": "../escape"}), "identity mismatch"),
+    ],
+)
+def test_remote_run_manifest_rejects_unsafe_or_mismatched_path_identity(
+    clean_registry,
+    tmp_path,
+    mutator,
+    pattern,
+) -> None:
+    """Loaded manifests must reject path traversal and inner/outer identity drift."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-safe",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path)
+    data = json.loads(json.dumps(manifest.to_dict()))
+    mutator(data)
+
+    with pytest.raises(ValueError, match=pattern):
+        RemoteRunManifest.from_dict(data)
+
+
+def test_launch_remote_run_can_use_diagnostics_backlog_for_planning(clean_registry, tmp_path):
+    """Launch can seed planning load from existing remote manager backlog."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", weight=1.0, worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", weight=1.0, worker_device="cuda:1"),
+    ]
+    events = []
+    local_results_dir = tmp_path / "results"
+
+    class FakeManager:
+        def preflight_node(self, node, *, timeout_sec, runner):
+            del runner
+            events.append(("preflight", node.name, timeout_sec))
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, timeout_sec, runner):
+            del poll_interval, slurm_group_size, runner
+            events.append(("start", node.name, timeout_sec))
+            return f"started {node.name}"
+
+        def diagnostics_node(self, node, *, timeout_sec, runner):
+            del runner
+            backlog = {"queue": 10, "running": 0, "submitted": 0} if node.name == "ty" else {}
+            events.append(("diagnostics", node.name, timeout_sec, backlog))
+            return {"node": node.name, "counts": backlog}
+
+    class FakeCompleted:
+        stdout = ""
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del text, check, capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        payload = json.loads(input)
+        for item in payload["requests"]:
+            request = item["request"]
+            result = execute_request(request)
+            result_path = local_results_dir / cmd[1] / request["run_id"] / item["filename"]
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps(result))
+        return FakeCompleted()
+
+    result = launch_remote_run(
+        "remote-mock",
+        nodes,
+        RemoteMockInput(sequences=["A", "B"]),
+        RemoteMockConfig(device="remote"),
+        bucket_size=1,
+        local_results_dir=local_results_dir,
+        manifest_path=tmp_path / "run.manifest.json",
+        output_path=tmp_path / "output.json",
+        run_id="run-backlog",
+        use_diagnostics_backlog=True,
+        timeout_sec=30.0,
+        remote_check_timeout_sec=12.5,
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    manifest = load_remote_run_manifest(tmp_path / "run.manifest.json")
+    assert [request.node_name for request in manifest.requests] == ["ty3", "ty3"]
+    assert result.initial_node_loads == {"ty": 10.0, "ty3": 0.0}
+    assert ("preflight", "ty", 12.5) in events
+    assert ("start", "ty", 12.5) in events
+    assert ("diagnostics", "ty", 12.5, {"queue": 10, "running": 0, "submitted": 0}) in events
+
+
+def test_resume_remote_run_manifest_reuses_existing_manifest_without_replanning(clean_registry, tmp_path):
+    """Resume should drive an existing manifest through managers, submit, wait, and collect."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", worker_device="cuda:1"),
+    ]
+    plan = RemoteDispatchPlanner(nodes, bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        RemoteMockConfig(device="remote"),
+        run_id="run-resume",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=nodes, bucket_size=1, local_results_dir=tmp_path / "results")
+    manifest_path = tmp_path / "run.manifest.json"
+    write_remote_run_manifest(manifest, manifest_path)
+    original_manifest_text = manifest_path.read_text()
+    events = []
+
+    class FakeManager:
+        def preflight_node(self, node, *, timeout_sec, runner):
+            del runner
+            events.append(("preflight", node.name, timeout_sec))
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, timeout_sec, runner):
+            del runner
+            events.append(("start", node.name, poll_interval, slurm_group_size, timeout_sec))
+            return f"started {node.name}"
+
+    class FakeCompleted:
+        stdout = ""
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del text, check, capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        payload = json.loads(input)
+        for item in payload["requests"]:
+            request = item["request"]
+            result = execute_request(request)
+            result_path = Path(manifest.local_results_dir) / cmd[1] / request["run_id"] / item["filename"]
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(json.dumps(result))
+        return FakeCompleted()
+
+    result = resume_remote_run_manifest(
+        load_remote_run_manifest(manifest_path),
+        manifest_path=manifest_path,
+        output_path=tmp_path / "output.json",
+        manager_poll_interval=2.0,
+        slurm_group_size=7,
+        timeout_sec=30.0,
+        remote_check_timeout_sec=12.5,
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    assert result.run_id == "run-resume"
+    assert result.manifest_path == str(manifest_path)
+    assert result.bucket_count == 2
+    assert result.staged_count == 2
+    assert result.managers == {"ty": "started ty", "ty3": "started ty3"}
+    assert manifest_path.read_text() == original_manifest_text
+    assert json.loads((tmp_path / "output.json").read_text())["results"] == ["AA:cuda:0:x", "BB:cuda:1:x"]
+    assert events[:4] == [
+        ("preflight", "ty", 12.5),
+        ("preflight", "ty3", 12.5),
+        ("start", "ty", 2.0, 7, 12.5),
+        ("start", "ty3", 2.0, 7, 12.5),
+    ]
+
+
+def test_resume_remote_run_manifest_skips_completed_result_beside_running_request(clean_registry, tmp_path):
+    """Resume should not fail when a completed result is visible before running is reconciled."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir=str(tmp_path / "remote" / "ty"),
+        worker_device="cuda:0",
+        python=sys.executable,
+    )
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        RemoteMockConfig(device="remote"),
+        run_id="run-resume-running-result",
+    )
+    manifest = RemoteRunManifest.from_plan(
+        plan,
+        nodes=[node],
+        bucket_size=1,
+        local_results_dir=tmp_path / "results",
+    )
+    manifest_path = tmp_path / "run.manifest.json"
+    write_remote_run_manifest(manifest, manifest_path)
+    request = manifest.requests[0].request
+    result_payload = execute_request(request)
+    remote_running = Path(node.work_dir) / "running" / manifest.run_id / "bucket-00000.json"
+    remote_running.parent.mkdir(parents=True)
+    remote_running.write_text(json.dumps(request, sort_keys=True) + "\n")
+    remote_result = Path(node.work_dir) / "results" / manifest.run_id / "bucket-00000.json"
+    remote_result.parent.mkdir(parents=True)
+    remote_result.write_text(json.dumps(result_payload, sort_keys=True) + "\n")
+    local_result = manifest.local_result_path(manifest.requests[0])
+    local_result.parent.mkdir(parents=True)
+    local_result.write_text(json.dumps(result_payload, sort_keys=True) + "\n")
+    events = []
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            events.append(("preflight", node.name))
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            del poll_interval, slurm_group_size, runner
+            events.append(("start", node.name))
+            return f"started {node.name}"
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        proc = subprocess.run(
+            ["bash", "-lc", cmd[-1]],
+            input=input,
+            text=text,
+            capture_output=True,
+            check=False,
+        )
+        if check and proc.returncode:
+            raise subprocess.CalledProcessError(proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr)
+        return proc
+
+    result = resume_remote_run_manifest(
+        load_remote_run_manifest(manifest_path),
+        manifest_path=manifest_path,
+        output_path=tmp_path / "output.json",
+        wait_poll_interval=0.01,
+        manager_client=FakeManager(),
+        runner=fake_runner,
+    )
+
+    assert result.run_id == "run-resume-running-result"
+    assert json.loads((tmp_path / "output.json").read_text())["results"] == ["AA:cuda:0:x"]
+    assert events == [("preflight", "ty"), ("start", "ty"), ("runner", "ssh", "ty")]
+    assert remote_running.exists()
+    assert not (Path(node.work_dir) / "queue" / manifest.run_id / "bucket-00000.json").exists()
+
+
+def test_resume_remote_run_manifest_rejects_existing_output_before_remote_side_effects(clean_registry, tmp_path):
+    """Resume should not preflight, submit, or rewrite evidence when output exists."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        RemoteMockConfig(device="remote"),
+        run_id="run-resume-output-exists",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path / "results")
+    manifest_path = tmp_path / "run.manifest.json"
+    write_remote_run_manifest(manifest, manifest_path)
+    original_manifest_text = manifest_path.read_text()
+    output_path = tmp_path / "output.json"
+    output_path.write_text("sentinel\n")
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            raise AssertionError("preflight should not run")
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            raise AssertionError("manager start should not run")
+
+    def fake_runner(*args, **kwargs):
+        raise AssertionError("submission should not run")
+
+    with pytest.raises(FileExistsError, match="Remote run output already exists"):
+        resume_remote_run_manifest(
+            load_remote_run_manifest(manifest_path),
+            manifest_path=manifest_path,
+            output_path=output_path,
+            manager_client=FakeManager(),
+            runner=fake_runner,
+        )
+
+    assert output_path.read_text() == "sentinel\n"
+    assert manifest_path.read_text() == original_manifest_text
+
+
+def test_launch_remote_run_preflight_failure_stops_before_manifest(clean_registry, tmp_path):
+    """Launch should not submit or write a manifest when preflight fails."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            return {"node": node.name, "ok": False, "checks": [{"name": "import proto_tools", "ok": False}]}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            raise AssertionError("manager start should not run")
+
+    def fake_runner(*args, **kwargs):
+        raise AssertionError("submission should not run")
+
+    with pytest.raises(ValueError, match="Remote preflight failed"):
+        launch_remote_run(
+            "remote-mock",
+            [node],
+            RemoteMockInput(sequences=["AA"]),
+            RemoteMockConfig(device="remote"),
+            bucket_size=1,
+            local_results_dir=tmp_path / "results",
+            manifest_path=tmp_path / "run.manifest.json",
+            output_path=tmp_path / "output.json",
+            manager_client=FakeManager(),
+            runner=fake_runner,
+        )
+
+    assert not (tmp_path / "run.manifest.json").exists()
+    assert not (tmp_path / "output.json").exists()
+
+
+def test_launch_remote_run_background_rsync_failure_stops_wait(clean_registry, tmp_path):
+    """Background launch should surface a stopped rsync loop instead of timing out."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    events = []
+    log_path = tmp_path / "rsync.log"
+    log_path.write_text("rsync failed\n")
+
+    class FakeManager:
+        def preflight_node(self, node, *, runner):
+            del runner
+            return {"node": node.name, "ok": True, "checks": []}
+
+        def start_node(self, node, *, poll_interval, slurm_group_size, runner):
+            del poll_interval, slurm_group_size, runner
+            return f"started {node.name}"
+
+    class FakeRsync:
+        def start(self, nodes, local_results_dir, *, pid_path, log_path, interval_sec, runner):
+            events.append(("start-rsync", [node.name for node in nodes], local_results_dir, pid_path, log_path, interval_sec))
+            return "started 123"
+
+        def status(self, pid_path, *, runner):
+            events.append(("status-rsync", pid_path))
+            return "stale 123"
+
+    class FakeCompleted:
+        stdout = ""
+
+    def fake_runner(cmd, input=None, text=False, check=False, capture_output=False):
+        del input, text, check, capture_output
+        events.append(("runner", cmd[0], cmd[1]))
+        return FakeCompleted()
+
+    with pytest.raises(RuntimeError, match=r"rsync pull loop is not running.*rsync failed"):
+        launch_remote_run(
+            "remote-mock",
+            [node],
+            RemoteMockInput(sequences=["AA"]),
+            RemoteMockConfig(device="remote"),
+            bucket_size=1,
+            local_results_dir=tmp_path / "results",
+            manifest_path=tmp_path / "run.manifest.json",
+            output_path=tmp_path / "output.json",
+            run_id="run-background-rsync",
+            rsync_mode="background",
+            rsync_pid_path=tmp_path / "rsync.pid",
+            rsync_log_path=log_path,
+            manager_client=FakeManager(),
+            rsync_client=FakeRsync(),
+            runner=fake_runner,
+        )
+
+    assert ("status-rsync", tmp_path / "rsync.pid") in events
+
+
+def test_submit_remote_run_manifest_stages_node_batches(clean_registry, tmp_path):
+    """Manifest submission should stage requests grouped by node."""
+    _register_remote_mock_tool(clean_registry)
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3", worker_device="cuda:1"),
+    ]
+    plan = RemoteDispatchPlanner(nodes, bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        run_id="run-submit-manifest",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=nodes, bucket_size=1, local_results_dir=tmp_path)
+    calls = []
+
+    def fake_runner(cmd, input=None, text=False, check=False):
+        calls.append({"cmd": cmd, "input": input, "text": text, "check": check})
+
+    staged = submit_remote_run_manifest(manifest, runner=fake_runner)
+
+    assert staged == [
+        manifest.node_for_request(request).queue_root / "run-submit-manifest" / f"{request.bucket_id}.json"
+        for request in manifest.requests
+    ]
+    assert [call["cmd"][:2] for call in calls] == [["ssh", "ty"], ["ssh", "ty3"]]
+    assert all(call["text"] is True and call["check"] is True for call in calls)
+    payloads = [json.loads(call["input"]) for call in calls]
+    assert [[item["filename"] for item in payload["requests"]] for payload in payloads] == [
+        ["bucket-00000.json"],
+        ["bucket-00001.json"],
+    ]
+
+    calls.clear()
+    selected = submit_remote_run_manifest(
+        manifest,
+        bucket_ids={"bucket-00001"},
+        runner=fake_runner,
+    )
+
+    assert selected == [nodes[1].queue_root / "run-submit-manifest" / "bucket-00001.json"]
+    assert [call["cmd"][:2] for call in calls] == [["ssh", "ty3"]]
+    assert [item["filename"] for item in json.loads(calls[0]["input"])["requests"]] == [
+        "bucket-00001.json"
+    ]
+
+
+def _run_stage_many_locally(root: Path, request: dict[str, object]):
+    """Run the remote staging script against a local state root."""
+    payload = {
+        "schema_version": 1,
+        "run_id": request["run_id"],
+        "requests": [{"filename": f"{request['bucket_id']}.json", "request": request}],
+    }
+    root.mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        [sys.executable, "-c", RemoteSubmissionClient._STAGE_MANY_PY, str(root), "--summary"],
+        input=json.dumps(payload, sort_keys=True) + "\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("state", ["queue", "submitted", "done"])
+def test_manifest_submit_skips_identical_request_already_in_state(clean_registry, tmp_path, state):
+    """Manifest submit should be idempotent for already staged or completed requests."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-idempotent",
+    )
+    request = plan.request_for(plan.assignments[0])
+    existing = tmp_path / state / "run-idempotent" / "bucket-00000.json"
+    existing.parent.mkdir(parents=True)
+    existing.write_text(json.dumps(request, sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-idempotent", request)
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {
+        "skipped": [
+            {
+                "filename": "bucket-00000.json",
+                "path": str(existing),
+                "state": state,
+            }
+        ],
+        "staged": [],
+    }
+    assert json.loads(existing.read_text()) == request
+
+
+def test_manifest_submit_skips_matching_completed_result(clean_registry, tmp_path):
+    """Manifest submit should not requeue a bucket that already has a matching completed result."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-result-idempotent",
+    )
+    request = plan.request_for(plan.assignments[0])
+    result = tmp_path / "results" / "run-result-idempotent" / "bucket-00000.json"
+    result.parent.mkdir(parents=True)
+    result.write_text(json.dumps(execute_request(request), sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-result-idempotent", request)
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {
+        "skipped": [
+            {
+                "filename": "bucket-00000.json",
+                "path": str(result),
+                "state": "result",
+            }
+        ],
+        "staged": [],
+    }
+    assert not (tmp_path / "queue" / "run-result-idempotent" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_skips_matching_running_request_without_requeue(clean_registry, tmp_path):
+    """Exact resume should wait for a claimed request without staging a duplicate."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running",
+    )
+    request = plan.request_for(plan.assignments[0])
+    running = tmp_path / "running" / "run-running" / "bucket-00000.json"
+    running.parent.mkdir(parents=True)
+    running.write_text(json.dumps(request, sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-running", request)
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {
+        "skipped": [
+            {
+                "filename": "bucket-00000.json",
+                "path": str(running),
+                "state": "running",
+            }
+        ],
+        "staged": [],
+    }
+    assert not (tmp_path / "queue" / "run-running" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_skips_running_request_with_matching_completed_result(clean_registry, tmp_path):
+    """Manifest submit should tolerate a manager-restart race when the result is already complete."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-result",
+    )
+    request = plan.request_for(plan.assignments[0])
+    running = tmp_path / "running" / "run-running-result" / "bucket-00000.json"
+    running.parent.mkdir(parents=True)
+    running.write_text(json.dumps(request, sort_keys=True) + "\n")
+    result = tmp_path / "results" / "run-running-result" / "bucket-00000.json"
+    result.parent.mkdir(parents=True)
+    result.write_text(json.dumps(execute_request(request), sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-running-result", request)
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {
+        "skipped": [
+            {
+                "filename": "bucket-00000.json",
+                "path": str(result),
+                "state": "running_result",
+            }
+        ],
+        "staged": [],
+    }
+    assert running.exists()
+    assert not (tmp_path / "queue" / "run-running-result" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_rejects_running_request_with_matching_failed_result(clean_registry, tmp_path):
+    """Manifest submit should preserve failed-result evidence beside a running request."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-failed-result",
+    )
+    request = plan.request_for(plan.assignments[0])
+    running = tmp_path / "running" / "run-running-failed-result" / "bucket-00000.json"
+    running.parent.mkdir(parents=True)
+    running.write_text(json.dumps(request, sort_keys=True) + "\n")
+    failed_result = tmp_path / "results" / "run-running-failed-result" / "bucket-00000.json"
+    failed_result.parent.mkdir(parents=True)
+    failed_result.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "tool_key": "remote-mock",
+                "run_id": "run-running-failed-result",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "error": "boom",
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-running-failed-result", request)
+
+    assert proc.returncode != 0
+    assert "request previously failed" in proc.stderr
+    assert json.loads(failed_result.read_text())["error"] == "boom"
+    assert running.exists()
+    assert not (tmp_path / "queue" / "run-running-failed-result" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_rejects_different_running_request_even_with_result(clean_registry, tmp_path):
+    """A completed result should not hide a conflicting running request payload."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-running-conflict",
+    )
+    request = plan.request_for(plan.assignments[0])
+    conflict = dict(request)
+    conflict["inputs"] = {"sequences": ["DIFFERENT"]}
+    running = tmp_path / "running" / "run-running-conflict" / "bucket-00000.json"
+    running.parent.mkdir(parents=True)
+    running.write_text(json.dumps(conflict, sort_keys=True) + "\n")
+    result = tmp_path / "results" / "run-running-conflict" / "bucket-00000.json"
+    result.parent.mkdir(parents=True)
+    result.write_text(json.dumps(execute_request(request), sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-running-conflict", request)
+
+    assert proc.returncode != 0
+    assert "existing running request differs from manifest" in proc.stderr
+    assert json.loads(running.read_text()) == conflict
+    assert not (tmp_path / "queue" / "run-running-conflict" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_rejects_failed_request_state(clean_registry, tmp_path):
+    """Manifest submit should not silently requeue a previously failed request."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-failed-state",
+    )
+    request = plan.request_for(plan.assignments[0])
+    failed = tmp_path / "failed" / "run-failed-state" / "bucket-00000.json"
+    failed.parent.mkdir(parents=True)
+    failed.write_text(json.dumps(request, sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-failed-state", request)
+
+    assert proc.returncode != 0
+    assert "request previously failed" in proc.stderr
+    assert not (tmp_path / "queue" / "run-failed-state" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_rejects_matching_failed_result(clean_registry, tmp_path):
+    """Manifest submit should preserve an existing failed result instead of requeueing."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-failed-result",
+    )
+    request = plan.request_for(plan.assignments[0])
+    failed_result = tmp_path / "results" / "run-failed-result" / "bucket-00000.json"
+    failed_result.parent.mkdir(parents=True)
+    failed_result.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "tool_key": "remote-mock",
+                "run_id": "run-failed-result",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "error": "boom",
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-failed-result", request)
+
+    assert proc.returncode != 0
+    assert "request previously failed" in proc.stderr
+    assert json.loads(failed_result.read_text())["error"] == "boom"
+    assert not (tmp_path / "queue" / "run-failed-result" / "bucket-00000.json").exists()
+
+
+def test_manifest_submit_rejects_different_existing_request(clean_registry, tmp_path):
+    """Manifest submit should fail visibly instead of overwriting a different request."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-conflict",
+    )
+    request = plan.request_for(plan.assignments[0])
+    conflict = dict(request)
+    conflict["inputs"] = {"sequences": ["DIFFERENT"]}
+    existing = tmp_path / "queue" / "run-conflict" / "bucket-00000.json"
+    existing.parent.mkdir(parents=True)
+    existing.write_text(json.dumps(conflict, sort_keys=True) + "\n")
+
+    proc = _run_stage_many_locally(tmp_path / "queue" / "run-conflict", request)
+
+    assert proc.returncode != 0
+    assert "existing queue request differs from manifest" in proc.stderr
+    assert json.loads(existing.read_text()) == conflict
+
+
+def test_wait_remote_run_manifest_raises_on_failed_envelope(clean_registry, tmp_path):
+    """Manifest wait should fail as soon as a failed bucket is mirrored."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-manifest-fail",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path)
+    failed_path = manifest.local_result_path(manifest.requests[0])
+    failed_path.parent.mkdir(parents=True)
+    failed_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "tool_key": "remote-mock",
+                "run_id": "run-manifest-fail",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+                "error": "boom",
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=r"ty/bucket-00000.*boom"):
+        wait_remote_run_manifest(manifest, pull_results=False, poll_interval=0.01, timeout_sec=0.1)
+
+
+def test_wait_remote_run_manifest_rejects_non_completed_envelope(clean_registry, tmp_path):
+    """Manifest wait should not treat a non-completed result envelope as done."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-manifest-submitted",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path)
+    result_path = manifest.local_result_path(manifest.requests[0])
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "submitted",
+                "tool_key": "remote-mock",
+                "run_id": "run-manifest-submitted",
+                "bucket_id": "bucket-00000",
+                "item_indices": [0],
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=r"non-completed result.*status='submitted'"):
+        wait_remote_run_manifest(manifest, pull_results=False, poll_interval=0.01, timeout_sec=0.1)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "pattern"),
+    [
+        ("run_id", "wrong-run", "run_id expected 'run-manifest-identity' got 'wrong-run'"),
+        ("bucket_id", "wrong-bucket", "bucket_id expected 'bucket-00000' got 'wrong-bucket'"),
+        ("tool_key", "wrong-tool", "tool_key expected 'remote-mock' got 'wrong-tool'"),
+        ("item_indices", [1], r"item_indices expected \[0\] got \[1\]"),
+    ],
+)
+def test_wait_remote_run_manifest_rejects_wrong_identity(clean_registry, tmp_path, field, value, pattern):
+    """Manifest wait should reject result files that belong to a different bucket."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-manifest-identity",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path)
+    result = execute_request(manifest.requests[0].request)
+    result[field] = value
+    result_path = manifest.local_result_path(manifest.requests[0])
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(result))
+
+    with pytest.raises(RuntimeError, match=pattern):
+        wait_remote_run_manifest(manifest, pull_results=False, poll_interval=0.01, timeout_sec=0.1)
+
+
+def test_collect_remote_run_manifest_rejects_wrong_identity(clean_registry, tmp_path):
+    """Collect should not merge a completed envelope from a different bucket identity."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-collect-identity",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path)
+    result = execute_request(manifest.requests[0].request)
+    result["run_id"] = "wrong-run"
+    result_path = manifest.local_result_path(manifest.requests[0])
+    result_path.parent.mkdir(parents=True)
+    result_path.write_text(json.dumps(result))
+
+    with pytest.raises(RuntimeError, match="wrong identity"):
+        collect_remote_run_manifest(manifest)
+
+
+def test_wait_remote_run_manifest_checks_background_rsync_health(clean_registry, tmp_path):
+    """Background wait should fail fast when the local rsync loop is no longer running."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-rsync-health",
+    )
+    manifest = RemoteRunManifest.from_plan(plan, nodes=[node], bucket_size=1, local_results_dir=tmp_path / "results")
+    log_path = tmp_path / "rsync.log"
+    log_path.write_text("old line\nfatal rsync error\n")
+    calls = []
+
+    class FakeRsyncClient:
+        def status(self, pid_path, *, runner):
+            calls.append((pid_path, runner))
+            return "stale 123"
+
+    with pytest.raises(RuntimeError, match=r"rsync pull loop is not running[\s\S]*fatal rsync error"):
+        wait_remote_run_manifest(
+            manifest,
+            pull_results=False,
+            poll_interval=0.01,
+            timeout_sec=10,
+            rsync_pid_path=tmp_path / "rsync.pid",
+            rsync_log_path=log_path,
+            rsync_client=FakeRsyncClient(),
+        )
+
+    assert calls == [(tmp_path / "rsync.pid", subprocess.run)]
+
+
+def test_wait_remote_run_manifest_retries_transient_inline_rsync_failure(
+    clean_registry,
+    tmp_path,
+    caplog,
+):
+    """One SSH/rsync transport failure should stay visible and retry within the wait timeout."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-inline-rsync-retry",
+    )
+    manifest = RemoteRunManifest.from_plan(
+        plan,
+        nodes=[node],
+        bucket_size=1,
+        local_results_dir=tmp_path / "results",
+    )
+    calls = []
+
+    def flaky_runner(cmd, *, check):
+        calls.append((cmd, check))
+        if len(calls) == 1:
+            raise subprocess.CalledProcessError(255, cmd, stderr="connection closed")
+        result_path = manifest.local_result_path(manifest.requests[0])
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(json.dumps(execute_request(manifest.requests[0].request)))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    wait_remote_run_manifest(
+        manifest,
+        poll_interval=0.01,
+        timeout_sec=1,
+        runner=flaky_runner,
+    )
+
+    assert len(calls) == 2
+    assert "rsync pull attempt failed" in caplog.text
+
+
+def test_wait_remote_run_manifest_follows_poll_hook_reassignment(clean_registry, tmp_path):
+    """One launcher must keep waiting on the manifest returned by its rebalance hook."""
+    _register_remote_mock_tool(clean_registry)
+    original_node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    target_node = RemoteNode(name="f101", host="f101", work_dir="/remote/f101", worker_device="cuda:0")
+    tool_input = RemoteMockInput(sequences=["AA"])
+    original_plan = RemoteDispatchPlanner([original_node], bucket_size=1).build_plan(
+        "remote-mock",
+        tool_input,
+        run_id="run-live-rebalance",
+    )
+    target_plan = RemoteDispatchPlanner([target_node], bucket_size=1).build_plan(
+        "remote-mock",
+        tool_input,
+        run_id="run-live-rebalance",
+    )
+    original = RemoteRunManifest.from_plan(
+        original_plan,
+        nodes=[original_node],
+        bucket_size=1,
+        local_results_dir=tmp_path,
+    )
+    target = RemoteRunManifest.from_plan(
+        target_plan,
+        nodes=[target_node],
+        bucket_size=1,
+        local_results_dir=tmp_path,
+    )
+    calls = []
+
+    def move_once(current):
+        calls.append(current)
+        result_path = target.local_result_path(target.requests[0])
+        result_path.parent.mkdir(parents=True)
+        result_path.write_text(json.dumps(execute_request(target.requests[0].request)))
+        return target
+
+    completed = wait_remote_run_manifest(
+        original,
+        pull_results=False,
+        poll_interval=0.01,
+        timeout_sec=1,
+        poll_hook=move_once,
+    )
+
+    assert calls == [original]
+    assert completed == target
+
+
+def test_remote_tool_dispatcher_routes_explicit_remote_device(clean_registry, tmp_path):
+    """RemoteToolDispatcher should plug into ToolRegistry for device='remote' calls."""
+    run_remote_mock = _register_remote_mock_tool(clean_registry)
+    nodes = [RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")]
+
+    class InlineSubmitter:
+        def submit_plan(self, plan, runner=None):
+            del runner
+            for assignment in plan.assignments:
+                result = execute_request(plan.request_for(assignment))
+                result_path = tmp_path / assignment.node.name / plan.run_id / f"{assignment.bucket.bucket_id}.json"
+                result_path.parent.mkdir(parents=True, exist_ok=True)
+                result_path.write_text(json.dumps(result))
+
+    with RemoteToolDispatcher(
+        nodes,
+        bucket_size=1,
+        local_results_dir=tmp_path,
+        submission_client=InlineSubmitter(),
+        pull_results=False,
+        poll_interval=0.01,
+    ) as dispatcher:
+        result = run_remote_mock(RemoteMockInput(sequences=["AA", "BB"]), RemoteMockConfig(device="remote"))
+
+    assert result.results == ["AA:cuda:0:x", "BB:cuda:0:x"]
+    assert result.tool_id == "remote-mock"
+    assert dispatcher.last_plan is not None
+    assert dispatcher.last_plan.run_id.startswith("remote-mock-")
+    assert ToolRegistry.dispatch_backend_configured() is False
+
+
+def test_dispatcher_raises_immediately_on_failed_envelope(clean_registry, tmp_path):
+    """Dispatcher waiting should fail as soon as a failed envelope is visible."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA", "BB"]),
+        run_id="run-fail-fast",
+    )
+    failed_path = tmp_path / "ty" / "run-fail-fast" / "bucket-00000.json"
+    failed_path.parent.mkdir(parents=True)
+    failed_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "run_id": "run-fail-fast",
+                "bucket_id": "bucket-00000",
+                "error": "boom",
+            }
+        )
+    )
+
+    dispatcher = RemoteToolDispatcher([node], bucket_size=1, local_results_dir=tmp_path, pull_results=False)
+
+    with pytest.raises(RuntimeError, match=r"ty/bucket-00000.*boom"):
+        dispatcher.wait_for_plan(plan)
+
+
+def test_collect_plan_outputs_failed_envelope_includes_node_path(clean_registry, tmp_path):
+    """Collect errors should include node, bucket, result path, and trace tail."""
+    _register_remote_mock_tool(clean_registry)
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", worker_device="cuda:0")
+    plan = RemoteDispatchPlanner([node], bucket_size=1).build_plan(
+        "remote-mock",
+        RemoteMockInput(sequences=["AA"]),
+        run_id="run-collect-fail",
+    )
+    failed_path = tmp_path / "ty" / "run-collect-fail" / "bucket-00000.json"
+    failed_path.parent.mkdir(parents=True)
+    failed_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "failed",
+                "run_id": "run-collect-fail",
+                "bucket_id": "bucket-00000",
+                "error": "worker died",
+                "traceback": "line1\nlast-line",
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=r"ty/bucket-00000.*worker died.*last-line"):
+        collect_plan_outputs(plan, tmp_path)
+
+
+def test_rsync_command_rendering():
+    """Rsync helpers should render one pull command per node and a parallel loop."""
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty", ssh_args=("-p", "2222")),
+        RemoteNode(
+            name="h100",
+            host="login",
+            rsync_host="h100-data",
+            rsync_ssh_args=("-J", "login"),
+            work_dir="/remote/h100",
+        ),
+    ]
+
+    commands = render_rsync_pull_commands(nodes, Path("/local/results"))
+    script = render_continuous_rsync_script(nodes, Path("/local/results"), interval_sec=30)
+
+    assert commands[0] == [
+        "rsync",
+        "-az",
+        "--partial",
+        "-e",
+        "ssh -p 2222",
+        "ty:/remote/ty/results/",
+        "/local/results/ty/",
+    ]
+    assert commands[1] == [
+        "rsync",
+        "-az",
+        "--partial",
+        "-e",
+        "ssh -J login",
+        "h100-data:/remote/h100/results/",
+        "/local/results/h100/",
+    ]
+    assert script.startswith("while true; do\n  pids=()")
+    assert "ty:/remote/ty/results/" in script
+    assert "h100-data:/remote/h100/results/" in script
+    assert script.count('pids+=("$!")') == 2
+    assert 'wait "$pid" || status=$?' in script
+    assert "sleep 30" in script
+
+
+def test_local_rsync_pull_scripts_manage_pid_and_log_paths():
+    """Local rsync pull scripts should manage pid/log files around the parallel loop."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+
+    start_script = render_start_rsync_pull_script(
+        [node],
+        Path("/local/results"),
+        pid_path=Path("/state/proto-rsync.pid"),
+        log_path=Path("/state/proto-rsync.log"),
+        interval_sec=7,
+    )
+    status_script = render_rsync_pull_status_script(Path("/state/proto-rsync.pid"))
+    stop_script = render_stop_rsync_pull_script(Path("/state/proto-rsync.pid"))
+
+    assert "nohup bash -lc" in start_script
+    assert "/state/proto-rsync.pid" in start_script
+    assert "/state/proto-rsync.log" in start_script
+    assert "pids=()" in start_script
+    assert "sleep 7" in start_script
+    assert "echo running" in status_script
+    assert "echo stale" in status_script
+    assert "kill \"$(cat /state/proto-rsync.pid)\"" in stop_script
+    assert "stale-removed" in stop_script
+
+
+def test_local_rsync_pull_client_uses_local_bash_runner():
+    """LocalRsyncPullClient should run start/status/stop through local bash."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+    outputs = ["started 123\n", "running 123\n", "stopped\n"]
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append({"cmd": cmd, "check": check, "text": text, "capture_output": capture_output})
+        return FakeCompleted(outputs.pop(0))
+
+    client = LocalRsyncPullClient()
+
+    assert (
+        client.start(
+            [node],
+            Path("/local/results"),
+            pid_path=Path("/state/proto-rsync.pid"),
+            log_path=Path("/state/proto-rsync.log"),
+            runner=fake_runner,
+        )
+        == "started 123"
+    )
+    assert client.status(Path("/state/proto-rsync.pid"), runner=fake_runner) == "running 123"
+    assert client.stop(Path("/state/proto-rsync.pid"), runner=fake_runner) == "stopped"
+
+    assert [call["cmd"][:2] for call in calls] == [["bash", "-lc"], ["bash", "-lc"], ["bash", "-lc"]]
+    assert "rsync -az --partial" in calls[0]["cmd"][2]
+    assert "manager-loop" not in calls[0]["cmd"][2]
+    assert all(call["check"] and call["text"] and call["capture_output"] for call in calls)
+
+
+def test_manager_loop_command_uses_node_scheduler_fields():
+    """Manager command rendering should carry scheduler and sbatch args from the node spec."""
+    node = RemoteNode(
+        name="h100",
+        host="h100",
+        work_dir="/remote/h100",
+        scheduler="slurm",
+        python="/env/bin/python",
+        sbatch_args=(
+            "--partition=gpu_special",
+            "--gres=gpu:h100:1",
+            "--output=/remote/h100/logs/slurm-%j.out",
+        ),
+        max_active_slurm_jobs=3,
+    )
+
+    cmd = render_manager_loop_command(node, poll_interval=2.5, once=True)
+    parsed = remote_execution_mod._build_arg_parser().parse_args(cmd[3:])
+
+    assert cmd[:5] == ["/env/bin/python", "-m", "proto_tools.utils.remote_execution", "manager-loop", "--queue-dir"]
+    assert "--scheduler" in cmd
+    assert cmd[cmd.index("--scheduler") + 1] == "slurm"
+    assert cmd[cmd.index("--slurm-group-size") + 1] == "10"
+    assert cmd[cmd.index("--max-active-slurm-jobs") + 1] == "3"
+    assert parsed.sbatch_arg == list(node.sbatch_args)
+    assert cmd[-1] == "--once"
+
+
+def test_manager_loop_command_requires_slurm_active_job_cap():
+    """Slurm manager rendering should not omit the active-job cap."""
+    node = RemoteNode(name="h100", host="h100", work_dir="/remote/h100", scheduler="slurm")
+
+    with pytest.raises(ValueError, match="Slurm manager requires max_active_slurm_jobs"):
+        render_manager_loop_command(node)
+
+
+def test_manager_start_and_status_scripts_use_pid_and_logs():
+    """Manager shell snippets should use stable pid and log paths."""
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/ty",
+        repo_dir="/remote/proto-tools",
+        python="/env/bin/python",
+    )
+
+    start_script = render_start_manager_script(node, poll_interval=1.5)
+    status_script = render_manager_status_script(node)
+
+    assert "cd /remote/proto-tools && export PYTHONPATH=/remote/proto-tools" in start_script
+    assert "nohup bash -lc" in start_script
+    assert "/env/bin/python -m proto_tools.utils.remote_execution manager-loop" in start_script
+    assert "/remote/ty/manager.pid" in start_script
+    assert "/remote/ty/logs/manager.log" in start_script
+    assert "sleep 0.2" in start_script
+    assert "tail -n 40" in start_script
+    assert "kill -0" in status_script
+    assert "echo stopped" in status_script
+
+
+def test_remote_manager_client_uses_ssh_runner():
+    """RemoteManagerClient should route start/status through SSH."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", ssh_args=("-p", "2222"))
+    calls = []
+
+    class FakeCompleted:
+        stdout = "running 123\n"
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append({"cmd": cmd, "check": check, "text": text, "capture_output": capture_output})
+        return FakeCompleted()
+
+    client = RemoteManagerClient()
+    assert client.start_node(node, runner=fake_runner) == "running 123"
+    assert client.status_node(node, runner=fake_runner) == "running 123"
+
+    assert calls[0]["cmd"][:6] == ["ssh", "-p", "2222", "ty", "bash", "-lc"]
+    assert "manager-loop" in calls[0]["cmd"][6]
+    assert "manager.pid" in calls[1]["cmd"][6]
+    assert calls[1]["cmd"][6].startswith("'set -euo pipefail;")
+    assert all(call["check"] and call["text"] and call["capture_output"] for call in calls)
+
+
+def test_remote_preflight_reports_python_import_and_slurm_checks():
+    """Preflight should check Python, importability, directories, rsync, and Slurm."""
+    node = RemoteNode(
+        name="h100",
+        host="h100",
+        work_dir="/remote/h100",
+        repo_dir="/remote/proto-tools",
+        scheduler="slurm",
+        python="/remote/proto-tools/.venv/bin/python",
+    )
+
+    script = render_preflight_script(node)
+
+    assert "python>=3.10" in script
+    assert "import proto_tools" in script
+    assert "/remote/proto-tools" in script
+    assert "/remote/h100/queue" in script
+    assert "rsync available" in script
+    assert "sbatch available" in script
+    assert "sacct available" in script
+
+
+def test_remote_manager_client_preflight_and_diagnostics_parse_json():
+    """Manager client should parse JSON returned by preflight and diagnostics."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    calls = []
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append(cmd)
+        if "recent_failed" in cmd[-1]:
+            return FakeCompleted('{"node":"ty","counts":{"queue":1},"recent_failed":[]}\n')
+        return FakeCompleted('{"node":"ty","ok":true,"checks":[]}\n')
+
+    client = RemoteManagerClient()
+
+    assert client.preflight_node(node, runner=fake_runner)["ok"] is True
+    assert client.diagnostics_node(node, runner=fake_runner)["counts"]["queue"] == 1
+    assert all(cmd[:4] == ["ssh", "ty", "bash", "-lc"] for cmd in calls)
+
+
+def test_remote_manager_client_preflight_invalid_json_names_node_and_output():
+    """Invalid preflight output should identify the node and preserve SSH evidence."""
+    node = RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3")
+
+    class FakeCompleted:
+        stdout = "login banner\n"
+        stderr = "remote warning\n"
+
+    with pytest.raises(
+        ValueError,
+        match=r"ty3.*invalid JSON.*login banner.*remote warning",
+    ):
+        RemoteManagerClient().preflight_node(node, runner=lambda *args, **kwargs: FakeCompleted())
+
+
+def test_remote_manager_client_preflight_accepts_final_json_after_visible_login_noise(caplog):
+    """A remote profile warning may precede the final JSON but must remain visible."""
+    node = RemoteNode(name="ty3", host="ty3", work_dir="/remote/ty3")
+
+    class FakeCompleted:
+        stdout = "gpu-ideal.sh: nvidia-modprobe: command not found\n{\"node\":\"ty3\",\"ok\":true}\n"
+        stderr = "Shared connection closed.\n"
+
+    payload = RemoteManagerClient().preflight_node(
+        node,
+        runner=lambda *args, **kwargs: FakeCompleted(),
+    )
+
+    assert payload == {"node": "ty3", "ok": True}
+    assert "gpu-ideal.sh: nvidia-modprobe: command not found" in caplog.text
+
+
+def test_remote_manager_client_passes_timeout_to_runner():
+    """Manager client should pass timeout_sec through to each SSH subprocess."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    outputs = iter(
+        [
+            "started\n",
+            "running\n",
+            '{"node":"ty","ok":true,"checks":[]}\n',
+            '{"node":"ty","counts":{},"recent_failed":[]}\n',
+        ]
+    )
+    calls = []
+
+    class FakeCompleted:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_runner(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return FakeCompleted(next(outputs))
+
+    client = RemoteManagerClient()
+
+    assert client.start_node(node, timeout_sec=12.5, runner=fake_runner) == "started"
+    assert client.status_node(node, timeout_sec=12.5, runner=fake_runner) == "running"
+    assert client.preflight_node(node, timeout_sec=12.5, runner=fake_runner)["ok"] is True
+    assert client.diagnostics_node(node, timeout_sec=12.5, runner=fake_runner)["counts"] == {}
+    assert [kwargs["timeout"] for _, kwargs in calls] == [12.5, 12.5, 12.5, 12.5]
+    assert all(kwargs["check"] is True and kwargs["text"] is True and kwargs["capture_output"] is True for _, kwargs in calls)
+
+
+def test_manager_diagnostics_script_counts_roots_and_failed_items():
+    """Diagnostics script should report queue state, log tail, and failed summaries."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", python="/env/bin/python")
+
+    script = render_manager_diagnostics_script(node)
+
+    assert "/remote/ty/queue" in script
+    assert "/remote/ty/results" in script
+    assert "/remote/ty/logs/manager.log" in script
+    assert "recent_failed" in script
+    assert "recent_running" in script
+    assert "recent_submitted" in script
+    assert "recent_tmp" in script
+    assert "recent_failed_results" in script
+
+
+def test_manager_diagnostics_script_reports_logical_counts_and_visibility(tmp_path):
+    """Diagnostics should surface stuck requests, sidecars, tmp files, and fallback failures."""
+    work_dir = tmp_path / "remote-work"
+    node = RemoteNode(name="ty", host="ty", work_dir=str(work_dir), python=sys.executable)
+    running_request = work_dir / "running" / "run-running" / "bucket-00000.json"
+    submitted_request = work_dir / "submitted" / "run-submitted" / "bucket-00001.json"
+    sidecar = submitted_request.with_suffix(submitted_request.suffix + ".slurm.json")
+    queue_tmp = work_dir / "queue" / "run-queued" / ".bucket-00002.json.tmp"
+    result_tmp = work_dir / "results" / "run-submitted" / ".bucket-00001.json.tmp"
+    fallback_failed = work_dir / "results" / "failed" / "missing-request.json"
+    for path in (running_request, submitted_request, sidecar, queue_tmp, result_tmp, fallback_failed):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    running_request.write_text(
+        json.dumps({"run_id": "run-running", "bucket_id": "bucket-00000", "tool_key": "remote-mock"})
+    )
+    submitted_request.write_text(
+        json.dumps({"run_id": "run-submitted", "bucket_id": "bucket-00001", "tool_key": "remote-mock"})
+    )
+    sidecar.write_text(
+        json.dumps(
+            {
+                "slurm_job_id": "12345",
+                "bucket_id": "bucket-00001",
+                "result_path": str(work_dir / "results" / "run-submitted" / "bucket-00001.json"),
+            }
+        )
+    )
+    queue_tmp.write_text("{}")
+    result_tmp.write_text("{}")
+    fallback_failed.write_text(
+        json.dumps(
+            {
+                "status": "failed",
+                "run_id": "run-failed",
+                "bucket_id": "bucket-00999",
+                "tool_key": "remote-mock",
+                "error": "request file missing",
+            }
+        )
+    )
+
+    completed = subprocess.run(
+        ["bash", "-lc", render_manager_diagnostics_script(node)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert payload["counts"]["queue"] == 0
+    assert payload["counts"]["running"] == 1
+    assert payload["counts"]["submitted"] == 1
+    assert payload["counts"]["results"] == 1
+    assert payload["sidecar_counts"] == {"submitted": 1}
+    assert payload["recent_running"][0]["run_id"] == "run-running"
+    assert payload["recent_running"][0]["bucket_id"] == "bucket-00000"
+    assert payload["recent_submitted"][0]["request_exists"] is True
+    assert payload["recent_submitted"][0]["slurm_job_id"] == "12345"
+    assert payload["recent_submitted"][0]["run_id"] == "run-submitted"
+    assert {item["root"] for item in payload["recent_tmp"]} == {"queue", "results"}
+    assert payload["recent_failed_results"][0]["status"] == "failed"
+    assert payload["recent_failed_results"][0]["error"] == "request file missing"
+
+
+def test_remote_deploy_renders_rsync_and_manager_env(tmp_path):
+    """Deployment rendering should make dirs, upload checkout, and install editable."""
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/ty-work",
+        repo_dir="/remote/proto-tools",
+        venv_dir="/remote/proto-tools/.venv",
+        bootstrap_python="/usr/bin/python3.12",
+        python="/remote/proto-tools/.venv/bin/python",
+        ssh_args=("-p", "2222"),
+    )
+
+    commands = render_deploy_commands(node, tmp_path)
+    start_script = render_start_manager_script(node)
+
+    assert commands[0][:6] == ["ssh", "-p", "2222", "ty", "bash", "-lc"]
+    assert "mkdir -p /remote/proto-tools /remote/ty-work/queue" in commands[0][-1]
+    assert commands[1][:4] == ["rsync", "-az", "--partial", "--delete"]
+    assert "--delete-excluded" not in commands[1]
+    assert str(tmp_path) + "/" in commands[1]
+    assert commands[1][-1] == "ty:/remote/proto-tools/"
+    assert "/usr/bin/python3.12 -m venv /remote/proto-tools/.venv" in commands[2][-1]
+    assert "/remote/proto-tools/.venv/bin/python -m pip install -e ." in commands[2][-1]
+    assert "cd /remote/proto-tools && export PYTHONPATH=/remote/proto-tools" in start_script
+    assert "/remote/proto-tools/.venv/bin/python -m proto_tools.utils.remote_execution" in start_script
+
+
+def test_inspect_local_checkout_counts_clean_dirty_and_untracked(tmp_path):
+    """Local checkout inspection should expose tracked and untracked changes."""
+    repo = _init_git_repo(tmp_path / "repo")
+
+    clean = inspect_local_checkout(repo)
+
+    assert clean.is_git_checkout is True
+    assert clean.path == str(repo.resolve())
+    assert clean.dirty is False
+    assert clean.dirty_count == 0
+    assert clean.untracked_count == 0
+    assert clean.head_commit
+
+    (repo / "tracked.txt").write_text("dirty\n")
+    (repo / "untracked.txt").write_text("new\n")
+
+    dirty = inspect_local_checkout(repo)
+
+    assert dirty.is_git_checkout is True
+    assert dirty.dirty is True
+    assert dirty.dirty_count == 1
+    assert dirty.untracked_count == 1
+    assert any(line.endswith("tracked.txt") for line in dirty.status_lines)
+    assert "?? untracked.txt" in dirty.status_lines
+
+
+def test_remote_deploy_report_serializes_structured_commands(tmp_path):
+    """Deployment report JSON should preserve argv plus stable command metadata."""
+    repo = _init_git_repo(tmp_path / "repo")
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/work", repo_dir="/remote/repo")
+
+    report = build_deploy_render_report([node], repo)
+    payload = report.to_dict()
+    commands = render_deploy_commands(node, repo)
+
+    assert payload["schema_version"] == 1
+    assert payload["ok"] is True
+    assert payload["local_repo_dir"] == str(repo.resolve())
+    assert payload["node_count"] == 1
+    assert payload["command_count"] == len(commands)
+    assert payload["nodes"][0]["name"] == "ty"
+    assert payload["nodes"][0]["command_count"] == len(commands)
+    assert [command["step"] for command in payload["nodes"][0]["commands"]] == [
+        "mkdir",
+        "rsync_upload",
+        "install_editable",
+    ]
+    assert [command["index"] for command in payload["nodes"][0]["commands"]] == [0, 1, 2]
+    assert [command["argv"] for command in payload["nodes"][0]["commands"]] == commands
+    assert payload["nodes"][0]["commands"][0]["shell"] == shlex.join(commands[0])
+
+
+def test_remote_deployment_client_executes_rendered_commands(tmp_path):
+    """Deployment client should execute the rendered command sequence."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/work", repo_dir="/remote/repo")
+    calls = []
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        calls.append({"cmd": cmd, "check": check, "text": text, "capture_output": capture_output})
+
+    RemoteDeploymentClient().deploy_node(node, tmp_path, runner=fake_runner)
+
+    assert len(calls) == 3
+    assert calls[0]["cmd"][0] == "ssh"
+    assert calls[1]["cmd"][0] == "rsync"
+    assert calls[2]["cmd"][0] == "ssh"
+    assert all(call["check"] and call["text"] and call["capture_output"] for call in calls)
+
+
+def test_load_remote_nodes_json(tmp_path):
+    """JSON profiles should load into RemoteNode objects with tuple arguments."""
+    profile = tmp_path / "nodes.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "name": "ty",
+                        "host": "ty",
+                        "work_dir": "/remote/ty",
+                        "repo_dir": "/remote/repo",
+                        "venv_dir": "/remote/repo/.venv",
+                        "bootstrap_python": "/usr/bin/python3.12",
+                        "ssh_args": ["-p", "2222"],
+                        "rsync_ssh_args": ["-J", "login"],
+                    }
+                ]
+            }
+        )
+    )
+
+    nodes = load_remote_nodes_json(profile)
+
+    assert nodes == [
+        RemoteNode(
+            name="ty",
+            host="ty",
+            work_dir="/remote/ty",
+            repo_dir="/remote/repo",
+            venv_dir="/remote/repo/.venv",
+            bootstrap_python="/usr/bin/python3.12",
+            ssh_args=("-p", "2222"),
+            rsync_ssh_args=("-J", "login"),
+        )
+    ]
+
+
+def test_scaffold_remote_node_uses_home_layout_and_static_validation(tmp_path):
+    """Profile scaffolding should produce deployable direct and Slurm nodes."""
+    nodes = [
+        scaffold_remote_node("ty", "/sfs/home/zengzhengpeng", scheduler="direct"),
+        scaffold_remote_node(
+            "h100",
+            "/public/home/zengzhengpeng",
+            scheduler="slurm",
+            weight=3.0,
+            max_active_slurm_jobs=2,
+            sbatch_args=("--partition=gpu", "--gres=gpu:h100:1"),
+        ),
+    ]
+    profile_path = tmp_path / "remote-nodes.json"
+
+    write_remote_nodes_json(nodes, profile_path)
+    loaded = load_remote_nodes_json(profile_path)
+
+    assert loaded == nodes
+    assert loaded[0].work_dir == "/sfs/home/zengzhengpeng/proto_remote"
+    assert loaded[0].repo_dir == "/sfs/home/zengzhengpeng/proto-tools"
+    assert loaded[0].venv_dir == "/sfs/home/zengzhengpeng/proto-tools/.venv"
+    assert loaded[0].python == "/sfs/home/zengzhengpeng/proto-tools/.venv/bin/python"
+    assert loaded[0].worker_device == "cuda:0"
+    assert loaded[1].worker_device == "cuda"
+    assert loaded[1].max_active_slurm_jobs == 2
+    assert validate_remote_nodes(loaded) == []
+
+
+def test_validate_remote_nodes_reports_duplicate_and_relative_paths():
+    """Static validation should catch local profile mistakes before SSH use."""
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(name="ty", host="ty2", work_dir="relative/work"),
+        RemoteNode(name="h100", host="h100", work_dir="/remote/h100", scheduler="slurm"),
+    ]
+
+    issues = validate_remote_nodes(nodes)
+
+    assert ("error", "ty", "name") in {(issue.level, issue.node_name, issue.field) for issue in issues}
+    assert ("error", "ty", "work_dir") in {(issue.level, issue.node_name, issue.field) for issue in issues}
+    assert ("error", "h100", "max_active_slurm_jobs") in {
+        (issue.level, issue.node_name, issue.field) for issue in issues
+    }
+    assert ("warning", "h100", "sbatch_args") in {(issue.level, issue.node_name, issue.field) for issue in issues}
+
+
+def test_validate_remote_nodes_warns_direct_max_concurrent_buckets_planner_only():
+    """Direct node concurrency is planner capacity, not per-manager parallel execution."""
+    node = RemoteNode(
+        name="ty",
+        host="ty",
+        work_dir="/remote/ty",
+        max_concurrent_buckets=2,
+    )
+
+    issues = validate_remote_nodes([node])
+
+    assert ("warning", "ty", "max_concurrent_buckets") in {
+        (issue.level, issue.node_name, issue.field) for issue in issues
+    }
+    assert any("only affects local planning capacity" in issue.message for issue in issues)
+
+
+def test_validate_remote_nodes_rejects_shared_work_dir_and_scaffold_template():
+    """Node-specific work templates should avoid shared queues on shared homes."""
+    nodes = [
+        scaffold_remote_node("ty2", "/mnt/sfs/zengzhengpeng", work_name="proto_remote"),
+        scaffold_remote_node("ty3", "/mnt/sfs/zengzhengpeng", work_name="proto_remote"),
+    ]
+
+    issues = validate_remote_nodes(nodes)
+    templated = scaffold_remote_node("ty3", "/mnt/sfs/zengzhengpeng", work_name="proto_remote_{node}")
+    templated_nodes = [
+        scaffold_remote_node("ty2", "/mnt/sfs/zengzhengpeng", work_name="proto_remote_{node}"),
+        templated,
+    ]
+    templated_issues = validate_remote_nodes(templated_nodes)
+
+    assert ("error", "ty2,ty3", "work_dir") in {(issue.level, issue.node_name, issue.field) for issue in issues}
+    assert ("warning", "ty2,ty3", "repo_dir") in {
+        (issue.level, issue.node_name, issue.field) for issue in templated_issues
+    }
+    assert ("warning", "ty2,ty3", "venv_dir") in {
+        (issue.level, issue.node_name, issue.field) for issue in templated_issues
+    }
+    assert templated.work_dir == "/mnt/sfs/zengzhengpeng/proto_remote_ty3"
+
+
+def test_smoke_remote_nodes_validates_profile_before_ssh(tmp_path):
+    """Smoke should stop before SSH when static profile validation fails."""
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/shared"),
+        RemoteNode(name="ty3", host="ty3", work_dir="/remote/shared"),
+    ]
+
+    class ForbiddenManager:
+        def preflight_node(self, *args, **kwargs):
+            raise AssertionError("preflight should not run")
+
+    report = smoke_remote_nodes(nodes, local_results_dir=tmp_path, manager_client=ForbiddenManager())
+
+    assert report.ok is False
+    assert report.preflight == {}
+    assert ("error", "ty,ty3", "work_dir") in {
+        (issue.level, issue.node_name, issue.field) for issue in report.profile_issues
+    }
+
+
+def test_smoke_remote_nodes_preflight_status_diagnostics_without_submission(tmp_path):
+    """Smoke should inspect nodes without starting managers or submitting Slurm."""
+    nodes = [
+        RemoteNode(name="ty", host="ty", work_dir="/remote/ty"),
+        RemoteNode(
+            name="h100",
+            host="h100",
+            work_dir="/remote/h100",
+            scheduler="slurm",
+            sbatch_args=("--partition=gpu", "--gres=gpu:h100:1"),
+            max_active_slurm_jobs=2,
+        ),
+    ]
+    calls = []
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False):
+        joined = " ".join(cmd)
+        calls.append(joined)
+        assert check is True
+        assert text is True
+        assert capture_output is True
+        assert cmd[0] == "ssh"
+        assert "manager-loop" not in joined
+        assert "run-request-batch" not in joined
+        assert "--wrap" not in joined
+        assert "nohup bash -lc" not in joined
+
+        class FakeCompleted:
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        script = cmd[-1]
+        if "recent_failed" in script:
+            return FakeCompleted('{"node":"x","manager":{"status":"stopped"},"counts":{},"recent_failed":[]}\n')
+        if "manager.pid" in script and "kill -0" in script:
+            return FakeCompleted("stopped\n")
+        return FakeCompleted('{"node":"x","ok":true,"checks":[{"name":"rsync available","ok":true}]}\n')
+
+    report = smoke_remote_nodes(nodes, local_results_dir=tmp_path / "results", runner=fake_runner)
+
+    assert report.ok is True
+    assert set(report.preflight) == {"ty", "h100"}
+    assert report.manager_status == {"ty": "stopped", "h100": "stopped"}
+    assert [cmd[0] for cmd in report.rsync_pull_commands] == ["rsync", "rsync"]
+    assert len(calls) == 6
+
+
+def test_smoke_remote_nodes_passes_timeout_to_remote_checks(tmp_path):
+    """Smoke should bound each SSH check when timeout_sec is provided."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty")
+    timeouts = []
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False, timeout=None):
+        del check, text, capture_output
+        timeouts.append(timeout)
+
+        class FakeCompleted:
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        script = cmd[-1]
+        if "recent_failed" in script:
+            return FakeCompleted('{"node":"ty","manager":{"status":"stopped"},"counts":{},"recent_failed":[]}\n')
+        if "manager.pid" in script and "kill -0" in script:
+            return FakeCompleted("stopped\n")
+        return FakeCompleted('{"node":"ty","ok":true,"checks":[]}\n')
+
+    report = smoke_remote_nodes([node], local_results_dir=tmp_path, timeout_sec=12.5, runner=fake_runner)
+
+    assert report.ok is True
+    assert timeouts == [12.5, 12.5, 12.5]
+
+
+def test_smoke_remote_nodes_reports_remote_check_failures_without_raising(tmp_path):
+    """Smoke should classify remote SSH failures per node instead of aborting the run."""
+    node = RemoteNode(name="ty", host="ty", work_dir="/remote/ty", python="/missing/python")
+
+    def fake_runner(cmd, check=False, text=False, capture_output=False, timeout=None):
+        del timeout
+        assert check is True
+        assert text is True
+        assert capture_output is True
+
+        class FakeCompleted:
+            stdout = "stopped\n"
+
+        script = cmd[-1]
+        if "manager.pid" in script and "kill -0" in script:
+            return FakeCompleted()
+        raise subprocess.CalledProcessError(
+            127,
+            cmd,
+            output="",
+            stderr="/missing/python: No such file or directory",
+        )
+
+    report = smoke_remote_nodes([node], local_results_dir=tmp_path, runner=fake_runner)
+
+    assert report.ok is False
+    assert report.preflight["ty"]["ok"] is False
+    assert report.preflight["ty"]["error"]["returncode"] == 127
+    assert "/missing/python" in report.preflight["ty"]["error"]["stderr"]
+    assert report.manager_status == {"ty": "stopped"}
+    assert report.diagnostics["ty"]["ok"] is False
+    assert report.diagnostics["ty"]["error"]["returncode"] == 127


### PR DESCRIPTION
## Summary

- add manifest-backed SSH and Slurm remote execution with manager supervision, resumable dispatch, and automatic result collection
- add existing-command runtimes plus `proto-tools remote compute` for maintained protein workflows
- enforce AlphaFold3 GPU admission and `CudaDevice` evidence so CPU fallback cannot pass
- discover `$hand-compute` registries from direct and bundled Codex skill installs

## Validation

- `pytest -q tests/tool_infra_tests/test_remote_execution.py tests/tool_infra_tests/test_cli.py`: 199 passed
- `pytest -q tests/style_consistency_tests/`: 6792 passed, 533 skipped
- `ruff check` on all changed Python files: passed
- live 30-record AlphaFold3 distributed run and idempotent resume: 30/30 tasks completed with CUDA evidence and collected scientific artifacts