### PR TITLE
fix(pyrosetta): call set_interface through DockingPartners on current builds

### DIFF
--- a/proto_tools/tools/structure_scoring/pyrosetta/standalone/inference.py
+++ b/proto_tools/tools/structure_scoring/pyrosetta/standalone/inference.py
@@ -10,6 +10,22 @@ from standalone_helpers import get_logger
 logger = get_logger(__name__)
 
 
+def _set_interface(iam: Any, spec: str) -> None:
+    """Point an ``InterfaceAnalyzerMover`` at the ``targets_binder`` interface *spec*.
+
+    Args:
+        iam (Any): The ``InterfaceAnalyzerMover`` to configure.
+        spec (str): Interface spec, target-side chains then binder (e.g. ``"A_B"``).
+    """
+    from pyrosetta.rosetta.core import pose
+
+    docking_partners = getattr(pose, "DockingPartners", None)
+    if docking_partners is None:
+        iam.set_interface(spec)
+        return
+    iam.set_interface(docking_partners.docking_partners_from_string(spec))
+
+
 # ============================================================================
 # PyRosetta Scorer
 # ============================================================================
@@ -741,7 +757,7 @@ class PyRosettaScorer:
             target_side = target_chains[i]
 
             iam = InterfaceAnalyzerMover()
-            iam.set_interface(f"{''.join(target_side)}_{binder_chain}")
+            _set_interface(iam, f"{''.join(target_side)}_{binder_chain}")
             sfxn = pyrosetta.create_score_function(scorefxn_name)
             iam.set_scorefunction(sfxn)
             iam.set_compute_packstat(True)


### PR DESCRIPTION
Fixes #24.

`pyrosetta-interface-analyzer` failed on every run with a `TypeError` from `InterfaceAnalyzerMover.set_interface()`.

## Root cause, verified against a real build

PyRosetta 2026.29 changed `InterfaceAnalyzerMover::set_interface` from taking a `std::string` to taking a `core::pose::DockingPartners`. The issue asked for the `DockingPartners` construction to be confirmed against a real build rather than assumed, so I built a scratch env with the exact release from the report (`2026.29+release.80a0635615`, which the channel also ships for osx-arm64) and introspected it:

```
set_interface(self: ...InterfaceAnalyzerMover, interface: ...core.pose.DockingPartners) -> None
DockingPartners.docking_partners_from_string(partner_string: str) -> DockingPartners
```

The spec string itself is unchanged; only how it is marshalled moved. `docking_partners_from_string("A_B")` round-trips to `partner1="A"`, `partner2="B"`, so the fix routes the existing `f"{targets}_{binder}"` spec through that factory instead of reconstructing anything.

The upstream change is [`2624daeacb`](https://github.com/RosettaCommons/rosetta/commit/2624daeacb) ("Support chain designations of multiple letters"). That title is worth a second look for this tool, because it could have changed how a multi-chain target spec parses. It does not: `"AB_C"` still yields `partner1=['A','B']`, `partner2=['C']`, so single-letter PDB chains split per character exactly as before and the binder-vs-rest path is unaffected.

## Why the dispatch, and why no pin

`_set_interface` dispatches on whether `core.pose` exposes `DockingPartners`, keeping both signatures working. That is not defensive coding, it is required:

- `setup.sh` installs `pyrosetta` unpinned, so a user's build is whatever the channel had the day their env was created.
- Editing a standalone does **not** change the env setup hash (that covers `setup.sh`, `requirements.txt`, `env_vars.txt`, `python_version.txt`), so no existing env is rebuilt by this change. Envs on older PyRosetta keep the string API.
- `linux-aarch64` is still on the 2023.11 build, as `setup.sh` already warns.

The dispatch cannot guess wrong, because `core/pose/DockingPartners.hh` was **added in the same commit** that last changed `InterfaceAnalyzerMover.hh`. Class-present and signature-changed are one condition, not two, so there is no version window in between.

Pinning the install was considered and rejected: no single pin resolves on every supported platform. `linux-aarch64` tops out at 2023.11 with no py311 build at all, and `osx-64` currently ships 2026.30 for py313/py38 only, with py311 (what this tool uses) one release behind at 2026.29. A correct pin would have to be platform-conditional, which is more machinery than the dispatch it would replace.

## Verification

Full pyrosetta toolkit suite (energy, interface-analyzer, relax, sap, sasa) with `--integration`, against both API generations, plus the seed tests that surfaced the bug in the issue:

| Build | `DockingPartners` | `set_interface` takes | Branch | Toolkit suite | Seed tests |
|---|---|---|---|---|---|
| 2026.19 | absent | `str` | fallback | 30 passed, 5 skipped | n/a |
| 2026.30 | present | `DockingPartners` | new | 30 passed, 5 skipped | 10 passed |

2026.30 is what `micromamba install pyrosetta` resolves to today, one release past the reporter's. The second row ran against a genuinely upgraded tool env, not a scratch copy. Seed coverage includes `test_all_tools_seed_reproducibility[pyrosetta-interface-analyzer]` and `test_duplicate_inputs_produce_diverse_outputs[pyrosetta-interface-analyzer]`, the tests named in the issue.

Scoring the bundled `pdl1.pdb` on 2026.29 through the fixed path returns `interface_sc=0.6487`, `interface_hbonds=2`, `interface_dG=179.295`, `interface_dSASA=1204.82`, `interface_packstat=0.6853`.

The suite passing on 2026.30 also answers the broader question: `set_interface` was the only API the toolkit uses that moved, despite that upstream commit spanning 300 files (`split_by_chain`, `pdb_info`, `LayerSelector`, the SAP scoreterms, `sasa`, and FastRelax all still behave).

The diff is deliberately just the call path; no test changes. Coverage comes from the existing `@pytest.mark.integration` and seed tests, which is what surfaced the break. Note those are skipped in CI without PyRosetta installed, so a regression back to the bare string call would only be caught by running them on a machine with a current build.

## Follow-up worth considering separately

`pyrosetta` is unpinned and, per the platform matrix above, cannot easily be pinned, so this class of break recurs on the next upstream API change and surfaces as a runtime failure for whoever builds an env that day. A scheduled job that rebuilds the env against the live channel and runs this suite would catch it before users do. Any such version watcher needs to resolve per (subdir, python version) rather than per "newest version", since those diverge today.