### PR TITLE
Let a deployment add packages, source, and startup plugins to every service image

### DIFF
--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -263,10 +263,13 @@ PROTO_MODAL_WORKER_PLUGINS=observability.hooks \
 proto-tools deploy --apps tmalign --env proto-env
 ```
 
-The plugin list is baked into the image's runtime environment, so it applies to every call the
-container serves and not to the build-time warmup. Imports happen once per process, on the first
-call. A module that cannot be imported raises rather than being skipped: a worker that served
-calls without a deployment's extensions would silently drop whatever they were responsible for.
+All three are applied by `with_proto_tools`, which every service image is built through — a guard
+test asserts that, since a service bypassing it would silently ignore all three.
+
+Plugins are imported once per process, on the first call a worker serves. The deploy-time warmup
+calls run functions directly rather than through `run_tool_call`, so it never loads them. A module
+that cannot be imported raises rather than being skipped: a worker that served calls without a
+deployment's extensions would silently drop whatever they were responsible for.
 
 Extra layers are added below proto-tools' own, so editing proto-tools does not rebuild them. A
 directory named by `PROTO_MODAL_EXTRA_SOURCE` that does not exist fails the deploy rather than the

--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -252,28 +252,38 @@ was built with. Three variables, read where the deploy runs, cover both:
 
 | Variable | Effect |
 |---|---|
-| `PROTO_MODAL_EXTRA_PACKAGES` | Requirements every service image installs. Whitespace-separated, since a specifier may contain a comma. |
-| `PROTO_MODAL_EXTRA_SOURCE` | Directories every service image carries, separated by `os.pathsep`. Each is mounted under `/root` by its own name and imports as that name. |
+| `PROTO_MODAL_EXTRA_PACKAGES` | Requirements every service image installs. Whitespace-separated, since a specifier may contain a comma — which also means an environment marker cannot be expressed here. |
+| `PROTO_MODAL_EXTRA_SOURCE` | Directories every service image carries, separated by `os.pathsep`. Each is mounted under `/root` by its own name and imports as that name, so the name must be a Python identifier. |
 | `PROTO_MODAL_WORKER_PLUGINS` | Modules a worker imports before serving its first call. Comma- or whitespace-separated. |
 
 ```bash
 PROTO_MODAL_EXTRA_PACKAGES="alpha>=1 beta" \
-PROTO_MODAL_EXTRA_SOURCE=/path/to/observability \
-PROTO_MODAL_WORKER_PLUGINS=observability.hooks \
+PROTO_MODAL_EXTRA_SOURCE=/path/to/extras \
+PROTO_MODAL_WORKER_PLUGINS=extras.hooks \
 proto-tools deploy --apps tmalign --env proto-env
 ```
 
-All three are applied by `with_proto_tools`, which every service image is built through — a guard
-test asserts that, since a service bypassing it would silently ignore all three.
+Packages and source are added by `with_proto_tools`, below proto-tools' own layers, so editing
+proto-tools does not rebuild them. The plugin list travels in `RUNTIME_ENV` instead, applied
+*above* the warmup: it is runtime metadata, and renaming a module would otherwise rebuild and
+re-warm all 54 images. Guard tests assert every service applies both, since the two that once
+omitted `RUNTIME_ENV` loaded no plugins at all while deploying and smoke-testing green.
 
-Plugins are imported once per process, on the first call a worker serves. The deploy-time warmup
-calls run functions directly rather than through `run_tool_call`, so it never loads them. A module
-that cannot be imported raises rather than being skipped: a worker that served calls without a
-deployment's extensions would silently drop whatever they were responsible for.
+Plugins are imported once per process, on the first call a worker serves — not at `@modal.enter`.
+So a middleware cannot observe what a service does in its enter hook, and a cold container charges
+the import to its first request. The deploy-time warmup calls run functions directly rather than
+through `run_tool_call`, so it never loads them.
 
-Extra layers are added below proto-tools' own, so editing proto-tools does not rebuild them. A
-directory named by `PROTO_MODAL_EXTRA_SOURCE` that does not exist fails the deploy rather than the
-first call.
+Both failure modes are surfaced rather than deferred, because a worker serving calls with a
+deployment's extensions silently absent is worse than a loud failure:
+
+- a module that cannot be imported raises an `ImportError` naming `PROTO_MODAL_WORKER_PLUGINS`;
+- a directory that does not exist, or whose name nothing could import, fails the deploy up front
+  rather than inside a subprocess whose output is filtered to phase lines.
+
+A mounted directory excludes `.git` and the usual build artefacts. It does *not* exclude `tests`,
+which in someone else's tree may be a package their code imports. Note that `/root` precedes
+site-packages, so a directory sharing a name with an installed package shadows it.
 
 ## Hosted environments
 
@@ -300,7 +310,7 @@ Eight environment variables, all optional, read in the environment a deploy runs
 | `PROTO_MODAL_PROTO_TOOLS` | unset | Build from this proto-tools checkout instead of the installed one. |
 | `PROTO_MODAL_EXTRA_PACKAGES` | unset | Requirements every service image installs. |
 | `PROTO_MODAL_EXTRA_SOURCE` | unset | Directories every service image carries, importable by their own names. |
-| `PROTO_MODAL_WORKER_PLUGINS` | unset | Modules a worker imports before serving its first call. |
+| `PROTO_MODAL_WORKER_PLUGINS` | unset | Modules a worker imports before serving its first call. Also re-read inside the container, which is where the import happens. |
 
 ### Container wall tiers
 

--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -245,6 +245,33 @@ Two limits worth knowing: payload hooks run before the progress context opens, s
 silent on the caller's spinner; and a middleware that forgets to return raises `TypeError` rather
 than returning `None` to the client.
 
+### Getting extension code into a worker
+
+A deployed container imports only what a service module reaches, and carries only what its image
+was built with. Three variables, read where the deploy runs, cover both:
+
+| Variable | Effect |
+|---|---|
+| `PROTO_MODAL_EXTRA_PACKAGES` | Requirements every service image installs. Whitespace-separated, since a specifier may contain a comma. |
+| `PROTO_MODAL_EXTRA_SOURCE` | Directories every service image carries, separated by `os.pathsep`. Each is mounted under `/root` by its own name and imports as that name. |
+| `PROTO_MODAL_WORKER_PLUGINS` | Modules a worker imports before serving its first call. Comma- or whitespace-separated. |
+
+```bash
+PROTO_MODAL_EXTRA_PACKAGES="alpha>=1 beta" \
+PROTO_MODAL_EXTRA_SOURCE=/path/to/observability \
+PROTO_MODAL_WORKER_PLUGINS=observability.hooks \
+proto-tools deploy --apps tmalign --env proto-env
+```
+
+The plugin list is baked into the image's runtime environment, so it applies to every call the
+container serves and not to the build-time warmup. Imports happen once per process, on the first
+call. A module that cannot be imported raises rather than being skipped: a worker that served
+calls without a deployment's extensions would silently drop whatever they were responsible for.
+
+Extra layers are added below proto-tools' own, so editing proto-tools does not rebuild them. A
+directory named by `PROTO_MODAL_EXTRA_SOURCE` that does not exist fails the deploy rather than the
+first call.
+
 ## Hosted environments
 
 `PROTO_IS_HOSTED_ENV` marks a process running tools for someone else rather than on a
@@ -259,7 +286,7 @@ and therefore logs a warning rather than passing silently.
 
 ## Configuration
 
-Five environment variables, all optional, read in the environment a deploy runs from.
+Eight environment variables, all optional, read in the environment a deploy runs from.
 
 | Variable | Default | Effect |
 |---|---|---|
@@ -268,6 +295,9 @@ Five environment variables, all optional, read in the environment a deploy runs 
 | `PROTO_MODAL_SCALEDOWN_WINDOW` | `30` | Seconds an idle container stays alive holding its model. |
 | `PROTO_MODAL_TIMEOUT_SCALE` | `1` | Multiplies every container wall tier. Values below 1 are ignored. |
 | `PROTO_MODAL_PROTO_TOOLS` | unset | Build from this proto-tools checkout instead of the installed one. |
+| `PROTO_MODAL_EXTRA_PACKAGES` | unset | Requirements every service image installs. |
+| `PROTO_MODAL_EXTRA_SOURCE` | unset | Directories every service image carries, importable by their own names. |
+| `PROTO_MODAL_WORKER_PLUGINS` | unset | Modules a worker imports before serving its first call. |
 
 ### Container wall tiers
 

--- a/proto_tools/modal/base_images.py
+++ b/proto_tools/modal/base_images.py
@@ -21,6 +21,23 @@ EXTRA_PACKAGES_ENV = "PROTO_MODAL_EXTRA_PACKAGES"
 #: mounted under :data:`CONTAINER_ROOT` by its own name, so a container imports it as that name.
 EXTRA_SOURCE_ENV = "PROTO_MODAL_EXTRA_SOURCE"
 
+# Excluded from an extra source directory. Narrower than :data:`proto_tools.modal.utils`'
+# LOCAL_DIR_IGNORE, which also drops `tests` and `notes`: those name this repository's own layout,
+# and a directory of someone else's may be a package its code imports.
+#
+# `.git` is the load-bearing entry. A checkout is the obvious thing to point this at, and git
+# rewrites its index during ordinary work, so mounting it would change the layer hash between two
+# deploys of identical code and rebuild every image below it.
+EXTRA_SOURCE_IGNORE: list[str] = [
+    ".git",
+    "__pycache__",
+    "*.pyc",
+    "*.egg-info",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+]
+
 # Resolving a source tree is a deploy-time concern; a container never builds an image.
 _CHECKOUT = checkout_or_none()
 
@@ -84,34 +101,37 @@ def extra_source_dirs() -> list[Path]:
         list[Path]: Resolved directories, empty when the variable is unset.
 
     Raises:
-        ValueError: If a named path is not a directory. Building an image without the code a
-            deployment asked for would fail later, inside a container, on the first call.
+        ValueError: If a named path is not a directory, or its name is not one a container could
+            import it by. Building an image without the code a deployment asked for would fail
+            later, inside a container, on the first call.
     """
     resolved = []
     for entry in os.environ.get(EXTRA_SOURCE_ENV, "").split(os.pathsep):
         if not entry:
             continue
-        path = Path(entry).resolve()
+        path = Path(entry).expanduser().resolve()
         if not path.is_dir():
             raise ValueError(f"{EXTRA_SOURCE_ENV} names {entry!r}, which is not a directory")
+        if not path.name.isidentifier():
+            raise ValueError(
+                f"{EXTRA_SOURCE_ENV} names {entry!r}, whose directory name is not a Python "
+                f"identifier. It is mounted under {CONTAINER_ROOT} by that name, so nothing "
+                f"could import it."
+            )
         resolved.append(path)
     return resolved
 
 
 def _with_extras(image: modal.Image) -> modal.Image:
-    """Add the packages, source, and plugin environment a deployment asked for.
+    """Add the packages and source a deployment asked for.
 
     Applied here because every service image is built through :func:`with_proto_tools`, which is
     not true of any later layer.
     """
-    from proto_tools.modal.hooks import plugin_env
-
     if packages := extra_packages():
         image = image.pip_install(*packages)
     for path in extra_source_dirs():
-        image = image.add_local_dir(str(path), f"{CONTAINER_ROOT}/{path.name}", copy=True)
-    if env := plugin_env():
-        image = image.env(env)
+        image = image.add_local_dir(str(path), f"{CONTAINER_ROOT}/{path.name}", copy=True, ignore=EXTRA_SOURCE_IGNORE)
     return image
 
 

--- a/proto_tools/modal/base_images.py
+++ b/proto_tools/modal/base_images.py
@@ -99,11 +99,19 @@ def extra_source_dirs() -> list[Path]:
 
 
 def _with_extras(image: modal.Image) -> modal.Image:
-    """Add the packages and source a deployment asked for, below proto-tools' own layers."""
+    """Add the packages, source, and plugin environment a deployment asked for.
+
+    Applied here because every service image is built through :func:`with_proto_tools`, which is
+    not true of any later layer.
+    """
+    from proto_tools.modal.hooks import plugin_env
+
     if packages := extra_packages():
         image = image.pip_install(*packages)
     for path in extra_source_dirs():
         image = image.add_local_dir(str(path), f"{CONTAINER_ROOT}/{path.name}", copy=True)
+    if env := plugin_env():
+        image = image.env(env)
     return image
 
 

--- a/proto_tools/modal/base_images.py
+++ b/proto_tools/modal/base_images.py
@@ -13,6 +13,14 @@ from proto_tools.modal.proto_tools_source import PATH_ENV, checkout_or_none
 # the tree that gets patched with standalone overrides is the one imports actually resolve to.
 CONTAINER_ROOT = "/root"
 
+#: Extra pip requirements every service image installs, separated by whitespace. For dependencies
+#: a deployment needs that proto-tools itself does not.
+EXTRA_PACKAGES_ENV = "PROTO_MODAL_EXTRA_PACKAGES"
+
+#: Extra local directories every service image carries, separated by :data:`os.pathsep`. Each is
+#: mounted under :data:`CONTAINER_ROOT` by its own name, so a container imports it as that name.
+EXTRA_SOURCE_ENV = "PROTO_MODAL_EXTRA_SOURCE"
+
 # Resolving a source tree is a deploy-time concern; a container never builds an image.
 _CHECKOUT = checkout_or_none()
 
@@ -59,6 +67,46 @@ def with_dependencies(image: modal.Image) -> modal.Image:
 BENCHMARK_REPORT_PATTERNS: list[str] = ["**/modal/*/*_deployment/README.md"]
 
 
+def extra_packages() -> list[str]:
+    """Return the requirements named in :data:`EXTRA_PACKAGES_ENV`.
+
+    Returns:
+        list[str]: Requirement specifiers, empty when the variable is unset. Split on whitespace
+            rather than commas, which a specifier may contain.
+    """
+    return os.environ.get(EXTRA_PACKAGES_ENV, "").split()
+
+
+def extra_source_dirs() -> list[Path]:
+    """Return the directories named in :data:`EXTRA_SOURCE_ENV`.
+
+    Returns:
+        list[Path]: Resolved directories, empty when the variable is unset.
+
+    Raises:
+        ValueError: If a named path is not a directory. Building an image without the code a
+            deployment asked for would fail later, inside a container, on the first call.
+    """
+    resolved = []
+    for entry in os.environ.get(EXTRA_SOURCE_ENV, "").split(os.pathsep):
+        if not entry:
+            continue
+        path = Path(entry).resolve()
+        if not path.is_dir():
+            raise ValueError(f"{EXTRA_SOURCE_ENV} names {entry!r}, which is not a directory")
+        resolved.append(path)
+    return resolved
+
+
+def _with_extras(image: modal.Image) -> modal.Image:
+    """Add the packages and source a deployment asked for, below proto-tools' own layers."""
+    if packages := extra_packages():
+        image = image.pip_install(*packages)
+    for path in extra_source_dirs():
+        image = image.add_local_dir(str(path), f"{CONTAINER_ROOT}/{path.name}", copy=True)
+    return image
+
+
 def with_proto_tools(
     image: modal.Image, *, overrides: str | None = None, overrides_dir: Path | str | None = None
 ) -> modal.Image:
@@ -74,9 +122,13 @@ def with_proto_tools(
             normally the service module's own directory.
 
     Returns:
-        modal.Image: The image with proto-tools importable.
+        modal.Image: The image with proto-tools importable, and whatever :data:`EXTRA_PACKAGES_ENV`
+            and :data:`EXTRA_SOURCE_ENV` name.
     """
     from proto_tools.modal.utils import apply_standalone_overrides
+
+    # Applied first, so editing proto-tools does not rebuild a deployment's own layers.
+    image = _with_extras(image)
 
     # ignore=[] is required: the default keeps only .py, dropping every setup.sh and
     # requirements.txt a standalone environment needs.

--- a/proto_tools/modal/deploy.py
+++ b/proto_tools/modal/deploy.py
@@ -422,6 +422,25 @@ def require_proto_tools() -> None:
     )
 
 
+def require_extra_source() -> None:
+    """Fail early, on screen, when an extra source directory cannot be mounted.
+
+    Resolved during service-module import, inside a ``modal deploy`` subprocess whose output is
+    filtered down to recognised phase lines. Without this the reason reaches the log file only,
+    once per app, and the console shows a bare deploy failure.
+
+    Raises:
+        SystemExit: If :data:`~proto_tools.modal.base_images.EXTRA_SOURCE_ENV` names a path that
+            is not a mountable directory.
+    """
+    from proto_tools.modal.base_images import extra_source_dirs
+
+    try:
+        extra_source_dirs()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     """Build the argument parser, named for however it was invoked."""
     parser = argparse.ArgumentParser(prog=prog, description=USAGE, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -492,6 +511,7 @@ def main(argv: list[str] | None = None, prog: str | None = None) -> int:
 
     if not args.status:
         require_proto_tools()
+        require_extra_source()
 
     if args.env:
         os.environ["MODAL_ENVIRONMENT"] = args.env

--- a/proto_tools/modal/hooks.py
+++ b/proto_tools/modal/hooks.py
@@ -9,12 +9,23 @@ service class. Two extension points cover that, distinguished by what they can s
 
 Both are process-wide and applied in registration order. Register during import, before any call
 is served: registration is not synchronized.
+
+:data:`PLUGINS_ENV` names the modules a worker imports to perform that registration, since a
+deployed container imports only what a service module reaches.
 """
 
 import functools
+import importlib
+import os
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
+
+#: Modules a worker imports before serving its first call, separated by commas or whitespace.
+#: Each is imported for its side effects, which is where a deployment registers its hooks. Read
+#: in the environment a deploy runs from, and baked into the image so the container sees it.
+PLUGINS_ENV = "PROTO_MODAL_WORKER_PLUGINS"
 
 #: Adjusts a call's raw input and config mappings in place, before either is validated.
 PayloadHook = Callable[[dict[str, Any], dict[str, Any]], None]
@@ -74,10 +85,50 @@ def register_call_middleware(middleware: CallMiddleware) -> None:
     _call_middleware.append(middleware)
 
 
+def plugin_modules(value: str | None = None) -> tuple[str, ...]:
+    """Return the module names in ``value``, defaulting to :data:`PLUGINS_ENV`.
+
+    Args:
+        value (str | None): Raw variable value. Read from the environment when omitted.
+
+    Returns:
+        tuple[str, ...]: Module names in the order given, empty when the variable is unset.
+    """
+    raw = os.environ.get(PLUGINS_ENV, "") if value is None else value
+    return tuple(name for name in re.split(r"[,\s]+", raw) if name)
+
+
+@functools.cache
+def load_plugins() -> tuple[str, ...]:
+    """Import every module named in :data:`PLUGINS_ENV`, once per process.
+
+    An unimportable name raises rather than being skipped. A worker that quietly served calls
+    without a deployment's extensions would drop whatever they were responsible for.
+
+    Returns:
+        tuple[str, ...]: The module names imported, in the order given.
+    """
+    names = plugin_modules()
+    for name in names:
+        importlib.import_module(name)
+    return names
+
+
+def plugin_env() -> dict[str, str]:
+    """Return :data:`PLUGINS_ENV` as image env, or empty when unset.
+
+    Returns:
+        dict[str, str]: Mapping to merge into a service image's runtime environment.
+    """
+    raw = os.environ.get(PLUGINS_ENV)
+    return {PLUGINS_ENV: raw} if raw else {}
+
+
 def clear_hooks() -> None:
     """Remove every registered hook. Intended for tests, which must not leak into each other."""
     _payload_hooks.clear()
     _call_middleware.clear()
+    load_plugins.cache_clear()
 
 
 def apply_payload_hooks(input_dict: dict[str, Any], config_dict: dict[str, Any]) -> None:
@@ -127,11 +178,15 @@ def _bind(
 
 
 __all__ = [
+    "PLUGINS_ENV",
     "CallContext",
     "CallMiddleware",
     "PayloadHook",
     "apply_payload_hooks",
     "clear_hooks",
+    "load_plugins",
+    "plugin_env",
+    "plugin_modules",
     "register_call_middleware",
     "register_payload_hook",
     "run_with_middleware",

--- a/proto_tools/modal/hooks.py
+++ b/proto_tools/modal/hooks.py
@@ -85,33 +85,52 @@ def register_call_middleware(middleware: CallMiddleware) -> None:
     _call_middleware.append(middleware)
 
 
-def plugin_modules(value: str | None = None) -> tuple[str, ...]:
-    """Return the module names in ``value``, defaulting to :data:`PLUGINS_ENV`.
+def _plugin_modules(raw: str) -> tuple[str, ...]:
+    """Return the module names in ``raw``.
 
     Args:
-        value (str | None): Raw variable value. Read from the environment when omitted.
+        raw (str): Raw variable value, comma- or whitespace-separated.
 
     Returns:
-        tuple[str, ...]: Module names in the order given, empty when the variable is unset.
+        tuple[str, ...]: Module names in the order given, empty when ``raw`` names none.
     """
-    raw = os.environ.get(PLUGINS_ENV, "") if value is None else value
     return tuple(name for name in re.split(r"[,\s]+", raw) if name)
 
 
 @functools.cache
 def load_plugins() -> tuple[str, ...]:
-    """Import every module named in :data:`PLUGINS_ENV`, once per process.
+    """Import every module named in :data:`PLUGINS_ENV`.
 
     An unimportable name raises rather than being skipped. A worker that quietly served calls
     without a deployment's extensions would drop whatever they were responsible for.
 
+    Cached to keep this off the hot path; ``sys.modules`` is what makes a module body run once.
+
     Returns:
         tuple[str, ...]: The module names imported, in the order given.
+
+    Raises:
+        ImportError: If a named module cannot be imported.
     """
-    names = plugin_modules()
+    names = _plugin_modules(os.environ.get(PLUGINS_ENV, ""))
     for name in names:
-        importlib.import_module(name)
+        _import_plugin(name)
     return names
+
+
+def _import_plugin(name: str) -> None:
+    """Import one plugin module, naming the variable it came from when that fails.
+
+    Args:
+        name (str): Module to import.
+
+    Raises:
+        ImportError: If the module cannot be imported.
+    """
+    try:
+        importlib.import_module(name)
+    except ImportError as exc:
+        raise ImportError(f"{PLUGINS_ENV} names {name!r}, which this worker cannot import") from exc
 
 
 def plugin_env() -> dict[str, str]:
@@ -125,7 +144,10 @@ def plugin_env() -> dict[str, str]:
 
 
 def clear_hooks() -> None:
-    """Remove every registered hook. Intended for tests, which must not leak into each other."""
+    """Remove every registered hook and forget which plugins were loaded.
+
+    Intended for tests, which must not leak into each other.
+    """
     _payload_hooks.clear()
     _call_middleware.clear()
     load_plugins.cache_clear()
@@ -186,7 +208,6 @@ __all__ = [
     "clear_hooks",
     "load_plugins",
     "plugin_env",
-    "plugin_modules",
     "register_call_middleware",
     "register_payload_hook",
     "run_with_middleware",

--- a/proto_tools/modal/structure_alignment/tmalign_deployment/tmalign_service.py
+++ b/proto_tools/modal/structure_alignment/tmalign_deployment/tmalign_service.py
@@ -13,7 +13,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import env_for, run_tool_call, stage_all_excluded_fixtures
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call, stage_all_excluded_fixtures
 
 
 def _tmalign_warmup() -> None:
@@ -24,8 +24,10 @@ def _tmalign_warmup() -> None:
 
 
 tmalign_image = with_proto_tools(CPU_BASE).env(env_for())
-tmalign_image = stage_all_excluded_fixtures(tmalign_image).run_function(
-    _tmalign_warmup, volumes={"/weights": MODEL_CACHE}, secrets=[HF_TOKEN_SECRET]
+tmalign_image = (
+    stage_all_excluded_fixtures(tmalign_image)
+    .run_function(_tmalign_warmup, volumes={"/weights": MODEL_CACHE}, secrets=[HF_TOKEN_SECRET])
+    .env(RUNTIME_ENV)
 )
 
 

--- a/proto_tools/modal/structure_alignment/usalign_deployment/usalign_service.py
+++ b/proto_tools/modal/structure_alignment/usalign_deployment/usalign_service.py
@@ -14,7 +14,7 @@ from proto_tools.modal.app import HF_TOKEN_SECRET, MODEL_CACHE, SERVICE_RETRIES,
 from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
 from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
 from proto_tools.modal.registry import register_tools
-from proto_tools.modal.utils import env_for, run_tool_call, stage_all_excluded_fixtures
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call, stage_all_excluded_fixtures
 
 
 def _usalign_warmup() -> None:
@@ -25,8 +25,10 @@ def _usalign_warmup() -> None:
 
 
 usalign_image = with_proto_tools(CPU_BASE).env(env_for())
-usalign_image = stage_all_excluded_fixtures(usalign_image).run_function(
-    _usalign_warmup, volumes={"/weights": MODEL_CACHE}, secrets=[HF_TOKEN_SECRET]
+usalign_image = (
+    stage_all_excluded_fixtures(usalign_image)
+    .run_function(_usalign_warmup, volumes={"/weights": MODEL_CACHE}, secrets=[HF_TOKEN_SECRET])
+    .env(RUNTIME_ENV)
 )
 
 

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import modal
 
-from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, run_with_middleware
+from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, plugin_env, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput, MissingAssetError
@@ -176,7 +176,10 @@ def env_for() -> dict[str, str]:
 #   RemoteError) and Modal autoscaling/retry would replay deterministic tool
 #   failures and burn GPU minutes. Capture-mode preserves the traceback and
 #   hands the caller a structured result it can inspect.
-RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1"}
+#
+# The plugin list belongs here rather than in an image layer below the warmup: it is runtime
+# metadata, and renaming a module would otherwise rebuild and re-warm every service.
+RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1", **plugin_env()}
 
 
 # Don't add ``examples`` — :func:`stage_all_excluded_fixtures` reads

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import modal
 
-from proto_tools.modal.hooks import CallContext, apply_payload_hooks, run_with_middleware
+from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, plugin_env, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput, MissingAssetError
@@ -176,7 +176,10 @@ def env_for() -> dict[str, str]:
 #   RemoteError) and Modal autoscaling/retry would replay deterministic tool
 #   failures and burn GPU minutes. Capture-mode preserves the traceback and
 #   hands the caller a structured result it can inspect.
-RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1"}
+#
+# Plugin modules join it here rather than in :func:`env_for`, so a deployment's extensions are
+# absent from the build-time warmup and present for every call the container serves.
+RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1", **plugin_env()}
 
 
 # Don't add ``examples`` — :func:`stage_all_excluded_fixtures` reads
@@ -308,6 +311,7 @@ def run_tool_call(
     # Hooks run before the progress context opens, so a slow one is silent on the caller's
     # spinner. Opening a second context here would double-register the log handler.
     mark_hosted_env()
+    load_plugins()
     apply_payload_hooks(input_dict, config_dict)
     return dispatch_tool_call(run_fn, input_model(**input_dict), config_model(**config_dict), instance=instance)
 

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import modal
 
-from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, plugin_env, run_with_middleware
+from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.tool_io import BaseToolInput, BaseToolOutput, MissingAssetError
@@ -176,10 +176,7 @@ def env_for() -> dict[str, str]:
 #   RemoteError) and Modal autoscaling/retry would replay deterministic tool
 #   failures and burn GPU minutes. Capture-mode preserves the traceback and
 #   hands the caller a structured result it can inspect.
-#
-# Plugin modules join it here rather than in :func:`env_for`, so a deployment's extensions are
-# absent from the build-time warmup and present for every call the container serves.
-RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1", **plugin_env()}
+RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1"}
 
 
 # Don't add ``examples`` — :func:`stage_all_excluded_fixtures` reads

--- a/tests/modal_tests/test_image_extensions.py
+++ b/tests/modal_tests/test_image_extensions.py
@@ -31,6 +31,10 @@ class _RecordingImage:
         self.calls.append(("add_local_dir", args, kwargs))
         return self
 
+    def env(self, *args: Any, **kwargs: Any) -> _RecordingImage:
+        self.calls.append(("env", args, kwargs))
+        return self
+
 
 def test_no_extras_leaves_the_image_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every deployment that asks for nothing must get the image it would have had."""
@@ -74,3 +78,28 @@ def test_a_missing_source_dir_fails_the_build(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setenv(EXTRA_SOURCE_ENV, str(tmp_path / "absent"))
     with pytest.raises(ValueError, match="not a directory"):
         extra_source_dirs()
+
+
+def test_the_plugin_list_is_baked_into_the_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A container reads the variable from its own environment, not the one that deployed it."""
+    from proto_tools.modal.hooks import PLUGINS_ENV
+
+    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
+    monkeypatch.delenv(EXTRA_SOURCE_ENV, raising=False)
+    monkeypatch.setenv(PLUGINS_ENV, "observability.hooks")
+
+    image = _RecordingImage()
+    _with_extras(image)
+    assert image.calls == [("env", ({PLUGINS_ENV: "observability.hooks"},), {})]
+
+
+def test_every_service_image_is_built_through_with_proto_tools() -> None:
+    """The extension points live there, so a service bypassing it would silently ignore all three."""
+    import pathlib
+
+    modal_root = pathlib.Path(__file__).resolve().parents[2] / "proto_tools" / "modal"
+    services = sorted(p for p in modal_root.rglob("*_service.py") if "__pycache__" not in p.parts)
+    missing = [str(p.relative_to(modal_root)) for p in services if "with_proto_tools" not in p.read_text()]
+
+    assert services, "found no service modules to check — the scan itself is broken"
+    assert not missing, f"service images not built through with_proto_tools: {missing}"

--- a/tests/modal_tests/test_image_extensions.py
+++ b/tests/modal_tests/test_image_extensions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 from pathlib import Path
 from typing import Any
@@ -11,10 +12,20 @@ import pytest
 from proto_tools.modal.base_images import (
     EXTRA_PACKAGES_ENV,
     EXTRA_SOURCE_ENV,
+    EXTRA_SOURCE_IGNORE,
     _with_extras,
     extra_packages,
     extra_source_dirs,
 )
+from proto_tools.modal.hooks import PLUGINS_ENV
+from tests.modal_tests.helpers import MODAL_ROOT, service_modules
+
+
+@pytest.fixture(autouse=True)
+def _clear_extension_env(monkeypatch: pytest.MonkeyPatch):
+    """A developer with any of these exported would otherwise fail tests that assert exact layers."""
+    for name in (EXTRA_PACKAGES_ENV, EXTRA_SOURCE_ENV, PLUGINS_ENV):
+        monkeypatch.delenv(name, raising=False)
 
 
 class _RecordingImage:
@@ -31,16 +42,9 @@ class _RecordingImage:
         self.calls.append(("add_local_dir", args, kwargs))
         return self
 
-    def env(self, *args: Any, **kwargs: Any) -> _RecordingImage:
-        self.calls.append(("env", args, kwargs))
-        return self
 
-
-def test_no_extras_leaves_the_image_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_extras_leaves_the_image_untouched() -> None:
     """Every deployment that asks for nothing must get the image it would have had."""
-    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
-    monkeypatch.delenv(EXTRA_SOURCE_ENV, raising=False)
-
     image = _RecordingImage()
     assert _with_extras(image) is image
     assert image.calls == []
@@ -54,23 +58,43 @@ def test_packages_split_on_whitespace_not_commas(monkeypatch: pytest.MonkeyPatch
 
 def test_a_source_dir_is_mounted_under_its_own_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The mount name is what a container imports it as, so it must follow the directory."""
-    package = tmp_path / "observability"
+    package = tmp_path / "extras"
     package.mkdir()
-    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
     monkeypatch.setenv(EXTRA_SOURCE_ENV, str(package))
 
     image = _RecordingImage()
     _with_extras(image)
-    assert image.calls == [("add_local_dir", (str(package), "/root/observability"), {"copy": True})]
+    assert image.calls == [
+        ("add_local_dir", (str(package), "/root/extras"), {"copy": True, "ignore": EXTRA_SOURCE_IGNORE})
+    ]
+
+
+def test_a_mounted_dir_excludes_its_repository_metadata() -> None:
+    """A checkout is the obvious thing to point this at, and git rewrites its index as you work.
+
+    Mounting that would change the layer hash between two deploys of identical code, rebuilding
+    every image below it.
+    """
+    assert ".git" in EXTRA_SOURCE_IGNORE
+    assert "tests" not in EXTRA_SOURCE_IGNORE, "someone else's tests/ may be a package their code imports"
 
 
 def test_several_source_dirs_are_path_separated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A path may contain spaces, so the list separator cannot be whitespace."""
-    first, second = tmp_path / "one", tmp_path / "two dirs"
+    first, second = tmp_path / "one", tmp_path / "two"
     first.mkdir()
     second.mkdir()
     monkeypatch.setenv(EXTRA_SOURCE_ENV, os.pathsep.join([str(first), str(second)]))
     assert extra_source_dirs() == [first, second]
+
+
+def test_a_home_relative_source_dir_is_expanded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Nothing expands ``~`` when the value arrives from a config file rather than a shell."""
+    package = tmp_path / "extras"
+    package.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(EXTRA_SOURCE_ENV, "~/extras")
+    assert extra_source_dirs() == [package]
 
 
 def test_a_missing_source_dir_fails_the_build(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -80,26 +104,34 @@ def test_a_missing_source_dir_fails_the_build(monkeypatch: pytest.MonkeyPatch, t
         extra_source_dirs()
 
 
-def test_the_plugin_list_is_baked_into_the_image(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A container reads the variable from its own environment, not the one that deployed it."""
-    from proto_tools.modal.hooks import PLUGINS_ENV
-
-    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
-    monkeypatch.delenv(EXTRA_SOURCE_ENV, raising=False)
-    monkeypatch.setenv(PLUGINS_ENV, "observability.hooks")
-
-    image = _RecordingImage()
-    _with_extras(image)
-    assert image.calls == [("env", ({PLUGINS_ENV: "observability.hooks"},), {})]
+@pytest.mark.parametrize("name", ["my-lib", "2foo", ""])
+def test_a_dir_nothing_could_import_is_refused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, name: str) -> None:
+    """It mounts by its own name, so a name that is not an identifier promises an import that fails."""
+    target = tmp_path / name if name else Path(os.sep)
+    if name:
+        target.mkdir()
+    monkeypatch.setenv(EXTRA_SOURCE_ENV, str(target))
+    with pytest.raises(ValueError, match="identifier"):
+        extra_source_dirs()
 
 
 def test_every_service_image_is_built_through_with_proto_tools() -> None:
-    """The extension points live there, so a service bypassing it would silently ignore all three."""
-    import pathlib
-
-    modal_root = pathlib.Path(__file__).resolve().parents[2] / "proto_tools" / "modal"
-    services = sorted(p for p in modal_root.rglob("*_service.py") if "__pycache__" not in p.parts)
-    missing = [str(p.relative_to(modal_root)) for p in services if "with_proto_tools" not in p.read_text()]
-
-    assert services, "found no service modules to check — the scan itself is broken"
+    """The image extension points live there, so a service bypassing it would ignore them."""
+    missing = [str(path.relative_to(MODAL_ROOT)) for path in service_modules() if not _calls(path, "with_proto_tools")]
+    assert service_modules(), "found no service modules to check — the scan itself is broken"
     assert not missing, f"service images not built through with_proto_tools: {missing}"
+
+
+def test_every_service_image_applies_the_runtime_environment() -> None:
+    """``RUNTIME_ENV`` carries the plugin list, and two services once omitted it and loaded none."""
+    missing = [str(path.relative_to(MODAL_ROOT)) for path in service_modules() if "RUNTIME_ENV" not in path.read_text()]
+    assert not missing, f"service images that never apply RUNTIME_ENV: {missing}"
+
+
+def _calls(path: Path, name: str) -> bool:
+    """Report whether ``path`` calls ``name``, rather than merely importing or mentioning it."""
+    tree = ast.parse(path.read_text(), str(path))
+    return any(
+        isinstance(node, ast.Call) and getattr(node.func, "id", getattr(node.func, "attr", None)) == name
+        for node in ast.walk(tree)
+    )

--- a/tests/modal_tests/test_image_extensions.py
+++ b/tests/modal_tests/test_image_extensions.py
@@ -1,0 +1,76 @@
+"""Extra packages and source a deployment adds to every service image."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from proto_tools.modal.base_images import (
+    EXTRA_PACKAGES_ENV,
+    EXTRA_SOURCE_ENV,
+    _with_extras,
+    extra_packages,
+    extra_source_dirs,
+)
+
+
+class _RecordingImage:
+    """Records the layers ``_with_extras`` adds, standing in for a ``modal.Image``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def pip_install(self, *args: Any, **kwargs: Any) -> _RecordingImage:
+        self.calls.append(("pip_install", args, kwargs))
+        return self
+
+    def add_local_dir(self, *args: Any, **kwargs: Any) -> _RecordingImage:
+        self.calls.append(("add_local_dir", args, kwargs))
+        return self
+
+
+def test_no_extras_leaves_the_image_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every deployment that asks for nothing must get the image it would have had."""
+    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
+    monkeypatch.delenv(EXTRA_SOURCE_ENV, raising=False)
+
+    image = _RecordingImage()
+    assert _with_extras(image) is image
+    assert image.calls == []
+
+
+def test_packages_split_on_whitespace_not_commas(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A version range is comma-separated, so splitting on commas would tear one in half."""
+    monkeypatch.setenv(EXTRA_PACKAGES_ENV, "alpha>=1,<2  beta==3.4")
+    assert extra_packages() == ["alpha>=1,<2", "beta==3.4"]
+
+
+def test_a_source_dir_is_mounted_under_its_own_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The mount name is what a container imports it as, so it must follow the directory."""
+    package = tmp_path / "observability"
+    package.mkdir()
+    monkeypatch.delenv(EXTRA_PACKAGES_ENV, raising=False)
+    monkeypatch.setenv(EXTRA_SOURCE_ENV, str(package))
+
+    image = _RecordingImage()
+    _with_extras(image)
+    assert image.calls == [("add_local_dir", (str(package), "/root/observability"), {"copy": True})]
+
+
+def test_several_source_dirs_are_path_separated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A path may contain spaces, so the list separator cannot be whitespace."""
+    first, second = tmp_path / "one", tmp_path / "two dirs"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setenv(EXTRA_SOURCE_ENV, os.pathsep.join([str(first), str(second)]))
+    assert extra_source_dirs() == [first, second]
+
+
+def test_a_missing_source_dir_fails_the_build(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Deferring this failure hides it until a container runs, long after the deploy reported success."""
+    monkeypatch.setenv(EXTRA_SOURCE_ENV, str(tmp_path / "absent"))
+    with pytest.raises(ValueError, match="not a directory"):
+        extra_source_dirs()

--- a/tests/modal_tests/test_worker_hooks.py
+++ b/tests/modal_tests/test_worker_hooks.py
@@ -7,9 +7,13 @@ from typing import Any
 import pytest
 
 from proto_tools.modal.hooks import (
+    PLUGINS_ENV,
     CallContext,
     apply_payload_hooks,
     clear_hooks,
+    load_plugins,
+    plugin_env,
+    plugin_modules,
     register_call_middleware,
     register_payload_hook,
     run_with_middleware,
@@ -274,3 +278,53 @@ def test_middleware_is_told_which_tool_it_wrapped() -> None:
 
     assert _CallContext(run_esm2_embeddings).tool_key == "esm2-embedding"
     assert _CallContext(lambda: None).tool_key is None, "an unregistered function resolves to nothing"
+
+
+# ── Plugin loading ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("", (), id="unset"),
+        pytest.param("pkg.one", ("pkg.one",), id="single"),
+        pytest.param("pkg.one,pkg.two", ("pkg.one", "pkg.two"), id="comma"),
+        pytest.param("pkg.one pkg.two", ("pkg.one", "pkg.two"), id="whitespace"),
+        pytest.param(" pkg.one , pkg.two ", ("pkg.one", "pkg.two"), id="padded"),
+    ],
+)
+def test_plugin_modules_parses_both_separators(raw: str, expected: tuple[str, ...]) -> None:
+    """A deployment naming several modules must not have to guess which separator is accepted."""
+    assert plugin_modules(raw) == expected
+
+
+def test_plugins_are_imported_once_per_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Registration is not idempotent, so importing twice would double every hook."""
+    import sys
+    import types
+
+    imported: list[str] = []
+    module = types.ModuleType("proto_tools_plugin_probe")
+    module.__dict__["_"] = imported.append("imported")
+    monkeypatch.setitem(sys.modules, "proto_tools_plugin_probe", module)
+    monkeypatch.setenv(PLUGINS_ENV, "proto_tools_plugin_probe")
+
+    assert load_plugins() == ("proto_tools_plugin_probe",)
+    assert load_plugins() == ("proto_tools_plugin_probe",), "the second call must be cached"
+    assert imported == ["imported"]
+
+
+def test_an_unimportable_plugin_fails_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Serving without a deployment's extensions silently drops whatever they were responsible for."""
+    monkeypatch.setenv(PLUGINS_ENV, "proto_tools_plugin_that_does_not_exist")
+    with pytest.raises(ModuleNotFoundError):
+        load_plugins()
+
+
+def test_plugin_env_reaches_the_container_only_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty variable baked into every image would be noise in each one's environment."""
+    monkeypatch.delenv(PLUGINS_ENV, raising=False)
+    assert plugin_env() == {}
+
+    monkeypatch.setenv(PLUGINS_ENV, "pkg.one")
+    assert plugin_env() == {PLUGINS_ENV: "pkg.one"}

--- a/tests/modal_tests/test_worker_hooks.py
+++ b/tests/modal_tests/test_worker_hooks.py
@@ -9,11 +9,11 @@ import pytest
 from proto_tools.modal.hooks import (
     PLUGINS_ENV,
     CallContext,
+    _plugin_modules,
     apply_payload_hooks,
     clear_hooks,
     load_plugins,
     plugin_env,
-    plugin_modules,
     register_call_middleware,
     register_payload_hook,
     run_with_middleware,
@@ -295,29 +295,42 @@ def test_middleware_is_told_which_tool_it_wrapped() -> None:
 )
 def test_plugin_modules_parses_both_separators(raw: str, expected: tuple[str, ...]) -> None:
     """A deployment naming several modules must not have to guess which separator is accepted."""
-    assert plugin_modules(raw) == expected
+    assert _plugin_modules(raw) == expected
 
 
-def test_plugins_are_imported_once_per_process(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Registration is not idempotent, so importing twice would double every hook."""
+def test_a_plugin_module_body_runs_and_registers(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """The point of the whole mechanism: importing the named module is what installs the hooks."""
     import sys
-    import types
 
-    imported: list[str] = []
-    module = types.ModuleType("proto_tools_plugin_probe")
-    module.__dict__["_"] = imported.append("imported")
-    monkeypatch.setitem(sys.modules, "proto_tools_plugin_probe", module)
-    monkeypatch.setenv(PLUGINS_ENV, "proto_tools_plugin_probe")
+    (tmp_path / "probe_plugin.py").write_text(
+        "from proto_tools.modal.hooks import register_call_middleware\n"
+        "register_call_middleware(lambda _ctx, nxt: {**nxt(), 'probed': True})\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "probe_plugin", raising=False)
+    monkeypatch.setenv(PLUGINS_ENV, "probe_plugin")
 
-    assert load_plugins() == ("proto_tools_plugin_probe",)
-    assert load_plugins() == ("proto_tools_plugin_probe",), "the second call must be cached"
-    assert imported == ["imported"]
+    assert load_plugins() == ("probe_plugin",)
+    assert run_with_middleware(_CTX, lambda: {"ok": True}) == {"ok": True, "probed": True}
 
 
-def test_an_unimportable_plugin_fails_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Serving without a deployment's extensions silently drops whatever they were responsible for."""
+def test_the_import_is_not_repeated_on_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This runs on the path of every served call, so it must not re-import per call."""
+    from proto_tools.modal import hooks
+
+    calls: list[str] = []
+    monkeypatch.setattr(hooks.importlib, "import_module", calls.append)
+    monkeypatch.setenv(PLUGINS_ENV, "pkg.one")
+
+    load_plugins()
+    load_plugins()
+    assert calls == ["pkg.one"], "import_module ran per call rather than once"
+
+
+def test_an_unimportable_plugin_names_the_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare ModuleNotFoundError leaves a reader no way to tell where the name came from."""
     monkeypatch.setenv(PLUGINS_ENV, "proto_tools_plugin_that_does_not_exist")
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(ImportError, match=PLUGINS_ENV):
         load_plugins()
 
 


### PR DESCRIPTION
The worker extension points added in #41 let whoever operates a deployment adapt or observe a call
without forking a service class. They had no way to reach a container, though: a deployed image
carries only what it was built with, and imports only what a service module reaches. Registering a
hook meant rebuilding the service definitions the extension points were meant to make unnecessary.

Three environment variables close that, all read where the deploy runs and all optional.

| Variable | Effect |
|---|---|
| `PROTO_MODAL_EXTRA_PACKAGES` | Requirements every service image installs. Whitespace-separated, since a specifier may contain a comma — so an environment marker cannot be expressed here. |
| `PROTO_MODAL_EXTRA_SOURCE` | Directories every service image carries, separated by `os.pathsep`. Each mounts under `/root` by its own name and imports as that name, so the name must be an identifier. |
| `PROTO_MODAL_WORKER_PLUGINS` | Modules a worker imports before serving its first call, which is where a deployment registers its hooks. |

```bash
PROTO_MODAL_EXTRA_PACKAGES="alpha>=1 beta" \
PROTO_MODAL_EXTRA_SOURCE=/path/to/extras \
PROTO_MODAL_WORKER_PLUGINS=extras.hooks \
proto-tools deploy --apps tmalign --env proto-env
```

## Where each applies, and why it matters

Packages and source are added by `with_proto_tools`, below proto-tools' own layers, so editing
proto-tools does not rebuild them.

The plugin list travels in `RUNTIME_ENV`, applied *above* the warmup. It is runtime metadata, and
putting it in an image layer below the warmup would mean renaming a module rebuilt and re-warmed
all 54 images — every toolkit's environment build, GPU included, for a change to a string.

Guard tests assert every service applies both. That is not hypothetical: `RUNTIME_ENV` was reaching
52 of 54 services, and on the other two the variable never arrived, so plugins loaded as none while
the deploy and its smoke test both reported success.

## Behaviour change worth noting

`tmalign_service.py` and `usalign_service.py` now apply `RUNTIME_ENV`, which they previously
omitted. Besides the plugin list this gives them `PROTO_CAPTURE_ERRORS=1`, so their tool failures
come back as `success=False` envelopes rather than raw container exceptions that `SERVICE_RETRIES`
replays four times. That matches the other 52 services. Happy to split it out if you would rather
keep this PR to the extension points alone.

## Failure behaviour

Both failure modes are surfaced rather than deferred, because a worker serving calls with a
deployment's extensions silently absent is worse than a loud failure:

- a module that cannot be imported raises an `ImportError` naming `PROTO_MODAL_WORKER_PLUGINS`.
  It runs outside the `PROTO_CAPTURE_ERRORS` envelope, so a bare `ModuleNotFoundError` would be
  replayed by `SERVICE_RETRIES` with nothing in it to say where the name came from;
- a directory that does not exist, or whose name nothing could import, fails in a deploy preflight
  rather than inside a subprocess whose output is filtered down to phase lines.

A mounted directory excludes `.git` and the usual build artefacts — a checkout is the obvious thing
to point this at, and git rewrites its index during ordinary work, which would change the layer
hash between two deploys of identical code. It deliberately does not exclude `tests`, which in
someone else's tree may be a package their code imports.

Nothing changes when the variables are unset, which is the default for every existing deploy.

## Verification

Deployed against Modal, not only unit-tested.

- With none of the variables set: `pyhmmer`, `foldseek`, and `tmalign` deployed with 8/8 smoke
  tests passing, unchanged from before.
- With all three set against a probe package that installs a dependency proto-tools does not have,
  sits outside the proto-tools tree, and registers a middleware tagging every result: the tag came
  back from a live call, so all three had to have worked. Re-verified after the `RUNTIME_ENV`
  rework, on `tmalign` and `usalign` together.

The live check is what caught the 52/54 gap. The unit tests passed and the smoke test passed while
the extension point was inert.

21 new tests. `ruff`, `mypy`, and the modal and style-consistency suites are green.
