### PR TITLE
feat(cli): add `signature` for payload-free symbol discovery

### DIFF
--- a/notes/finding-tools.md
+++ b/notes/finding-tools.md
@@ -18,6 +18,7 @@ proto-tools catalog --json
 proto-tools docs esm2-embedding
 proto-tools docs esm2-embedding --json
 proto-tools schema esm2-embedding --input
+proto-tools signature esm2-embedding
 proto-tools example-input esm2-embedding
 proto-tools access esm3-embedding
 ```
@@ -81,7 +82,7 @@ ToolRegistry.get_output_schema("esm2-embedding")
 ToolRegistry.get_example_input("esm2-embedding")
 ```
 
-`example_input()` values are minimal valid `Input` objects, useful for smoke tests, notebooks, and script templates.
+`example_input()` values are minimal valid `Input` objects, useful for smoke tests, notebooks, and script templates. They carry real payloads, so for structure tools and model-context-length sequence tools they run to hundreds of KB; that size is inherent (`BorzoiInput` requires exactly 524,288 bp), not a fixture that could be trimmed. When you only need the symbol names and required field names, use `proto-tools signature <tool>`, which renders a fixed few hundred bytes for every tool.
 
 ## Citation, Links, License, and Access
 

--- a/proto_tools/agent_context.md
+++ b/proto_tools/agent_context.md
@@ -45,6 +45,7 @@ output. Resolve a tool by registry key (`esm2-embedding`), run-function name
 | `proto-tools docs <tool>` | Intro, applications, usage tips, license |
 | `proto-tools schema <tool> [--input/--config/--output]` | JSON Schema(s) |
 | `proto-tools input/config/output <tool>` | Field-level model docs |
+| `proto-tools signature <tool>` | Imports, symbol names, and required input fields for the call |
 | `proto-tools example-input <tool> [--as-python]` | A minimal valid `Input`, as JSON or as a runnable snippet |
 | `proto-tools example <tool>` | The toolkit example notebook as markdown |
 
@@ -58,21 +59,27 @@ than the rule. `blast-create-db` exports `CreateBlastDbInput` and
 Ask instead of guessing:
 
 ```bash
-proto-tools example-input blast-create-db --as-python
+proto-tools signature blast-create-db
 ```
 
 ```python
 from proto_tools.tools.sequence_alignment.blast.create_blast_db import (
+    CreateBlastDbConfig,
     CreateBlastDbInput,
     run_create_blast_db,
 )
 
 result = run_create_blast_db(
-    CreateBlastDbInput(
-        fasta='.../example_input_fixture.fasta',
-    ),
-)
+    CreateBlastDbInput(fasta=...),
+    CreateBlastDbConfig(),  # optional, omit for defaults
+)  # -> CreateBlastDbOutput
 ```
+
+`signature` is the cheap call: it renders symbol names and required field names
+only, so it costs the same few hundred bytes for every tool. `example-input`
+carries real values and scales with them, which for a structure or a
+model-context-length window means hundreds of KB; reach for it when you want a
+payload to actually run, not when you want the names.
 
 From Python, when you already hold a registry key, call the tool through its
 spec rather than importing anything (there is no `ToolRegistry.run()`):

--- a/proto_tools/cli.py
+++ b/proto_tools/cli.py
@@ -229,6 +229,82 @@ def _cmd_schema(args: argparse.Namespace) -> int:
     return 0
 
 
+def _signature_payload(spec: ToolSpec) -> dict[str, Any]:
+    """Collect the symbol names and import modules that make up a tool's call surface."""
+    return {
+        "key": spec.key,
+        "run_function": spec.function.__name__,
+        "input_class": spec.input_model.__name__,
+        "config_class": spec.config_model.__name__,
+        "output_class": spec.output_model.__name__,
+        "modules": {
+            "run_function": spec.function.__module__,
+            "input_class": spec.input_model.__module__,
+            "config_class": spec.config_model.__module__,
+            "output_class": spec.output_model.__module__,
+        },
+        "required_input_fields": [name for name, field in spec.input_model.model_fields.items() if field.is_required()],
+    }
+
+
+def _render_signature(spec: ToolSpec) -> str:
+    """Render a tool's call surface: imports, symbol names, and required input fields.
+
+    Everything here is fixed-size, so surveying tools costs the same whether the tool
+    takes a peptide or a 524,288 bp window. ``example-input`` carries real values and
+    scales with them; this does not, which is what makes it the cheap discovery path.
+
+    ``Output`` is named but not imported: callers never construct one, so importing it
+    would leave an unused name in pasted code, and for 24 of the registered tools it
+    lives in a different module from the ``Input`` anyway.
+
+    Args:
+        spec (ToolSpec): The resolved tool.
+
+    Returns:
+        str: Python source sketching the call, with ``...`` in place of argument values.
+    """
+    run_fn = spec.function.__name__
+    input_cls = spec.input_model.__name__
+    config_cls = spec.config_model.__name__
+
+    by_module: dict[str, set[str]] = {}
+    for symbol, module in (
+        (input_cls, spec.input_model.__module__),
+        (config_cls, spec.config_model.__module__),
+        (run_fn, spec.function.__module__),
+    ):
+        by_module.setdefault(module, set()).add(symbol)
+    imports = "\n".join(
+        f"from {module} import (\n" + "".join(f"    {s},\n" for s in sorted(symbols)) + ")"
+        for module, symbols in sorted(by_module.items())
+    )
+
+    required = [name for name, field in spec.input_model.model_fields.items() if field.is_required()]
+    args = ", ".join(f"{name}=..." for name in required)
+    call = (
+        f"result = {run_fn}(\n"
+        f"    {input_cls}({args}),\n"
+        f"    {config_cls}(),  # optional, omit for defaults\n"
+        f")  # -> {spec.output_model.__name__}"
+    )
+
+    hint = f"\n\n# Field-level docs: proto-tools input|config|output {spec.key}"
+    return f"{imports}\n\n{call}{hint}\n"
+
+
+def _cmd_signature(args: argparse.Namespace) -> int:
+    """``proto-tools signature <tool> [--json]``."""
+    from proto_tools.utils.tool_docs import _normalize_tool_key
+
+    spec = ToolRegistry.get(_normalize_tool_key(args.tool))
+    if args.json:
+        print(_dump_json(_signature_payload(spec)))
+        return 0
+    print(_render_signature(spec), end="")
+    return 0
+
+
 def _render_example_as_python(spec: ToolSpec, example: BaseModel) -> str:
     """Render a runnable call to ``spec``, with the symbol names spelled out.
 
@@ -463,6 +539,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p_schema_g.add_argument("--config", action="store_true")
     p_schema_g.add_argument("--output", action="store_true")
     p_schema.set_defaults(func=_cmd_schema)
+
+    p_signature = sub.add_parser(
+        "signature",
+        help="Imports, symbol names, and required input fields for the tool's call. No example payload.",
+    )
+    p_signature.add_argument("tool")
+    p_signature.add_argument("--json", action="store_true", help="Emit the symbol names as JSON.")
+    p_signature.set_defaults(func=_cmd_signature)
 
     p_example_input = sub.add_parser("example-input", help="A minimal valid Input for the tool.")
     p_example_input.add_argument("tool")

--- a/tests/tool_infra_tests/test_cli.py
+++ b/tests/tool_infra_tests/test_cli.py
@@ -134,6 +134,100 @@ def test_unknown_section_exits_one() -> None:
     assert "not found" in err
 
 
+# ── Signature ──────────────────────────────────────────────────────────────
+
+
+def test_signature_names_symbols_the_key_cannot_predict() -> None:
+    """The point of the verb: registry key 'blast-create-db' does not yield these names."""
+    code, out, _ = _run("signature", "blast-create-db")
+    assert code == 0
+    assert "CreateBlastDbInput" in out  # not BlastCreateDbInput
+    assert "run_create_blast_db" in out  # not run_blast_create_db
+    assert "CreateBlastDbConfig" in out
+    assert "CreateBlastDbOutput" in out
+    assert "proto_tools.tools.sequence_alignment.blast.create_blast_db" in out
+
+
+def test_signature_names_the_output_without_importing_it() -> None:
+    """Callers never construct an Output, so importing it would leave an unused name."""
+    code, out, _ = _run("signature", "ipsae-scoring")
+    assert code == 0
+    imports, call = out.split("\n\nresult =", maxsplit=1)
+    assert "IPSAEScoringOutput" not in imports
+    assert "-> IPSAEScoringOutput" in call
+
+
+def test_signature_lists_required_input_fields_only() -> None:
+    code, out, _ = _run("signature", "ipsae-scoring")
+    assert code == 0
+    assert "IPSAEScoringInput(structure=..., binder_chain=..., target_chains=...)" in out
+
+
+def test_signature_resolves_a_run_function_name() -> None:
+    code, out, _ = _run("signature", "run_create_blast_db")
+    assert code == 0
+    assert "CreateBlastDbInput" in out
+
+
+def test_signature_stays_small_for_a_tool_with_a_huge_example() -> None:
+    """The reason the verb exists: cost is fixed, not proportional to the example payload.
+
+    borzoi's example input is a 524,288 bp window (the model context length, enforced by
+    ``BorzoiInput``), so ``example-input`` cannot be made cheap for it at any fixture size.
+    """
+    code, signature, _ = _run("signature", "borzoi-prediction")
+    assert code == 0
+    _, example, _ = _run("example-input", "borzoi-prediction")
+    assert len(signature) < 1024
+    assert len(example) > 500_000
+
+
+def test_signature_json_carries_symbols_and_modules() -> None:
+    code, out, _ = _run("signature", "blast-create-db", "--json")
+    assert code == 0
+    payload = json.loads(out)
+    assert payload["input_class"] == "CreateBlastDbInput"
+    assert payload["run_function"] == "run_create_blast_db"
+    assert payload["output_class"] == "CreateBlastDbOutput"
+    assert payload["required_input_fields"] == ["fasta"]
+    assert payload["modules"]["input_class"].startswith("proto_tools.tools.")
+
+
+@pytest.mark.extensive
+def test_signature_parses_and_imports_resolve_for_every_tool() -> None:
+    """Every rendered signature is valid Python whose imports bind the names it uses."""
+    import ast
+
+    from proto_tools.tools.tool_registry import ToolRegistry
+
+    specs = {s.key: s for s in [*ToolRegistry.list_cpu_tools(), *ToolRegistry.list_gpu_tools()]}
+    failures: list[str] = []
+    for key, spec in sorted(specs.items()):
+        code, out, _ = _run("signature", key)
+        if code != 0:
+            failures.append(f"{key}: exit {code}")
+            continue
+        try:
+            tree = ast.parse(out)
+        except SyntaxError as exc:
+            failures.append(f"{key}: {exc}")
+            continue
+        imports = [node for node in tree.body if isinstance(node, ast.Import | ast.ImportFrom)]
+        namespace: dict[str, object] = {}
+        try:
+            exec(compile(ast.Module(body=imports, type_ignores=[]), "<generated>", "exec"), namespace)  # noqa: S102
+        except Exception as exc:
+            failures.append(f"{key}: {type(exc).__name__}: {exc}")
+            continue
+        failures.extend(
+            f"{key}: emitted import did not bind {symbol}"
+            for symbol in (spec.input_model.__name__, spec.config_model.__name__, spec.function.__name__)
+            if symbol not in namespace
+        )
+
+    assert not failures, "signatures with unusable imports:\n" + "\n".join(failures)
+
+
 # ── Schema / example-input ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Adds `proto-tools signature <tool>`: the imports, symbol names, and required input fields for a tool's call, with no example payload.

## Why

`agent_context.md` has a section headed "Don't guess symbol names from the registry key" (`blast-create-db` exports `CreateBlastDbInput` and `run_create_blast_db`; `mafft-align` exports `MafftInput`, not `MafftAlignInput`). Until now the only surface that answered it was `example-input --as-python`, which renders the example's real values via `repr()`. So asking for four symbol names costs whatever the example weighs.

I checked what each existing verb emits for `ipsae-scoring`:

| Command | Gives you | Size |
|---|---|---|
| `input` | `IPSAEScoringInput` + every field, type, required flag, docs | 986 B |
| `config` | `IPSAEScoringConfig` + fields | 1,492 B |
| `output` | `IPSAEScoringOutput` + metrics | 683 B |
| `example-input --as-python` | the above, plus 2 more facts, plus a barnase-barstar PDB and a PAE matrix | 368 KB |

The class names were already cheap. The run-function name and the import module were the only gap, and I grepped `docs`, `schema`, and `list --json` to confirm neither appears anywhere else (`list --json` carries `key, label, category, description, uses_gpu, gpu_only, pin_visible_devices, device_count, config_model`).

## What it looks like

```
$ proto-tools signature blast-create-db

from proto_tools.tools.sequence_alignment.blast.create_blast_db import (
    CreateBlastDbConfig,
    CreateBlastDbInput,
    run_create_blast_db,
)

result = run_create_blast_db(
    CreateBlastDbInput(fasta=...),
    CreateBlastDbConfig(),  # optional, omit for defaults
)  # -> CreateBlastDbOutput

# Field-level docs: proto-tools input|config|output blast-create-db
```

Nothing in that output scales with the example, so the cost is flat. Across all 133 registered tools: **median 383 bytes, maximum 504 bytes, 51 KB for the entire registry**, against 4.8 MB for the same sweep via `example-input` (9.7 MB as the CLI actually prints it, since `_dump_json` uses `indent=2`).

## Design notes

- **Output is named, not imported.** You never construct one, so importing it would leave an unused name in pasted code, and for 24 of the 133 tools it lives in a different module from the `Input` (`shared_data_models`). It appears in the trailing `# -> XOutput` annotation instead, which is enough to look up `proto-tools output <tool>`.
- **`...` is deliberately not runnable.** An elided literal like `'<524288-char str>'` looks runnable and then fails validation, which costs a retry to discover. `...` cannot be mistaken for a value.
- **Imports are grouped by defining module** (at most two across the registry), not by toolkit package, so they do not depend on `__init__` re-exports. Same reasoning as `_render_example_as_python`.
- **Required fields only.** `input <tool>` stays the field-level detail view, and the footer points at it.
- **`--json`** emits the same symbols plus per-symbol modules for MCP servers and other programmatic callers.
- Resolves any identifier form (`_normalize_tool_key`), so `signature run_create_blast_db` works from a traceback.

`example-input` is unchanged and remains the way to get a payload you can actually execute; it is just no longer the documented path for learning names. Worth noting for anyone tempted to shrink the fixtures instead: those sizes are mostly inherent, not bloat. `BorzoiInput.validate_window_inputs` requires exactly 524,288 bp (the model context length), so a smaller borzoi example is an invalid one, and the structure fixtures back integration tests in a dozen-plus test files.

## Tests

New in `tests/tool_infra_tests/test_cli.py`:

- names the symbols the registry key cannot predict (the reason the verb exists)
- names the output without importing it (guards the design decision above)
- lists required input fields only
- resolves a run-function name
- stays under 1 KB for `borzoi-prediction`, whose example exceeds 500 KB
- `--json` carries symbols and modules
- `@pytest.mark.extensive`: every one of the 133 signatures parses as Python and its imports bind `Input`, `Config`, and the run function

Green: 30 CLI tests (including `--extensive`), full `tests/style_consistency_tests/`, `ruff check`, `ruff format`, and `mypy proto_tools/cli.py` clean. One pre-existing unrelated failure, `test_iterable_output_element_is_a_model[progen2-sample]`, reproduces on a clean `main`.

Docs updated in the same change: `agent_context.md` (verb table plus the "Don't guess symbol names" section now leads with `signature`) and `notes/finding-tools.md`.