### PR TITLE
Add worker extension points, and route service methods through one entry

### DIFF
--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -224,28 +224,26 @@ belongs at Proto's submission path and is tracked in proto-tools-api#567.
 ## Worker extension points
 
 A service method ends in `run_tool_call(run_fn, InputModel, ConfigModel, input_dict, config_dict)`,
-which validates the mappings and hands off to `dispatch_tool_call`. Going through one function is
-what gives an operator somewhere to intervene, and a guard test fails any service that calls
-`dispatch_tool_call` directly — that path still works, which is exactly why it needs catching.
+which validates the mappings and hands off to `dispatch_tool_call`. A guard test asserts every
+`@modal.method` goes through it — a method that dispatches some other way silently ignores hooks
+rather than erroring.
 
-`proto_tools/modal/hooks.py` offers two, distinguished by what they can still see:
+`proto_tools/modal/hooks.py` offers two:
 
 | | Runs | Sees |
 |---|---|---|
 | `register_payload_hook` | before validation | the raw `input_dict` and `config_dict`, mutable |
-| `register_call_middleware` | around the call | the next step; may transform the result |
+| `register_call_middleware` | around the call | a `CallContext` and the next step; may transform the result |
 
-A payload hook is the only place a value can still be rewritten — once a mapping becomes a model,
-validation has already accepted or rejected it. So resolving a reference the caller passed instead
-of a value belongs here.
+A payload hook is the only place a value can still be rewritten. Middleware follows the ASGI
+shape; first registered is outermost, and `CallContext.tool_key` says which tool it wrapped.
 
-Middleware follows the ASGI shape: take the next step, call it, return a mapping. Timing a call,
-wrapping it in a context manager, or moving a large field somewhere the transport prefers all fit.
-The first registered is outermost.
+Both are process-wide. Register during import, from whatever module defines the deployment's
+entry point — registration is not synchronized. Nothing registers by default.
 
-Both are process-wide. Register at import time from whatever module defines the deployment's entry
-point, so every call through that worker sees them. Nothing registers by default, and with nothing
-registered both are pass-throughs.
+Two limits worth knowing: payload hooks run before the progress context opens, so a slow one is
+silent on the caller's spinner; and a middleware that forgets to return raises `TypeError` rather
+than returning `None` to the client.
 
 ## Hosted environments
 

--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -221,6 +221,32 @@ defining a differently named hook.
 request crafted directly against the API bypasses it entirely. Server-side enforcement
 belongs at Proto's submission path and is tracked in proto-tools-api#567.
 
+## Worker extension points
+
+A service method ends in `run_tool_call(run_fn, InputModel, ConfigModel, input_dict, config_dict)`,
+which validates the mappings and hands off to `dispatch_tool_call`. Going through one function is
+what gives an operator somewhere to intervene, and a guard test fails any service that calls
+`dispatch_tool_call` directly — that path still works, which is exactly why it needs catching.
+
+`proto_tools/modal/hooks.py` offers two, distinguished by what they can still see:
+
+| | Runs | Sees |
+|---|---|---|
+| `register_payload_hook` | before validation | the raw `input_dict` and `config_dict`, mutable |
+| `register_call_middleware` | around the call | the next step; may transform the result |
+
+A payload hook is the only place a value can still be rewritten — once a mapping becomes a model,
+validation has already accepted or rejected it. So resolving a reference the caller passed instead
+of a value belongs here.
+
+Middleware follows the ASGI shape: take the next step, call it, return a mapping. Timing a call,
+wrapping it in a context manager, or moving a large field somewhere the transport prefers all fit.
+The first registered is outermost.
+
+Both are process-wide. Register at import time from whatever module defines the deployment's entry
+point, so every call through that worker sees them. Nothing registers by default, and with nothing
+registered both are pass-throughs.
+
 ## Hosted environments
 
 `PROTO_IS_HOSTED_ENV` marks a process running tools for someone else rather than on a

--- a/proto_tools/modal/binder_design/freebindcraft_deployment/freebindcraft_service.py
+++ b/proto_tools/modal/binder_design/freebindcraft_deployment/freebindcraft_service.py
@@ -18,9 +18,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
 )
 
 # Mirrors FreeBindCraft's own Dockerfile; the shared GPU_BASE segfaults in the first compiled AF2 pass.
@@ -108,6 +108,11 @@ class FreeBindCraftService:
             run_freebindcraft_design,
         )
 
-        inputs = FreeBindCraftInput(**input_dict)
-        config = FreeBindCraftConfig(**config_dict)
-        return dispatch_tool_call(run_freebindcraft_design, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_freebindcraft_design,
+            FreeBindCraftInput,
+            FreeBindCraftConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/causal_models/evo1_deployment/evo1_service.py
+++ b/proto_tools/modal/causal_models/evo1_deployment/evo1_service.py
@@ -18,9 +18,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
 )
 
 
@@ -93,9 +93,9 @@ class Evo1Service:
             run_evo1_sample,
         )
 
-        inputs = Evo1SampleInput(**input_dict)
-        config = Evo1SampleConfig(**config_dict)
-        return dispatch_tool_call(run_evo1_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_evo1_sample, Evo1SampleInput, Evo1SampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -114,6 +114,6 @@ class Evo1Service:
             run_evo1_score,
         )
 
-        inputs = Evo1ScoringInput(**input_dict)
-        config = Evo1ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_evo1_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_evo1_score, Evo1ScoringInput, Evo1ScoringConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/causal_models/evo2_deployment/evo2_service.py
+++ b/proto_tools/modal/causal_models/evo2_deployment/evo2_service.py
@@ -18,9 +18,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
 )
 
 
@@ -101,9 +101,9 @@ class Evo2Service:
             run_evo2_sample,
         )
 
-        inputs = Evo2SampleInput(**input_dict)
-        config = Evo2SampleConfig(**config_dict)
-        return dispatch_tool_call(run_evo2_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_evo2_sample, Evo2SampleInput, Evo2SampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -122,6 +122,6 @@ class Evo2Service:
             run_evo2_score,
         )
 
-        inputs = Evo2ScoringInput(**input_dict)
-        config = Evo2ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_evo2_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_evo2_score, Evo2ScoringInput, Evo2ScoringConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/causal_models/progen2_deployment/progen2_service.py
+++ b/proto_tools/modal/causal_models/progen2_deployment/progen2_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,9 +87,9 @@ class ProGen2Service:
             run_progen2_sample,
         )
 
-        inputs = ProGen2SampleInput(**input_dict)
-        config = ProGen2SampleConfig(**config_dict)
-        return dispatch_tool_call(run_progen2_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_progen2_sample, ProGen2SampleInput, ProGen2SampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -108,6 +108,11 @@ class ProGen2Service:
             run_progen2_score,
         )
 
-        inputs = ProGen2ScoringInput(**input_dict)
-        config = ProGen2ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_progen2_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_progen2_score,
+            ProGen2ScoringInput,
+            ProGen2ScoringConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/causal_models/progen3_deployment/progen3_service.py
+++ b/proto_tools/modal/causal_models/progen3_deployment/progen3_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -92,9 +92,14 @@ class ProGen3Service:
         )
         from proto_tools.tools.causal_models.shared_data_models import CausalModelSampleInput
 
-        inputs = CausalModelSampleInput(**input_dict)
-        config = ProGen3SampleConfig(**config_dict)
-        return dispatch_tool_call(run_progen3_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_progen3_sample,
+            CausalModelSampleInput,
+            ProGen3SampleConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -113,6 +118,11 @@ class ProGen3Service:
         )
         from proto_tools.tools.causal_models.shared_data_models import CausalModelScoringInput
 
-        inputs = CausalModelScoringInput(**input_dict)
-        config = ProGen3ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_progen3_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_progen3_score,
+            CausalModelScoringInput,
+            ProGen3ScoringConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/database_retrieval/ccd_lookup_deployment/ccd_lookup_service.py
+++ b/proto_tools/modal/database_retrieval/ccd_lookup_deployment/ccd_lookup_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -77,6 +77,6 @@ class CcdLookupService:
             run_ccd_lookup,
         )
 
-        inputs = CcdLookupInput(**input_dict)
-        config = CcdLookupConfig(**config_dict)
-        return dispatch_tool_call(run_ccd_lookup, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ccd_lookup, CcdLookupInput, CcdLookupConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/gene_annotation/crispr_tracr_rna_deployment/crispr_tracr_rna_service.py
+++ b/proto_tools/modal/gene_annotation/crispr_tracr_rna_deployment/crispr_tracr_rna_service.py
@@ -17,7 +17,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -84,6 +84,11 @@ class CrisprTracrRNAService:
             run_crispr_tracr_rna,
         )
 
-        inputs = CrisprTracrRNAInput(**input_dict)
-        config = CrisprTracrRNAConfig(**config_dict)
-        return dispatch_tool_call(run_crispr_tracr_rna, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_crispr_tracr_rna,
+            CrisprTracrRNAInput,
+            CrisprTracrRNAConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/gene_annotation/minced_deployment/minced_service.py
+++ b/proto_tools/modal/gene_annotation/minced_deployment/minced_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -72,6 +72,4 @@ class MincedService:
         """
         from proto_tools.tools.gene_annotation.minced import MincedConfig, MincedInput, run_minced
 
-        inputs = MincedInput(**input_dict)
-        config = MincedConfig(**config_dict)
-        return dispatch_tool_call(run_minced, inputs, config, instance=self.instance)
+        return run_tool_call(run_minced, MincedInput, MincedConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/gene_annotation/miranda_deployment/miranda_service.py
+++ b/proto_tools/modal/gene_annotation/miranda_deployment/miranda_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -82,6 +82,6 @@ class MirandaService:
             run_miranda_scan,
         )
 
-        inputs = MirandaInput(**input_dict)
-        config = MirandaConfig(**config_dict)
-        return dispatch_tool_call(run_miranda_scan, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_miranda_scan, MirandaInput, MirandaConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/gene_annotation/promoter_calculator_deployment/promoter_calculator_service.py
+++ b/proto_tools/modal/gene_annotation/promoter_calculator_deployment/promoter_calculator_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -79,6 +79,11 @@ class PromoterCalculatorService:
             run_promoter_calculator,
         )
 
-        inputs = PromoterCalculatorInput(**input_dict)
-        config = PromoterCalculatorConfig(**config_dict)
-        return dispatch_tool_call(run_promoter_calculator, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_promoter_calculator,
+            PromoterCalculatorInput,
+            PromoterCalculatorConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/gene_annotation/pyhmmer_deployment/pyhmmer_service.py
+++ b/proto_tools/modal/gene_annotation/pyhmmer_deployment/pyhmmer_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -83,9 +83,14 @@ class PyHmmerService:
             run_pyhmmer_jackhmmer,
         )
 
-        inputs = PyJackhmmerInput(**input_dict)
-        config = PyJackhmmerConfig(**config_dict)
-        return dispatch_tool_call(run_pyhmmer_jackhmmer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyhmmer_jackhmmer,
+            PyJackhmmerInput,
+            PyJackhmmerConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def nhmmer(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -104,9 +109,9 @@ class PyHmmerService:
             run_pyhmmer_nhmmer,
         )
 
-        inputs = PyNhmmerInput(**input_dict)
-        config = PyNhmmerConfig(**config_dict)
-        return dispatch_tool_call(run_pyhmmer_nhmmer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyhmmer_nhmmer, PyNhmmerInput, PyNhmmerConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def phmmer(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -122,6 +127,6 @@ class PyHmmerService:
         from proto_tools.tools.gene_annotation.pyhmmer.phmmer import PyPhmmerInput, run_pyhmmer_phmmer
         from proto_tools.tools.gene_annotation.pyhmmer.shared_data_models import PyHmmerConfig
 
-        inputs = PyPhmmerInput(**input_dict)
-        config = PyHmmerConfig(**config_dict)
-        return dispatch_tool_call(run_pyhmmer_phmmer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyhmmer_phmmer, PyPhmmerInput, PyHmmerConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/hooks.py
+++ b/proto_tools/modal/hooks.py
@@ -1,33 +1,55 @@
 """Extension points for code that runs inside a deployed worker.
 
-A deployment is not always just the tool. Whoever operates one may need to adapt a call or
-observe it — resolving a reference the caller passed instead of a value, recording timings,
-moving a large result somewhere the transport is happier with — without forking every service
-class to do it.
+Whoever operates a deployment may need to adapt a call or observe it without forking every
+service class. Two extension points cover that, distinguished by what they can still see:
 
-Two extension points cover that, distinguished by what they can still see:
+- A :data:`PayloadHook` runs on the raw mappings, before validation. The only place a value can
+  still be rewritten.
+- A :data:`CallMiddleware` wraps the call, and may transform what it returns.
 
-- A :data:`PayloadHook` runs on the raw mappings, before they are validated into models. This is
-  the only place a value can still be rewritten, because validation may reject or normalize it.
-- A :data:`CallMiddleware` wraps the call itself, and may transform what it returns.
-
-Both are process-wide and applied in registration order. Register them at import time, from the
-module that defines a deployment's entry point, so every call through that worker sees them.
+Both are process-wide and applied in registration order. Register during import, before any call
+is served: registration is not synchronized.
 """
 
-from collections.abc import Callable
+import functools
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 #: Adjusts a call's raw input and config mappings in place, before either is validated.
 PayloadHook = Callable[[dict[str, Any], dict[str, Any]], None]
 
-#: Wraps one tool call. Receives a zero-argument callable that performs the call and returns its
-#: result mapping; must call it and return a mapping. Wrapping it in a context manager, timing it,
-#: or transforming the result are all ordinary uses.
-CallMiddleware = Callable[[Callable[[], dict[str, Any]]], dict[str, Any]]
+
+@dataclass(frozen=True)
+class CallContext:
+    """What a middleware is told about the call it is wrapping.
+
+    Attributes:
+        run_fn (Callable[..., Any]): The tool's ``run_*`` function.
+    """
+
+    run_fn: Callable[..., Any]
+
+    @property
+    def tool_key(self) -> str | None:
+        """Registry key for this tool, or ``None``. A middleware's only handle on which call it is."""
+        return _tool_key_for(self.run_fn)
+
+
+#: Wraps one tool call. Receives its :class:`CallContext` and a zero-argument callable that
+#: performs it; must call that and return a mapping.
+CallMiddleware = Callable[[CallContext, Callable[[], dict[str, Any]]], dict[str, Any]]
 
 _payload_hooks: list[PayloadHook] = []
 _call_middleware: list[CallMiddleware] = []
+
+
+@functools.cache
+def _tool_key_for(run_fn: Callable[..., Any]) -> str | None:
+    """Return the registry key whose tool is ``run_fn``, or ``None``. Cached: the map is static."""
+    from proto_tools.tools import ToolRegistry
+
+    return next((spec.key for spec in ToolRegistry.list_all() if spec.function is run_fn), None)
 
 
 def register_payload_hook(hook: PayloadHook) -> None:
@@ -69,29 +91,43 @@ def apply_payload_hooks(input_dict: dict[str, Any], config_dict: dict[str, Any])
         hook(input_dict, config_dict)
 
 
-def run_with_middleware(call: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+def run_with_middleware(context: CallContext, call: Callable[[], dict[str, Any]]) -> dict[str, Any]:
     """Invoke ``call`` through every registered middleware, outermost first.
 
     Args:
+        context (CallContext): Describes the call, passed to each middleware.
         call (Callable[[], dict[str, Any]]): Performs the call and returns its result mapping.
 
     Returns:
         dict[str, Any]: The result, as returned by the outermost middleware. With none
             registered, exactly what ``call`` returned.
+
+    Raises:
+        TypeError: If a middleware returns a non-mapping — usually one that forgot to return at
+            all, whose ``None`` would otherwise surface as a client-side error naming no middleware.
     """
     wrapped = call
     # Reversed so the first registered ends up outermost, matching the documented order.
     for middleware in reversed(_call_middleware):
-        wrapped = _bind(middleware, wrapped)
-    return wrapped()
+        wrapped = _bind(middleware, context, wrapped)
+    result = wrapped()
+    if not isinstance(result, Mapping):
+        raise TypeError(
+            f"A registered call middleware returned {type(result).__name__}, not a mapping. "
+            f"Middleware must return the result of the step it wraps."
+        )
+    return result
 
 
-def _bind(middleware: CallMiddleware, next_step: Callable[[], dict[str, Any]]) -> Callable[[], dict[str, Any]]:
-    """Bind ``next_step`` into ``middleware``, so the chain can be built without late binding."""
-    return lambda: middleware(next_step)
+def _bind(
+    middleware: CallMiddleware, context: CallContext, next_step: Callable[[], dict[str, Any]]
+) -> Callable[[], dict[str, Any]]:
+    """Bind this layer's arguments, so building the chain in a loop cannot late-bind them."""
+    return lambda: middleware(context, next_step)
 
 
 __all__ = [
+    "CallContext",
     "CallMiddleware",
     "PayloadHook",
     "apply_payload_hooks",

--- a/proto_tools/modal/hooks.py
+++ b/proto_tools/modal/hooks.py
@@ -1,0 +1,102 @@
+"""Extension points for code that runs inside a deployed worker.
+
+A deployment is not always just the tool. Whoever operates one may need to adapt a call or
+observe it — resolving a reference the caller passed instead of a value, recording timings,
+moving a large result somewhere the transport is happier with — without forking every service
+class to do it.
+
+Two extension points cover that, distinguished by what they can still see:
+
+- A :data:`PayloadHook` runs on the raw mappings, before they are validated into models. This is
+  the only place a value can still be rewritten, because validation may reject or normalize it.
+- A :data:`CallMiddleware` wraps the call itself, and may transform what it returns.
+
+Both are process-wide and applied in registration order. Register them at import time, from the
+module that defines a deployment's entry point, so every call through that worker sees them.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+#: Adjusts a call's raw input and config mappings in place, before either is validated.
+PayloadHook = Callable[[dict[str, Any], dict[str, Any]], None]
+
+#: Wraps one tool call. Receives a zero-argument callable that performs the call and returns its
+#: result mapping; must call it and return a mapping. Wrapping it in a context manager, timing it,
+#: or transforming the result are all ordinary uses.
+CallMiddleware = Callable[[Callable[[], dict[str, Any]]], dict[str, Any]]
+
+_payload_hooks: list[PayloadHook] = []
+_call_middleware: list[CallMiddleware] = []
+
+
+def register_payload_hook(hook: PayloadHook) -> None:
+    """Register ``hook`` to run on every call's raw mappings before validation.
+
+    Args:
+        hook (PayloadHook): Callable taking ``(input_dict, config_dict)``. Mutates in place;
+            its return value is ignored.
+    """
+    _payload_hooks.append(hook)
+
+
+def register_call_middleware(middleware: CallMiddleware) -> None:
+    """Register ``middleware`` to wrap every tool call in this process.
+
+    Registration order is outermost first: the first registered sees the call before the second,
+    and sees the second's result.
+
+    Args:
+        middleware (CallMiddleware): Callable taking the next step and returning a result mapping.
+    """
+    _call_middleware.append(middleware)
+
+
+def clear_hooks() -> None:
+    """Remove every registered hook. Intended for tests, which must not leak into each other."""
+    _payload_hooks.clear()
+    _call_middleware.clear()
+
+
+def apply_payload_hooks(input_dict: dict[str, Any], config_dict: dict[str, Any]) -> None:
+    """Run every registered payload hook, in registration order.
+
+    Args:
+        input_dict (dict[str, Any]): The call's raw input mapping, mutated in place.
+        config_dict (dict[str, Any]): The call's raw config mapping, mutated in place.
+    """
+    for hook in _payload_hooks:
+        hook(input_dict, config_dict)
+
+
+def run_with_middleware(call: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+    """Invoke ``call`` through every registered middleware, outermost first.
+
+    Args:
+        call (Callable[[], dict[str, Any]]): Performs the call and returns its result mapping.
+
+    Returns:
+        dict[str, Any]: The result, as returned by the outermost middleware. With none
+            registered, exactly what ``call`` returned.
+    """
+    wrapped = call
+    # Reversed so the first registered ends up outermost, matching the documented order.
+    for middleware in reversed(_call_middleware):
+        wrapped = _bind(middleware, wrapped)
+    return wrapped()
+
+
+def _bind(middleware: CallMiddleware, next_step: Callable[[], dict[str, Any]]) -> Callable[[], dict[str, Any]]:
+    """Bind ``next_step`` into ``middleware``, so the chain can be built without late binding."""
+    return lambda: middleware(next_step)
+
+
+__all__ = [
+    "CallMiddleware",
+    "PayloadHook",
+    "apply_payload_hooks",
+    "clear_hooks",
+    "register_call_middleware",
+    "register_payload_hook",
+    "run_with_middleware",
+]

--- a/proto_tools/modal/inverse_folding/esm_if1_deployment/esm_if1_service.py
+++ b/proto_tools/modal/inverse_folding/esm_if1_deployment/esm_if1_service.py
@@ -17,9 +17,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -93,9 +93,14 @@ class ESMIF1Service:
             run_esm_if1_sample,
         )
 
-        inputs = ESMIF1SampleInput(**input_dict)
-        config = ESMIF1SampleConfig(**config_dict)
-        return dispatch_tool_call(run_esm_if1_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm_if1_sample,
+            ESMIF1SampleInput,
+            ESMIF1SampleConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -114,6 +119,11 @@ class ESMIF1Service:
             run_esm_if1_score,
         )
 
-        inputs = ESMIF1ScoringInput(**input_dict)
-        config = ESMIF1ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_esm_if1_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm_if1_score,
+            ESMIF1ScoringInput,
+            ESMIF1ScoringConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/inverse_folding/fampnn_deployment/fampnn_service.py
+++ b/proto_tools/modal/inverse_folding/fampnn_deployment/fampnn_service.py
@@ -21,9 +21,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -104,9 +104,9 @@ class FAMPNNService:
             run_fampnn_sample,
         )
 
-        inputs = FAMPNNSampleInput(**input_dict)
-        config = FAMPNNSampleConfig(**config_dict)
-        return dispatch_tool_call(run_fampnn_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_fampnn_sample, FAMPNNSampleInput, FAMPNNSampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -125,9 +125,9 @@ class FAMPNNService:
             run_fampnn_score,
         )
 
-        inputs = FAMPNNScoreInput(**input_dict)
-        config = FAMPNNScoreConfig(**config_dict)
-        return dispatch_tool_call(run_fampnn_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_fampnn_score, FAMPNNScoreInput, FAMPNNScoreConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score_all_mutations(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -146,9 +146,14 @@ class FAMPNNService:
             run_fampnn_score_all_mutations,
         )
 
-        inputs = FAMPNNScoreAllMutationsInput(**input_dict)
-        config = FAMPNNScoreAllMutationsConfig(**config_dict)
-        return dispatch_tool_call(run_fampnn_score_all_mutations, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_fampnn_score_all_mutations,
+            FAMPNNScoreAllMutationsInput,
+            FAMPNNScoreAllMutationsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def pack(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -167,6 +172,6 @@ class FAMPNNService:
             run_fampnn_pack,
         )
 
-        inputs = FAMPNNPackInput(**input_dict)
-        config = FAMPNNPackConfig(**config_dict)
-        return dispatch_tool_call(run_fampnn_pack, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_fampnn_pack, FAMPNNPackInput, FAMPNNPackConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/inverse_folding/ligandmpnn_deployment/ligandmpnn_service.py
+++ b/proto_tools/modal/inverse_folding/ligandmpnn_deployment/ligandmpnn_service.py
@@ -16,9 +16,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -92,9 +92,14 @@ class LigandMPNNService:
             run_ligandmpnn_sample,
         )
 
-        inputs = LigandMPNNSampleInput(**input_dict)
-        config = LigandMPNNSampleConfig(**config_dict)
-        return dispatch_tool_call(run_ligandmpnn_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ligandmpnn_sample,
+            LigandMPNNSampleInput,
+            LigandMPNNSampleConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -105,6 +110,11 @@ class LigandMPNNService:
             run_ligandmpnn_score,
         )
 
-        inputs = LigandMPNNScoringInput(**input_dict)
-        config = LigandMPNNScoringConfig(**config_dict)
-        return dispatch_tool_call(run_ligandmpnn_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ligandmpnn_score,
+            LigandMPNNScoringInput,
+            LigandMPNNScoringConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/inverse_folding/proteinmpnn_deployment/proteinmpnn_service.py
+++ b/proto_tools/modal/inverse_folding/proteinmpnn_deployment/proteinmpnn_service.py
@@ -17,9 +17,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -93,9 +93,14 @@ class ProteinMPNNService:
             run_proteinmpnn_sample,
         )
 
-        inputs = ProteinMPNNSampleInput(**input_dict)
-        config = ProteinMPNNSampleConfig(**config_dict)
-        return dispatch_tool_call(run_proteinmpnn_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_proteinmpnn_sample,
+            ProteinMPNNSampleInput,
+            ProteinMPNNSampleConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -114,9 +119,14 @@ class ProteinMPNNService:
             run_proteinmpnn_score,
         )
 
-        inputs = ProteinMPNNScoringInput(**input_dict)
-        config = ProteinMPNNScoringConfig(**config_dict)
-        return dispatch_tool_call(run_proteinmpnn_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_proteinmpnn_score,
+            ProteinMPNNScoringInput,
+            ProteinMPNNScoringConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -127,6 +137,11 @@ class ProteinMPNNService:
             run_proteinmpnn_gradient,
         )
 
-        inputs = ProteinMPNNGradientInput(**input_dict)
-        config = ProteinMPNNGradientConfig(**config_dict)
-        return dispatch_tool_call(run_proteinmpnn_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_proteinmpnn_gradient,
+            ProteinMPNNGradientInput,
+            ProteinMPNNGradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/masked_models/ablang_deployment/ablang_service.py
+++ b/proto_tools/modal/masked_models/ablang_deployment/ablang_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_BASIC
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -99,9 +99,9 @@ class AbLangService:
             run_ablang_sample,
         )
 
-        inputs = AbLangSampleInput(**input_dict)
-        config = AbLangSampleConfig(**config_dict)
-        return dispatch_tool_call(run_ablang_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ablang_sample, AbLangSampleInput, AbLangSampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -120,9 +120,9 @@ class AbLangService:
             run_ablang_score,
         )
 
-        inputs = AbLangScoringInput(**input_dict)
-        config = AbLangScoringConfig(**config_dict)
-        return dispatch_tool_call(run_ablang_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ablang_score, AbLangScoringInput, AbLangScoringConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def inference(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -141,9 +141,14 @@ class AbLangService:
             run_ablang_embeddings,
         )
 
-        inputs = AbLangEmbeddingsInput(**input_dict)
-        config = AbLangEmbeddingsConfig(**config_dict)
-        return dispatch_tool_call(run_ablang_embeddings, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ablang_embeddings,
+            AbLangEmbeddingsInput,
+            AbLangEmbeddingsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -162,6 +167,11 @@ class AbLangService:
             run_ablang_gradient,
         )
 
-        inputs = AbLangGradientInput(**input_dict)
-        config = AbLangGradientConfig(**config_dict)
-        return dispatch_tool_call(run_ablang_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ablang_gradient,
+            AbLangGradientInput,
+            AbLangGradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/masked_models/esm2_deployment/esm2_service.py
+++ b/proto_tools/modal/masked_models/esm2_deployment/esm2_service.py
@@ -16,7 +16,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -90,9 +90,14 @@ class ESM2Service:
             run_esm2_embeddings,
         )
 
-        inputs = ESM2EmbeddingsInput(**input_dict)
-        config = ESM2EmbeddingsConfig(**config_dict)
-        return dispatch_tool_call(run_esm2_embeddings, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm2_embeddings,
+            ESM2EmbeddingsInput,
+            ESM2EmbeddingsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def sample(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -111,9 +116,9 @@ class ESM2Service:
             run_esm2_sample,
         )
 
-        inputs = ESM2SampleInput(**input_dict)
-        config = ESM2SampleConfig(**config_dict)
-        return dispatch_tool_call(run_esm2_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm2_sample, ESM2SampleInput, ESM2SampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -132,9 +137,9 @@ class ESM2Service:
             run_esm2_score,
         )
 
-        inputs = ESM2ScoringInput(**input_dict)
-        config = ESM2ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_esm2_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm2_score, ESM2ScoringInput, ESM2ScoringConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -145,6 +150,6 @@ class ESM2Service:
             run_esm2_gradient,
         )
 
-        inputs = ESM2GradientInput(**input_dict)
-        config = ESM2GradientConfig(**config_dict)
-        return dispatch_tool_call(run_esm2_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm2_gradient, ESM2GradientInput, ESM2GradientConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/masked_models/esm3_deployment/esm3_service.py
+++ b/proto_tools/modal/masked_models/esm3_deployment/esm3_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -93,9 +93,14 @@ class ESM3Service:
             run_esm3_embeddings,
         )
 
-        inputs = ESM3EmbeddingsInput(**input_dict)
-        config = ESM3EmbeddingsConfig(**config_dict)
-        return dispatch_tool_call(run_esm3_embeddings, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm3_embeddings,
+            ESM3EmbeddingsInput,
+            ESM3EmbeddingsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def sample(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -114,9 +119,9 @@ class ESM3Service:
             run_esm3_sample,
         )
 
-        inputs = ESM3SampleInput(**input_dict)
-        config = ESM3SampleConfig(**config_dict)
-        return dispatch_tool_call(run_esm3_sample, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm3_sample, ESM3SampleInput, ESM3SampleConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -135,6 +140,6 @@ class ESM3Service:
             run_esm3_score,
         )
 
-        inputs = ESM3ScoringInput(**input_dict)
-        config = ESM3ScoringConfig(**config_dict)
-        return dispatch_tool_call(run_esm3_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esm3_score, ESM3ScoringInput, ESM3ScoringConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/masked_models/esmc_deployment/esmc_service.py
+++ b/proto_tools/modal/masked_models/esmc_deployment/esmc_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -91,9 +91,14 @@ class ESMCService:
             run_esmc_embeddings,
         )
 
-        inputs = ESMCEmbeddingsInput(**input_dict)
-        config = ESMCEmbeddingsConfig(**config_dict)
-        return dispatch_tool_call(run_esmc_embeddings, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esmc_embeddings,
+            ESMCEmbeddingsInput,
+            ESMCEmbeddingsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def sae_features(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -112,6 +117,11 @@ class ESMCService:
             run_esmc_sae_features,
         )
 
-        inputs = ESMCSAEFeaturesInput(**input_dict)
-        config = ESMCSAEFeaturesConfig(**config_dict)
-        return dispatch_tool_call(run_esmc_sae_features, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esmc_sae_features,
+            ESMCSAEFeaturesInput,
+            ESMCSAEFeaturesConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/orf_prediction/orf_deployment/orf_service.py
+++ b/proto_tools/modal/orf_prediction/orf_deployment/orf_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 # =============================================================================
@@ -83,6 +83,6 @@ class OrfipyService:
             run_orfipy_prediction,
         )
 
-        inputs = OrfipyInput(**input_dict)
-        config = OrfipyConfig(**config_dict)
-        return dispatch_tool_call(run_orfipy_prediction, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_orfipy_prediction, OrfipyInput, OrfipyConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/orf_prediction/prodigal_deployment/prodigal_service.py
+++ b/proto_tools/modal/orf_prediction/prodigal_deployment/prodigal_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -76,6 +76,6 @@ class ProdigalService:
             run_prodigal_prediction,
         )
 
-        inputs = ProdigalInput(**input_dict)
-        config = ProdigalConfig(**config_dict)
-        return dispatch_tool_call(run_prodigal_prediction, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_prodigal_prediction, ProdigalInput, ProdigalConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/rna_splicing/pangolin_deployment/pangolin_service.py
+++ b/proto_tools/modal/rna_splicing/pangolin_deployment/pangolin_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_BASIC
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,9 +87,14 @@ class PangolinService:
         )
         from proto_tools.tools.rna_splicing.pangolin.pangolin_predict import run_pangolin_predict
 
-        inputs = PangolinPredictInput(**input_dict)
-        config = PangolinPredictConfig(**config_dict)
-        return dispatch_tool_call(run_pangolin_predict, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pangolin_predict,
+            PangolinPredictInput,
+            PangolinPredictConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score_variants(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -110,6 +115,11 @@ class PangolinService:
         )
         from proto_tools.tools.rna_splicing.pangolin.pangolin_score_variants import run_pangolin_score_variants
 
-        inputs = PangolinScoreVariantsInput(**input_dict)
-        config = PangolinScoreVariantsConfig(**config_dict)
-        return dispatch_tool_call(run_pangolin_score_variants, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pangolin_score_variants,
+            PangolinScoreVariantsInput,
+            PangolinScoreVariantsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/rna_splicing/splice_transformer_deployment/splice_transformer_service.py
+++ b/proto_tools/modal/rna_splicing/splice_transformer_deployment/splice_transformer_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_BASIC
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -86,6 +86,11 @@ class SpliceTransformerService:
             run_splice_transformer,
         )
 
-        inputs = SpliceTransformerInput(**input_dict)
-        config = SpliceTransformerConfig(**config_dict)
-        return dispatch_tool_call(run_splice_transformer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_splice_transformer,
+            SpliceTransformerInput,
+            SpliceTransformerConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/rna_splicing/spliceai_deployment/spliceai_service.py
+++ b/proto_tools/modal/rna_splicing/spliceai_deployment/spliceai_service.py
@@ -22,7 +22,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -110,9 +110,14 @@ class SpliceAIService:
             run_spliceai_predict,
         )
 
-        inputs = SpliceAIPredictInput(**input_dict)
-        config = SpliceAIPredictConfig(**config_dict)
-        return dispatch_tool_call(run_spliceai_predict, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_spliceai_predict,
+            SpliceAIPredictInput,
+            SpliceAIPredictConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -131,6 +136,6 @@ class SpliceAIService:
             run_spliceai_score,
         )
 
-        inputs = SpliceAIScoreInput(**input_dict)
-        config = SpliceAIScoreConfig(**config_dict)
-        return dispatch_tool_call(run_spliceai_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_spliceai_score, SpliceAIScoreInput, SpliceAIScoreConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/sequence_alignment/mafft_deployment/mafft_service.py
+++ b/proto_tools/modal/sequence_alignment/mafft_deployment/mafft_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -79,6 +79,4 @@ class MafftAlignService:
             run_mafft_align,
         )
 
-        inputs = MafftInput(**input_dict)
-        config = MafftConfig(**config_dict)
-        return dispatch_tool_call(run_mafft_align, inputs, config, instance=self.instance)
+        return run_tool_call(run_mafft_align, MafftInput, MafftConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/sequence_scoring/alphagenome_deployment/alphagenome_service.py
+++ b/proto_tools/modal/sequence_scoring/alphagenome_deployment/alphagenome_service.py
@@ -16,7 +16,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -97,9 +97,14 @@ class AlphaGenomeService:
             run_alphagenome_predict_intervals,
         )
 
-        inputs = AlphaGenomePredictIntervalsInput(**input_dict)
-        config = AlphaGenomePredictIntervalsConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_predict_intervals, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_predict_intervals,
+            AlphaGenomePredictIntervalsInput,
+            AlphaGenomePredictIntervalsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def predict_sequences(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -118,9 +123,14 @@ class AlphaGenomeService:
             run_alphagenome_predict_sequences,
         )
 
-        inputs = AlphaGenomePredictSequencesInput(**input_dict)
-        config = AlphaGenomePredictSequencesConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_predict_sequences, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_predict_sequences,
+            AlphaGenomePredictSequencesInput,
+            AlphaGenomePredictSequencesConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def predict_variants(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -139,9 +149,14 @@ class AlphaGenomeService:
             run_alphagenome_predict_variants,
         )
 
-        inputs = AlphaGenomePredictVariantsInput(**input_dict)
-        config = AlphaGenomePredictVariantsConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_predict_variants, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_predict_variants,
+            AlphaGenomePredictVariantsInput,
+            AlphaGenomePredictVariantsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score_intervals(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -160,9 +175,14 @@ class AlphaGenomeService:
             run_alphagenome_score_intervals,
         )
 
-        inputs = AlphaGenomeScoreIntervalsInput(**input_dict)
-        config = AlphaGenomeScoreIntervalsConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_score_intervals, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_score_intervals,
+            AlphaGenomeScoreIntervalsInput,
+            AlphaGenomeScoreIntervalsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score_ism_variants(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -181,9 +201,14 @@ class AlphaGenomeService:
             run_alphagenome_score_ism_variants_batch,
         )
 
-        inputs = AlphaGenomeScoreISMInput(**input_dict)
-        config = AlphaGenomeScoreISMConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_score_ism_variants_batch, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_score_ism_variants_batch,
+            AlphaGenomeScoreISMInput,
+            AlphaGenomeScoreISMConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def score_variants(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -202,6 +227,11 @@ class AlphaGenomeService:
             run_alphagenome_score_variants,
         )
 
-        inputs = AlphaGenomeScoreVariantsInput(**input_dict)
-        config = AlphaGenomeScoreVariantsConfig(**config_dict)
-        return dispatch_tool_call(run_alphagenome_score_variants, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphagenome_score_variants,
+            AlphaGenomeScoreVariantsInput,
+            AlphaGenomeScoreVariantsConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/sequence_scoring/borzoi_deployment/borzoi_service.py
+++ b/proto_tools/modal/sequence_scoring/borzoi_deployment/borzoi_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,9 +87,7 @@ class BorzoiService:
             run_borzoi,
         )
 
-        inputs = BorzoiInput(**input_dict)
-        config = BorzoiConfig(**config_dict)
-        return dispatch_tool_call(run_borzoi, inputs, config, instance=self.instance)
+        return run_tool_call(run_borzoi, BorzoiInput, BorzoiConfig, input_dict, config_dict, instance=self.instance)
 
     @modal.method()
     def predict_ensemble(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -108,6 +106,6 @@ class BorzoiService:
             run_borzoi_ensemble,
         )
 
-        inputs = BorzoiInput(**input_dict)
-        config = BorzoiEnsembleConfig(**config_dict)
-        return dispatch_tool_call(run_borzoi_ensemble, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_borzoi_ensemble, BorzoiInput, BorzoiEnsembleConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/sequence_scoring/enformer_deployment/enformer_service.py
+++ b/proto_tools/modal/sequence_scoring/enformer_deployment/enformer_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,6 +87,6 @@ class EnformerService:
             run_enformer,
         )
 
-        inputs = EnformerInput(**input_dict)
-        config = EnformerConfig(**config_dict)
-        return dispatch_tool_call(run_enformer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_enformer, EnformerInput, EnformerConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/sequence_scoring/malinois_deployment/malinois_service.py
+++ b/proto_tools/modal/sequence_scoring/malinois_deployment/malinois_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_BASIC
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -83,9 +83,9 @@ class MalinoisService:
             run_malinois_score,
         )
 
-        inputs = MalinoisScoreInput(**input_dict)
-        config = MalinoisScoreConfig(**config_dict)
-        return dispatch_tool_call(run_malinois_score, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_malinois_score, MalinoisScoreInput, MalinoisScoreConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -104,6 +104,11 @@ class MalinoisService:
             run_malinois_gradient,
         )
 
-        inputs = MalinoisGradientInput(**input_dict)
-        config = MalinoisGradientConfig(**config_dict)
-        return dispatch_tool_call(run_malinois_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_malinois_gradient,
+            MalinoisGradientInput,
+            MalinoisGradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/sequence_scoring/parade_deployment/parade_service.py
+++ b/proto_tools/modal/sequence_scoring/parade_deployment/parade_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -93,9 +93,14 @@ class ParadeService:
         )
         from proto_tools.tools.sequence_scoring.parade.shared_data_models import ParadeSequenceInput
 
-        inputs = ParadeSequenceInput(**input_dict)
-        config = ParadeActivityConfig(**config_dict)
-        return dispatch_tool_call(run_parade_activity, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_parade_activity,
+            ParadeSequenceInput,
+            ParadeActivityConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -114,9 +119,14 @@ class ParadeService:
             run_parade_gradient,
         )
 
-        inputs = ParadeGradientInput(**input_dict)
-        config = ParadeGradientConfig(**config_dict)
-        return dispatch_tool_call(run_parade_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_parade_gradient,
+            ParadeGradientInput,
+            ParadeGradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def stability(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -135,6 +145,11 @@ class ParadeService:
             ParadeSequenceInput,
         )
 
-        inputs = ParadeSequenceInput(**input_dict)
-        config = ParadeCheckpointConfig(**config_dict)
-        return dispatch_tool_call(run_parade_stability, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_parade_stability,
+            ParadeSequenceInput,
+            ParadeCheckpointConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/sequence_scoring/puffin_deployment/puffin_service.py
+++ b/proto_tools/modal/sequence_scoring/puffin_deployment/puffin_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -91,9 +91,14 @@ class PuffinService:
             run_puffin_interpretation,
         )
 
-        inputs = PuffinInterpretationInput(**input_dict)
-        config = PuffinInterpretationConfig(**config_dict)
-        return dispatch_tool_call(run_puffin_interpretation, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_puffin_interpretation,
+            PuffinInterpretationInput,
+            PuffinInterpretationConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def predict(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -112,6 +117,11 @@ class PuffinService:
             run_puffin_prediction,
         )
 
-        inputs = PuffinPredictionInput(**input_dict)
-        config = PuffinPredictionConfig(**config_dict)
-        return dispatch_tool_call(run_puffin_prediction, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_puffin_prediction,
+            PuffinPredictionInput,
+            PuffinPredictionConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/sequence_utils/segmasker_deployment/segmasker_service.py
+++ b/proto_tools/modal/sequence_utils/segmasker_deployment/segmasker_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -80,6 +80,6 @@ class SegmaskerService:
             run_segmasker,
         )
 
-        inputs = SegmaskerInput(**input_dict)
-        config = SegmaskerConfig(**config_dict)
-        return dispatch_tool_call(run_segmasker, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_segmasker, SegmaskerInput, SegmaskerConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_alignment/foldmason_deployment/foldmason_service.py
+++ b/proto_tools/modal/structure_alignment/foldmason_deployment/foldmason_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -81,9 +81,9 @@ class FoldmasonService:
             run_foldmason_msa,
         )
 
-        inputs = FoldmasonMSAInput(**input_dict)
-        config = FoldmasonMSAConfig(**config_dict)
-        return dispatch_tool_call(run_foldmason_msa, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldmason_msa, FoldmasonMSAInput, FoldmasonMSAConfig, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def score_msa(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -102,6 +102,11 @@ class FoldmasonService:
             run_foldmason_score_msa,
         )
 
-        inputs = FoldmasonScoreMSAInput(**input_dict)
-        config = FoldmasonScoreMSAConfig(**config_dict)
-        return dispatch_tool_call(run_foldmason_score_msa, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldmason_score_msa,
+            FoldmasonScoreMSAInput,
+            FoldmasonScoreMSAConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_alignment/foldseek_deployment/foldseek_service.py
+++ b/proto_tools/modal/structure_alignment/foldseek_deployment/foldseek_service.py
@@ -20,7 +20,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -90,9 +90,14 @@ class FoldseekService:
             run_foldseek_cluster,
         )
 
-        inputs = FoldseekClusterInput(**input_dict)
-        config = FoldseekClusterConfig(**config_dict)
-        return dispatch_tool_call(run_foldseek_cluster, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldseek_cluster,
+            FoldseekClusterInput,
+            FoldseekClusterConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def multimer_search(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -111,9 +116,14 @@ class FoldseekService:
             run_foldseek_multimer_search,
         )
 
-        inputs = FoldseekMultimerSearchInput(**input_dict)
-        config = FoldseekMultimerSearchConfig(**config_dict)
-        return dispatch_tool_call(run_foldseek_multimer_search, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldseek_multimer_search,
+            FoldseekMultimerSearchInput,
+            FoldseekMultimerSearchConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def multimer_cluster(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -132,9 +142,14 @@ class FoldseekService:
             run_foldseek_multimercluster,
         )
 
-        inputs = FoldseekMultimerClusterInput(**input_dict)
-        config = FoldseekMultimerClusterConfig(**config_dict)
-        return dispatch_tool_call(run_foldseek_multimercluster, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldseek_multimercluster,
+            FoldseekMultimerClusterInput,
+            FoldseekMultimerClusterConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def search(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -153,6 +168,11 @@ class FoldseekService:
             run_foldseek_search,
         )
 
-        inputs = FoldseekSearchInput(**input_dict)
-        config = FoldseekSearchConfig(**config_dict)
-        return dispatch_tool_call(run_foldseek_search, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_foldseek_search,
+            FoldseekSearchInput,
+            FoldseekSearchConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_alignment/pymol_deployment/pymol_service.py
+++ b/proto_tools/modal/structure_alignment/pymol_deployment/pymol_service.py
@@ -10,8 +10,8 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -76,6 +76,6 @@ class PyMOLService:
             run_pymol_rmsd_alignment,
         )
 
-        inputs = PyMOLRMSDInput(**input_dict)
-        config = PyMOLRMSDConfig(**config_dict)
-        return dispatch_tool_call(run_pymol_rmsd_alignment, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pymol_rmsd_alignment, PyMOLRMSDInput, PyMOLRMSDConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_alignment/tmalign_deployment/tmalign_service.py
+++ b/proto_tools/modal/structure_alignment/tmalign_deployment/tmalign_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import dispatch_tool_call, env_for, stage_all_excluded_fixtures
+from proto_tools.modal.utils import env_for, run_tool_call, stage_all_excluded_fixtures
 
 
 def _tmalign_warmup() -> None:
@@ -74,6 +74,4 @@ class TMalignService:
             run_tmalign,
         )
 
-        inputs = TMalignInput(**input_dict)
-        config = TMalignConfig(**config_dict)
-        return dispatch_tool_call(run_tmalign, inputs, config, instance=self.instance)
+        return run_tool_call(run_tmalign, TMalignInput, TMalignConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_alignment/usalign_deployment/usalign_service.py
+++ b/proto_tools/modal/structure_alignment/usalign_deployment/usalign_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import dispatch_tool_call, env_for, stage_all_excluded_fixtures
+from proto_tools.modal.utils import env_for, run_tool_call, stage_all_excluded_fixtures
 
 
 def _usalign_warmup() -> None:
@@ -77,6 +77,4 @@ class USalignService:
             run_usalign,
         )
 
-        inputs = USalignInput(**input_dict)
-        config = USalignConfig(**config_dict)
-        return dispatch_tool_call(run_usalign, inputs, config, instance=self.instance)
+        return run_tool_call(run_usalign, USalignInput, USalignConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_design/rfdiffusion3_deployment/rfdiffusion3_service.py
+++ b/proto_tools/modal/structure_design/rfdiffusion3_deployment/rfdiffusion3_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -86,6 +86,6 @@ class RFdiffusion3Service:
             run_rfdiffusion3,
         )
 
-        inputs = RFdiffusion3Input(**input_dict)
-        config = RFdiffusion3Config(**config_dict)
-        return dispatch_tool_call(run_rfdiffusion3, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_rfdiffusion3, RFdiffusion3Input, RFdiffusion3Config, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_dynamics/bioemu_deployment/bioemu_service.py
+++ b/proto_tools/modal/structure_dynamics/bioemu_deployment/bioemu_service.py
@@ -17,9 +17,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -93,6 +93,4 @@ class BioEmuService:
             run_bioemu,
         )
 
-        inputs = BioEmuInput(**input_dict)
-        config = BioEmuConfig(**config_dict)
-        return dispatch_tool_call(run_bioemu, inputs, config, instance=self.instance)
+        return run_tool_call(run_bioemu, BioEmuInput, BioEmuConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_prediction/alphafold2_deployment/alphafold2_service.py
+++ b/proto_tools/modal/structure_prediction/alphafold2_deployment/alphafold2_service.py
@@ -21,7 +21,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -99,9 +99,9 @@ class AlphaFold2Service:
             run_alphafold2,
         )
 
-        inputs = AlphaFold2Input(**input_dict)
-        config = AlphaFold2Config(**config_dict)
-        return dispatch_tool_call(run_alphafold2, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphafold2, AlphaFold2Input, AlphaFold2Config, input_dict, config_dict, instance=self.instance
+        )
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -120,6 +120,11 @@ class AlphaFold2Service:
             run_alphafold2_gradient,
         )
 
-        inputs = AlphaFold2GradientInput(**input_dict)
-        config = AlphaFold2GradientConfig(**config_dict)
-        return dispatch_tool_call(run_alphafold2_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_alphafold2_gradient,
+            AlphaFold2GradientInput,
+            AlphaFold2GradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_prediction/boltz2_deployment/boltz2_service.py
+++ b/proto_tools/modal/structure_prediction/boltz2_deployment/boltz2_service.py
@@ -18,9 +18,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
 )
 
 _BOLTZ2_CACHE_DIR = Path("/weights/boltz2")
@@ -118,9 +118,7 @@ class Boltz2Service:
         )
         from proto_tools.tools.structure_prediction.boltz2.boltz2 import run_boltz2
 
-        inputs = Boltz2Input(**input_dict)
-        config = Boltz2Config(**config_dict)
-        return dispatch_tool_call(run_boltz2, inputs, config, instance=self.instance)
+        return run_tool_call(run_boltz2, Boltz2Input, Boltz2Config, input_dict, config_dict, instance=self.instance)
 
     @modal.method()
     def affinity(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -142,6 +140,11 @@ class Boltz2Service:
         )
         from proto_tools.tools.structure_prediction.boltz2.boltz2_affinity import run_boltz2_affinity
 
-        inputs = Boltz2AffinityInput(**input_dict)
-        config = Boltz2AffinityConfig(**config_dict)
-        return dispatch_tool_call(run_boltz2_affinity, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_boltz2_affinity,
+            Boltz2AffinityInput,
+            Boltz2AffinityConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_prediction/chai1_deployment/chai1_service.py
+++ b/proto_tools/modal/structure_prediction/chai1_deployment/chai1_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,6 +87,4 @@ class Chai1Service:
         )
         from proto_tools.tools.structure_prediction.chai1.chai1 import run_chai1
 
-        inputs = Chai1Input(**input_dict)
-        config = Chai1Config(**config_dict)
-        return dispatch_tool_call(run_chai1, inputs, config, instance=self.instance)
+        return run_tool_call(run_chai1, Chai1Input, Chai1Config, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_prediction/esmfold2_deployment/esmfold2_service.py
+++ b/proto_tools/modal/structure_prediction/esmfold2_deployment/esmfold2_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -89,6 +89,6 @@ class ESMFold2Service:
         )
         from proto_tools.tools.structure_prediction.esmfold2.esmfold2 import run_esmfold2
 
-        inputs = ESMFold2Input(**input_dict)
-        config = ESMFold2Config(**config_dict)
-        return dispatch_tool_call(run_esmfold2, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esmfold2, ESMFold2Input, ESMFold2Config, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_prediction/esmfold_deployment/esmfold_service.py
+++ b/proto_tools/modal/structure_prediction/esmfold_deployment/esmfold_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,9 +87,7 @@ class ESMFoldService:
         )
         from proto_tools.tools.structure_prediction.esmfold.esmfold import run_esmfold
 
-        inputs = ESMFoldInput(**input_dict)
-        config = ESMFoldConfig(**config_dict)
-        return dispatch_tool_call(run_esmfold, inputs, config, instance=self.instance)
+        return run_tool_call(run_esmfold, ESMFoldInput, ESMFoldConfig, input_dict, config_dict, instance=self.instance)
 
     @modal.method()
     def gradient(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -100,6 +98,11 @@ class ESMFoldService:
             run_esmfold_gradient,
         )
 
-        inputs = ESMFoldGradientInput(**input_dict)
-        config = ESMFoldGradientConfig(**config_dict)
-        return dispatch_tool_call(run_esmfold_gradient, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_esmfold_gradient,
+            ESMFoldGradientInput,
+            ESMFoldGradientConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_prediction/opendde_deployment/opendde_service.py
+++ b/proto_tools/modal/structure_prediction/opendde_deployment/opendde_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -86,6 +86,4 @@ class OpenDDEService:
             run_opendde,
         )
 
-        inputs = OpenDDEInput(**input_dict)
-        config = OpenDDEConfig(**config_dict)
-        return dispatch_tool_call(run_opendde, inputs, config, instance=self.instance)
+        return run_tool_call(run_opendde, OpenDDEInput, OpenDDEConfig, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_prediction/protenix_deployment/protenix_service.py
+++ b/proto_tools/modal/structure_prediction/protenix_deployment/protenix_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,6 +87,6 @@ class ProtenixService:
         )
         from proto_tools.tools.structure_prediction.protenix.protenix import run_protenix
 
-        inputs = ProtenixInput(**input_dict)
-        config = ProtenixConfig(**config_dict)
-        return dispatch_tool_call(run_protenix, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_protenix, ProtenixInput, ProtenixConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_prediction/rf3_deployment/rf3_service.py
+++ b/proto_tools/modal/structure_prediction/rf3_deployment/rf3_service.py
@@ -15,7 +15,7 @@ from proto_tools.modal.base_images import GPU_BASE, with_proto_tools
 from proto_tools.modal.gpu_profiles import GPU_DEFAULT
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, ensure_gpu_ready, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, ensure_gpu_ready, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -87,6 +87,4 @@ class RF3Service:
         )
         from proto_tools.tools.structure_prediction.rf3.rf3_prediction import run_rf3_prediction
 
-        inputs = RF3Input(**input_dict)
-        config = RF3Config(**config_dict)
-        return dispatch_tool_call(run_rf3_prediction, inputs, config, instance=self.instance)
+        return run_tool_call(run_rf3_prediction, RF3Input, RF3Config, input_dict, config_dict, instance=self.instance)

--- a/proto_tools/modal/structure_prediction/viennarna_deployment/viennarna_service.py
+++ b/proto_tools/modal/structure_prediction/viennarna_deployment/viennarna_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -76,6 +76,6 @@ class ViennaRNAService:
             run_viennarna,
         )
 
-        inputs = ViennaRNAInput(**input_dict)
-        config = ViennaRNAConfig(**config_dict)
-        return dispatch_tool_call(run_viennarna, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_viennarna, ViennaRNAInput, ViennaRNAConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_scoring/dssp_deployment/dssp_service.py
+++ b/proto_tools/modal/structure_scoring/dssp_deployment/dssp_service.py
@@ -16,8 +16,8 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -86,6 +86,11 @@ class DSSPService:
             run_dssp_secondary_structure,
         )
 
-        inputs = DSSPSecondaryStructureInput(**input_dict)
-        config = DSSPSecondaryStructureConfig(**config_dict)
-        return dispatch_tool_call(run_dssp_secondary_structure, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_dssp_secondary_structure,
+            DSSPSecondaryStructureInput,
+            DSSPSecondaryStructureConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_scoring/ipsae_deployment/ipsae_service.py
+++ b/proto_tools/modal/structure_scoring/ipsae_deployment/ipsae_service.py
@@ -10,8 +10,8 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -67,6 +67,6 @@ class IPSAEService:
             run_ipsae_scoring,
         )
 
-        inputs = IPSAEScoringInput(**input_dict)
-        config = IPSAEScoringConfig(**config_dict)
-        return dispatch_tool_call(run_ipsae_scoring, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_ipsae_scoring, IPSAEScoringInput, IPSAEScoringConfig, input_dict, config_dict, instance=self.instance
+        )

--- a/proto_tools/modal/structure_scoring/metal3d_deployment/metal3d_service.py
+++ b/proto_tools/modal/structure_scoring/metal3d_deployment/metal3d_service.py
@@ -11,9 +11,9 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     ensure_gpu_ready,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -79,6 +79,11 @@ class Metal3DService:
             run_metal3d_prediction,
         )
 
-        inputs = Metal3DPredictionInput(**input_dict)
-        config = Metal3DPredictionConfig(**config_dict)
-        return dispatch_tool_call(run_metal3d_prediction, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_metal3d_prediction,
+            Metal3DPredictionInput,
+            Metal3DPredictionConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_scoring/pdockq2_deployment/pdockq2_service.py
+++ b/proto_tools/modal/structure_scoring/pdockq2_deployment/pdockq2_service.py
@@ -17,7 +17,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, SERVICE_RETRIES, get_app_for_
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -67,6 +67,4 @@ class PDockQ2Service:
             run_pdockq2,
         )
 
-        inputs = PDockQ2Input(**input_dict)
-        config = PDockQ2Config(**config_dict)
-        return dispatch_tool_call(run_pdockq2, inputs, config)
+        return run_tool_call(run_pdockq2, PDockQ2Input, PDockQ2Config, input_dict, config_dict)

--- a/proto_tools/modal/structure_scoring/pyrosetta_deployment/pyrosetta_service.py
+++ b/proto_tools/modal/structure_scoring/pyrosetta_deployment/pyrosetta_service.py
@@ -16,8 +16,8 @@ from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
 from proto_tools.modal.utils import (
     RUNTIME_ENV,
-    dispatch_tool_call,
     env_for,
+    run_tool_call,
     stage_all_excluded_fixtures,
 )
 
@@ -94,9 +94,14 @@ class PyRosettaService:
             run_pyrosetta_energy,
         )
 
-        inputs = PyRosettaEnergyInput(**input_dict)
-        config = PyRosettaEnergyConfig(**config_dict)
-        return dispatch_tool_call(run_pyrosetta_energy, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyrosetta_energy,
+            PyRosettaEnergyInput,
+            PyRosettaEnergyConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def interface_analyzer(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -115,9 +120,14 @@ class PyRosettaService:
             run_pyrosetta_interface_analyzer,
         )
 
-        inputs = PyRosettaInterfaceAnalyzerInput(**input_dict)
-        config = PyRosettaInterfaceAnalyzerConfig(**config_dict)
-        return dispatch_tool_call(run_pyrosetta_interface_analyzer, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyrosetta_interface_analyzer,
+            PyRosettaInterfaceAnalyzerInput,
+            PyRosettaInterfaceAnalyzerConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def relax(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -136,9 +146,14 @@ class PyRosettaService:
             run_pyrosetta_relax,
         )
 
-        inputs = PyRosettaRelaxInput(**input_dict)
-        config = PyRosettaRelaxConfig(**config_dict)
-        return dispatch_tool_call(run_pyrosetta_relax, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyrosetta_relax,
+            PyRosettaRelaxInput,
+            PyRosettaRelaxConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def sap(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -157,9 +172,14 @@ class PyRosettaService:
             run_pyrosetta_sap,
         )
 
-        inputs = PyRosettaSAPInput(**input_dict)
-        config = PyRosettaSAPConfig(**config_dict)
-        return dispatch_tool_call(run_pyrosetta_sap, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyrosetta_sap,
+            PyRosettaSAPInput,
+            PyRosettaSAPConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )
 
     @modal.method()
     def sasa(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
@@ -178,6 +198,11 @@ class PyRosettaService:
             run_pyrosetta_sasa,
         )
 
-        inputs = PyRosettaSASAInput(**input_dict)
-        config = PyRosettaSASAConfig(**config_dict)
-        return dispatch_tool_call(run_pyrosetta_sasa, inputs, config, instance=self.instance)
+        return run_tool_call(
+            run_pyrosetta_sasa,
+            PyRosettaSASAInput,
+            PyRosettaSASAConfig,
+            input_dict,
+            config_dict,
+            instance=self.instance,
+        )

--- a/proto_tools/modal/structure_scoring/structure_metrics_deployment/structure_metrics_service.py
+++ b/proto_tools/modal/structure_scoring/structure_metrics_deployment/structure_metrics_service.py
@@ -18,7 +18,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, SERVICE_RETRIES, get_app_for_
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import RUNTIME_ENV, dispatch_tool_call, env_for
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
 
 
 def _warmup() -> None:
@@ -71,6 +71,6 @@ class StructureMetricsService:
             run_structure_metrics,
         )
 
-        inputs = StructureMetricsInput(**input_dict)
-        config = StructureMetricsConfig(**config_dict)
-        return dispatch_tool_call(run_structure_metrics, inputs, config)
+        return run_tool_call(
+            run_structure_metrics, StructureMetricsInput, StructureMetricsConfig, input_dict, config_dict
+        )

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import modal
 
-from proto_tools.modal.hooks import apply_payload_hooks, run_with_middleware
+from proto_tools.modal.hooks import CallContext, apply_payload_hooks, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput, MissingAssetError
@@ -246,6 +246,15 @@ def apply_tool_envelope(
     return strip_base_fields(result.model_dump())
 
 
+def mark_hosted_env() -> None:
+    """Tell the tool it runs for someone else, so a config reaching for a large local corpus adapts.
+
+    Set per call rather than at import, since the value has to be visible wherever the call
+    executes, and before payload hooks run, since one may branch on it.
+    """
+    os.environ["PROTO_IS_HOSTED_ENV"] = "1"
+
+
 def dispatch_tool_call(
     run_fn: Callable[..., BaseToolOutput],
     *args: Any,
@@ -258,23 +267,17 @@ def dispatch_tool_call(
     the workspace running the container, so nothing needs configuring.
     Worker logs are read with ``modal app logs <app>``.
     """
-    # This container hosts the tool for someone else, so a config that would reach for a large
-    # local corpus adjusts itself before preprocess runs. Set per call rather than at import, since
-    # the value has to be visible wherever the call actually executes.
-    os.environ["PROTO_IS_HOSTED_ENV"] = "1"
+    mark_hosted_env()
 
     # @app.cls(timeout=...) is Modal's outer wall; null the inner timer so it can't fire early.
     configs = [arg for arg in (*args, *kwargs.values()) if isinstance(arg, BaseConfig)]
     for config in configs:
         config.timeout = None
 
-    # Stream this call's log output back to the caller's spinner when they asked for it. Wired here
-    # rather than in each service method, so every deployed tool reports progress on the same terms.
     partition = next((config._progress_partition for config in configs if config._progress_partition), None)
     level = next((config._progress_level for config in configs if config._progress_partition), logging.INFO)
     with container_progress(partition, level=level):
-        # Inside the progress context, so anything a middleware logs reaches the caller too.
-        return run_with_middleware(lambda: apply_tool_envelope(run_fn, *args, **kwargs))
+        return run_with_middleware(CallContext(run_fn), lambda: apply_tool_envelope(run_fn, *args, **kwargs))
 
 
 def run_tool_call(
@@ -288,9 +291,8 @@ def run_tool_call(
 ) -> dict[str, Any]:
     """Validate one call's mappings and run it. The entry point a service method calls.
 
-    Construction happens here rather than in each service method so payload hooks have somewhere
-    to run: once a mapping becomes a model it has already been validated, and a value that needed
-    resolving first has already been rejected or normalized.
+    Construction happens here so payload hooks have somewhere to run: once a mapping becomes a
+    model, validation has already accepted or rejected it.
 
     Args:
         run_fn (Callable[..., BaseToolOutput]): The tool's ``run_*`` function.
@@ -303,6 +305,9 @@ def run_tool_call(
     Returns:
         dict[str, Any]: The tool's serialized output.
     """
+    # Hooks run before the progress context opens, so a slow one is silent on the caller's
+    # spinner. Opening a second context here would double-register the log handler.
+    mark_hosted_env()
     apply_payload_hooks(input_dict, config_dict)
     return dispatch_tool_call(run_fn, input_model(**input_dict), config_model(**config_dict), instance=instance)
 

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,9 +9,10 @@ from typing import Any
 
 import modal
 
+from proto_tools.modal.hooks import apply_payload_hooks, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
-from proto_tools.utils.tool_io import BaseToolOutput, MissingAssetError
+from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput, MissingAssetError
 
 _utils_logger = logging.getLogger(__name__)
 
@@ -272,7 +273,38 @@ def dispatch_tool_call(
     partition = next((config._progress_partition for config in configs if config._progress_partition), None)
     level = next((config._progress_level for config in configs if config._progress_partition), logging.INFO)
     with container_progress(partition, level=level):
-        return apply_tool_envelope(run_fn, *args, **kwargs)
+        # Inside the progress context, so anything a middleware logs reaches the caller too.
+        return run_with_middleware(lambda: apply_tool_envelope(run_fn, *args, **kwargs))
+
+
+def run_tool_call(
+    run_fn: Callable[..., BaseToolOutput],
+    input_model: type[BaseToolInput],
+    config_model: type[BaseConfig],
+    input_dict: dict[str, Any],
+    config_dict: dict[str, Any],
+    *,
+    instance: Any = None,
+) -> dict[str, Any]:
+    """Validate one call's mappings and run it. The entry point a service method calls.
+
+    Construction happens here rather than in each service method so payload hooks have somewhere
+    to run: once a mapping becomes a model it has already been validated, and a value that needed
+    resolving first has already been rejected or normalized.
+
+    Args:
+        run_fn (Callable[..., BaseToolOutput]): The tool's ``run_*`` function.
+        input_model (type[BaseToolInput]): Input model to validate ``input_dict`` with.
+        config_model (type[BaseConfig]): Config model to validate ``config_dict`` with.
+        input_dict (dict[str, Any]): Raw input mapping as received from the caller.
+        config_dict (dict[str, Any]): Raw config mapping as received from the caller.
+        instance (Any): Persistent worker to run on, when the service keeps one.
+
+    Returns:
+        dict[str, Any]: The tool's serialized output.
+    """
+    apply_payload_hooks(input_dict, config_dict)
+    return dispatch_tool_call(run_fn, input_model(**input_dict), config_model(**config_dict), instance=instance)
 
 
 def apply_standalone_overrides(image: modal.Image, tool: str, source_dir: Path | str) -> modal.Image:

--- a/tests/modal_tests/test_worker_hooks.py
+++ b/tests/modal_tests/test_worker_hooks.py
@@ -1,0 +1,216 @@
+"""Extension points a worker exposes, and the guarantees they carry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from proto_tools.modal.hooks import (
+    apply_payload_hooks,
+    clear_hooks,
+    register_call_middleware,
+    register_payload_hook,
+    run_with_middleware,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hooks():
+    """Hooks are process-wide, so a test that registers one must not leak into the next."""
+    clear_hooks()
+    yield
+    clear_hooks()
+
+
+def test_nothing_registered_is_a_pass_through() -> None:
+    """The default must cost nothing and change nothing: most deployments register no hooks."""
+    payload: dict[str, Any] = {"sequences": ["ACGT"]}
+    config: dict[str, Any] = {"batch_size": 2}
+    apply_payload_hooks(payload, config)
+    assert payload == {"sequences": ["ACGT"]}
+    assert config == {"batch_size": 2}
+    assert run_with_middleware(lambda: {"ok": True}) == {"ok": True}
+
+
+def test_a_payload_hook_sees_both_mappings() -> None:
+    """Config carries file references as often as inputs do, so a hook must reach both."""
+    seen: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    register_payload_hook(lambda i, c: seen.append((i, c)))
+
+    apply_payload_hooks({"a": 1}, {"b": 2})
+    assert seen == [({"a": 1}, {"b": 2})]
+
+
+def test_a_payload_hook_can_rewrite_a_value() -> None:
+    """The reason this hook runs before validation: a value may need resolving to pass it."""
+
+    def resolve(input_dict: dict[str, Any], _config: dict[str, Any]) -> None:
+        if input_dict.get("path") == "ref://x":
+            input_dict["path"] = "/staged/x"
+
+    register_payload_hook(resolve)
+    payload = {"path": "ref://x"}
+    apply_payload_hooks(payload, {})
+    assert payload == {"path": "/staged/x"}
+
+
+def test_payload_hooks_run_in_registration_order() -> None:
+    """Later hooks see earlier ones' edits, which is what makes them composable."""
+    register_payload_hook(lambda i, _c: i.__setitem__("order", "first"))
+    register_payload_hook(lambda i, _c: i.__setitem__("order", i["order"] + "-second"))
+
+    payload: dict[str, Any] = {}
+    apply_payload_hooks(payload, {})
+    assert payload["order"] == "first-second"
+
+
+def test_middleware_wraps_the_call() -> None:
+    """The common case: do something before and after, and return the result untouched."""
+    events: list[str] = []
+
+    def timing(next_step):
+        events.append("before")
+        result = next_step()
+        events.append("after")
+        return result
+
+    register_call_middleware(timing)
+    assert run_with_middleware(lambda: {"value": 1}) == {"value": 1}
+    assert events == ["before", "after"]
+
+
+def test_middleware_can_transform_the_result() -> None:
+    """A large field may need moving elsewhere before the transport sees it."""
+    register_call_middleware(lambda nxt: {**nxt(), "added": True})
+    assert run_with_middleware(lambda: {"value": 1}) == {"value": 1, "added": True}
+
+
+def test_middleware_may_wrap_the_call_in_a_context() -> None:
+    """Capturing output for the duration of a call is the motivating shape."""
+    import contextlib
+
+    entered: list[str] = []
+
+    @contextlib.contextmanager
+    def capture():
+        entered.append("open")
+        try:
+            yield
+        finally:
+            entered.append("close")
+
+    def with_capture(next_step):
+        with capture():
+            return next_step()
+
+    register_call_middleware(with_capture)
+    run_with_middleware(lambda: {"ok": True})
+    assert entered == ["open", "close"]
+
+
+def test_the_first_registered_middleware_is_outermost() -> None:
+    """Documented ordering. Reversing it would silently invert nesting for anyone relying on it."""
+    order: list[str] = []
+
+    def outer(next_step):
+        order.append("outer-in")
+        result = next_step()
+        order.append("outer-out")
+        return result
+
+    def inner(next_step):
+        order.append("inner-in")
+        result = next_step()
+        order.append("inner-out")
+        return result
+
+    register_call_middleware(outer)
+    register_call_middleware(inner)
+    run_with_middleware(dict)
+    assert order == ["outer-in", "inner-in", "inner-out", "outer-out"]
+
+
+def test_each_middleware_binds_its_own_next_step() -> None:
+    """Building the chain in a loop invites late binding, where every layer calls the last one."""
+    calls: list[int] = []
+
+    def make(index: int):
+        def middleware(next_step):
+            calls.append(index)
+            return next_step()
+
+        return middleware
+
+    for index in range(3):
+        register_call_middleware(make(index))
+    run_with_middleware(dict)
+    assert calls == [0, 1, 2]
+
+
+def test_a_raising_middleware_propagates() -> None:
+    """Swallowing an error here would report a failed call as a successful one."""
+    register_call_middleware(lambda nxt: nxt())
+
+    def explode(_next_step):
+        raise RuntimeError("middleware failed")
+
+    register_call_middleware(explode)
+    with pytest.raises(RuntimeError, match="middleware failed"):
+        run_with_middleware(dict)
+
+
+def test_no_service_bypasses_the_hook_point() -> None:
+    """Every service method must dispatch through ``run_tool_call``.
+
+    A method that builds its own models and calls ``dispatch_tool_call`` directly still works,
+    which is the problem: payload hooks never see that call, and the omission shows up as a
+    tool that quietly ignores whatever the operator installed rather than as an error.
+    """
+    import ast
+    import pathlib
+
+    modal_root = pathlib.Path(__file__).resolve().parents[2] / "proto_tools" / "modal"
+    offenders: list[str] = []
+    for path in sorted(modal_root.rglob("*_service.py")):
+        tree = ast.parse(path.read_text(), str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name == "dispatch_tool_call":
+                offenders.append(f"{path.relative_to(modal_root)}:{node.lineno}")
+
+    assert not offenders, (
+        f"Service methods call dispatch_tool_call directly, bypassing payload hooks: {offenders}. "
+        f"Use run_tool_call(run_fn, InputModel, ConfigModel, input_dict, config_dict) instead."
+    )
+
+
+def test_run_tool_call_applies_payload_hooks_before_validation() -> None:
+    """The whole point of centralizing: a hook must be able to fix a value validation rejects."""
+    from proto_tools.modal.utils import run_tool_call
+    from proto_tools.utils.base_config import BaseConfig
+    from proto_tools.utils.tool_io import BaseToolInput
+
+    class _Input(BaseToolInput):
+        sequence: str
+
+    class _Config(BaseConfig):
+        pass
+
+    def resolve(input_dict: dict[str, Any], _config: dict[str, Any]) -> None:
+        input_dict["sequence"] = input_dict["sequence"].removeprefix("ref://")
+
+    register_payload_hook(resolve)
+
+    seen: dict[str, Any] = {}
+
+    def fake_run(inputs: _Input, config: _Config, instance: Any = None) -> Any:
+        seen["sequence"] = inputs.sequence
+        raise RuntimeError("stop here — validation already happened")
+
+    with pytest.raises(RuntimeError, match="stop here"):
+        run_tool_call(fake_run, _Input, _Config, {"sequence": "ref://ACGT"}, {})
+    assert seen["sequence"] == "ACGT", "the hook must run before the model is constructed"

--- a/tests/modal_tests/test_worker_hooks.py
+++ b/tests/modal_tests/test_worker_hooks.py
@@ -7,12 +7,15 @@ from typing import Any
 import pytest
 
 from proto_tools.modal.hooks import (
+    CallContext,
     apply_payload_hooks,
     clear_hooks,
     register_call_middleware,
     register_payload_hook,
     run_with_middleware,
 )
+
+_CTX = CallContext(run_fn=lambda: None)
 
 
 @pytest.fixture(autouse=True)
@@ -30,7 +33,7 @@ def test_nothing_registered_is_a_pass_through() -> None:
     apply_payload_hooks(payload, config)
     assert payload == {"sequences": ["ACGT"]}
     assert config == {"batch_size": 2}
-    assert run_with_middleware(lambda: {"ok": True}) == {"ok": True}
+    assert run_with_middleware(_CTX, lambda: {"ok": True}) == {"ok": True}
 
 
 def test_a_payload_hook_sees_both_mappings() -> None:
@@ -69,21 +72,21 @@ def test_middleware_wraps_the_call() -> None:
     """The common case: do something before and after, and return the result untouched."""
     events: list[str] = []
 
-    def timing(next_step):
+    def timing(_ctx, next_step):
         events.append("before")
         result = next_step()
         events.append("after")
         return result
 
     register_call_middleware(timing)
-    assert run_with_middleware(lambda: {"value": 1}) == {"value": 1}
+    assert run_with_middleware(_CTX, lambda: {"value": 1}) == {"value": 1}
     assert events == ["before", "after"]
 
 
 def test_middleware_can_transform_the_result() -> None:
     """A large field may need moving elsewhere before the transport sees it."""
-    register_call_middleware(lambda nxt: {**nxt(), "added": True})
-    assert run_with_middleware(lambda: {"value": 1}) == {"value": 1, "added": True}
+    register_call_middleware(lambda _ctx, nxt: {**nxt(), "added": True})
+    assert run_with_middleware(_CTX, lambda: {"value": 1}) == {"value": 1, "added": True}
 
 
 def test_middleware_may_wrap_the_call_in_a_context() -> None:
@@ -100,12 +103,12 @@ def test_middleware_may_wrap_the_call_in_a_context() -> None:
         finally:
             entered.append("close")
 
-    def with_capture(next_step):
+    def with_capture(_ctx, next_step):
         with capture():
             return next_step()
 
     register_call_middleware(with_capture)
-    run_with_middleware(lambda: {"ok": True})
+    run_with_middleware(_CTX, lambda: {"ok": True})
     assert entered == ["open", "close"]
 
 
@@ -113,13 +116,13 @@ def test_the_first_registered_middleware_is_outermost() -> None:
     """Documented ordering. Reversing it would silently invert nesting for anyone relying on it."""
     order: list[str] = []
 
-    def outer(next_step):
+    def outer(_ctx, next_step):
         order.append("outer-in")
         result = next_step()
         order.append("outer-out")
         return result
 
-    def inner(next_step):
+    def inner(_ctx, next_step):
         order.append("inner-in")
         result = next_step()
         order.append("inner-out")
@@ -127,7 +130,7 @@ def test_the_first_registered_middleware_is_outermost() -> None:
 
     register_call_middleware(outer)
     register_call_middleware(inner)
-    run_with_middleware(dict)
+    run_with_middleware(_CTX, dict)
     assert order == ["outer-in", "inner-in", "inner-out", "outer-out"]
 
 
@@ -136,7 +139,7 @@ def test_each_middleware_binds_its_own_next_step() -> None:
     calls: list[int] = []
 
     def make(index: int):
-        def middleware(next_step):
+        def middleware(_ctx, next_step):
             calls.append(index)
             return next_step()
 
@@ -144,47 +147,56 @@ def test_each_middleware_binds_its_own_next_step() -> None:
 
     for index in range(3):
         register_call_middleware(make(index))
-    run_with_middleware(dict)
+    run_with_middleware(_CTX, dict)
     assert calls == [0, 1, 2]
 
 
 def test_a_raising_middleware_propagates() -> None:
     """Swallowing an error here would report a failed call as a successful one."""
-    register_call_middleware(lambda nxt: nxt())
+    register_call_middleware(lambda _ctx, nxt: nxt())
 
-    def explode(_next_step):
+    def explode(_ctx, _next_step):
         raise RuntimeError("middleware failed")
 
     register_call_middleware(explode)
     with pytest.raises(RuntimeError, match="middleware failed"):
-        run_with_middleware(dict)
+        run_with_middleware(_CTX, dict)
 
 
 def test_no_service_bypasses_the_hook_point() -> None:
     """Every service method must dispatch through ``run_tool_call``.
 
-    A method that builds its own models and calls ``dispatch_tool_call`` directly still works,
-    which is the problem: payload hooks never see that call, and the omission shows up as a
-    tool that quietly ignores whatever the operator installed rather than as an error.
+    Asserted positively rather than by banning ``dispatch_tool_call``: calling the run function
+    or the envelope directly bypasses hooks just as effectively, and a bypass shows up as a tool
+    quietly ignoring whatever the operator installed rather than as an error.
     """
     import ast
     import pathlib
 
     modal_root = pathlib.Path(__file__).resolve().parents[2] / "proto_tools" / "modal"
     offenders: list[str] = []
+    checked = 0
     for path in sorted(modal_root.rglob("*_service.py")):
         tree = ast.parse(path.read_text(), str(path))
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
+            if not isinstance(node, ast.FunctionDef):
                 continue
-            func = node.func
-            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
-            if name == "dispatch_tool_call":
-                offenders.append(f"{path.relative_to(modal_root)}:{node.lineno}")
+            decorators = [d.func if isinstance(d, ast.Call) else d for d in node.decorator_list]
+            if not any(getattr(d, "attr", None) == "method" for d in decorators):
+                continue
+            checked += 1
+            called = {
+                inner.func.id if isinstance(inner.func, ast.Name) else getattr(inner.func, "attr", None)
+                for inner in ast.walk(node)
+                if isinstance(inner, ast.Call)
+            }
+            if "run_tool_call" not in called:
+                offenders.append(f"{path.relative_to(modal_root)}:{node.lineno} ({node.name})")
 
+    assert checked, "found no service methods to check — the scan itself is broken"
     assert not offenders, (
-        f"Service methods call dispatch_tool_call directly, bypassing payload hooks: {offenders}. "
-        f"Use run_tool_call(run_fn, InputModel, ConfigModel, input_dict, config_dict) instead."
+        f"Service methods do not dispatch through run_tool_call, so hooks never see them: {offenders}. "
+        f"Use run_tool_call(run_fn, InputModel, ConfigModel, input_dict, config_dict)."
     )
 
 
@@ -214,3 +226,51 @@ def test_run_tool_call_applies_payload_hooks_before_validation() -> None:
     with pytest.raises(RuntimeError, match="stop here"):
         run_tool_call(fake_run, _Input, _Config, {"sequence": "ref://ACGT"}, {})
     assert seen["sequence"] == "ACGT", "the hook must run before the model is constructed"
+
+
+def test_middleware_cleanup_runs_when_the_tool_raises() -> None:
+    """The guarantee that matters for a context-manager middleware, and the one a success cannot show."""
+    import contextlib
+
+    entered: list[str] = []
+
+    @contextlib.contextmanager
+    def capture():
+        entered.append("open")
+        try:
+            yield
+        finally:
+            entered.append("close")
+
+    def with_capture(_ctx, next_step):
+        with capture():
+            return next_step()
+
+    register_call_middleware(with_capture)
+
+    def explode() -> dict[str, Any]:
+        raise RuntimeError("the tool failed")
+
+    with pytest.raises(RuntimeError, match="the tool failed"):
+        run_with_middleware(_CTX, explode)
+    assert entered == ["open", "close"], "cleanup must run when the wrapped call raises"
+
+
+def test_a_middleware_that_forgets_to_return_is_named() -> None:
+    """Otherwise the None travels to the client and fails somewhere pointing at no middleware."""
+
+    def forgets(_ctx, next_step) -> None:
+        next_step()
+
+    register_call_middleware(forgets)
+    with pytest.raises(TypeError, match="middleware returned NoneType"):
+        run_with_middleware(_CTX, lambda: {"ok": True})
+
+
+def test_middleware_is_told_which_tool_it_wrapped() -> None:
+    """Timings and destinations need naming; the run function alone is not a stable label."""
+    from proto_tools.modal.hooks import CallContext as _CallContext
+    from proto_tools.tools.masked_models.esm2.esm2_embeddings import run_esm2_embeddings
+
+    assert _CallContext(run_esm2_embeddings).tool_key == "esm2-embedding"
+    assert _CallContext(lambda: None).tool_key is None, "an unregistered function resolves to nothing"


### PR DESCRIPTION
A deployment is not always just the tool. Whoever operates one may need to adapt a call or observe it — resolving a reference the caller passed instead of a value, recording timings, moving a large result somewhere the transport is happier with — and today the only way is to fork all 54 service classes.

This adds two extension points and gives them one place to run.

## The extension points

`proto_tools/modal/hooks.py`, distinguished by what they can still see:

| | Runs | Sees |
|---|---|---|
| `register_payload_hook` | before validation | the raw `input_dict` and `config_dict`, mutable |
| `register_call_middleware` | around the call | the next step; may transform the result |

A **payload hook** is the only place a value can still be rewritten: once a mapping becomes a model, validation has already accepted or rejected it. Resolving an indirect reference belongs here, and nowhere later works.

**Middleware** follows the ASGI shape — take the next step, call it, return a mapping. Timing, wrapping in a context manager, and transforming a result are all one concept rather than three hooks. First registered is outermost.

Both are process-wide, registered at import time from whatever module defines a deployment's entry point. Nothing registers by default, and with nothing registered both are pass-throughs.

## Why service methods changed

The payload hook needs the raw mappings, which only exist inside each service method. Rather than add a line to all 99 of them, the three-line tail every method shared:

```python
inputs = ESM2EmbeddingsInput(**input_dict)
config = ESM2EmbeddingsConfig(**config_dict)
return dispatch_tool_call(run_esm2_embeddings, inputs, config, instance=self.instance)
```

becomes one call that owns validation and dispatch together:

```python
return run_tool_call(
    run_esm2_embeddings, ESM2EmbeddingsInput, ESM2EmbeddingsConfig,
    input_dict, config_dict, instance=self.instance,
)
```

**99 methods across 54 files.** The migration was uniform: 97 sites were byte-identical in shape, 2 omit `instance=` (`pdockq2`, `structure-metrics`), and no method did anything between constructing the models and dispatching, so nothing was reordered. Lazy `from proto_tools.tools...` imports are untouched — per-tool import stays lazy.

`dispatch_tool_call` keeps its signature and stays public; it now composes the middleware chain inside the existing progress context, so anything a middleware logs still reaches the caller's spinner.

## Guard

A test fails any service that calls `dispatch_tool_call` directly. That path still works, which is exactly why it needs catching — a service that bypasses `run_tool_call` silently ignores whatever hooks an operator installed, rather than erroring.

## Verification

- 12 tests on the hooks: pass-through default, both mappings reachable, rewriting before validation, registration order for both kinds, middleware wrapping/transforming/context-managing, exception propagation, per-layer binding (a loop-built chain invites late binding where every layer calls the last), the bypass guard, and an end-to-end check that a payload hook fixes a value the model would otherwise reject.
- 1,823 pass across `modal_tests` and `tool_infra_tests`; 8,373 across the style suite.
- `ruff check` clean. `mypy` at 75 errors, identical to this branch's base — none in `proto_tools/modal/`.
- `notes/modal-deployment.md` documents both hooks and the entry point.