### PR TITLE
Return unknown tool keys as recoverable results, and expose tool citations over MCP

### DIFF
--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -72,10 +72,17 @@ Large outputs, such as predicted structures and embeddings, are written to disk
 and returned as file paths rather than inline.
 """
 
+# Stated for every backend because a key is the one argument a caller has to invent, and
+# guessing a model name read from a paper is the most common way a call goes wrong.
+_KEY_CONVENTION = """Tool keys are `<model>-<action>`, such as `esmfold-prediction` or
+`esm2-embedding`. A model name on its own is not a key: several actions usually exist for
+one model. Use `search_tools` or `list_tools` to resolve a name into a key.
+"""
+
 INSTRUCTIONS = {
-    "modal": _MODAL_INSTRUCTIONS,
-    "proto": _PROTO_INSTRUCTIONS,
-    "local": _LOCAL_INSTRUCTIONS,
+    "modal": _MODAL_INSTRUCTIONS + "\n" + _KEY_CONVENTION,
+    "proto": _PROTO_INSTRUCTIONS + "\n" + _KEY_CONVENTION,
+    "local": _LOCAL_INSTRUCTIONS + "\n" + _KEY_CONVENTION,
 }
 
 
@@ -137,6 +144,14 @@ def build_server(device: Device = "modal") -> FastMCP:
         To actually run the example, call run_tool with use_example=True.
         """
         return impl.get_tool_example(tool_key)
+
+    @mcp.tool
+    def get_tool_citation(tool_key: str) -> dict[str, Any]:
+        """Get the BibTeX citation and DOI for the method a tool implements.
+
+        Use this when reporting results, so the underlying work is attributed.
+        """
+        return impl.get_tool_citation(tool_key)
 
     @mcp.tool
     def run_tool(

--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -304,11 +304,33 @@ def search_tools(query: str, deployed_only: bool = True, device: Device = "modal
     return [entry for _score, entry in scored]
 
 
+def _unknown_key(tool_key: str) -> dict[str, Any]:
+    """Describe an unresolvable tool key as a result the caller can act on.
+
+    Returned rather than raised: a raise becomes an MCP protocol error, which reads as
+    "this call is broken" instead of "try another argument". Guessing a key is the most
+    likely mistake an agent makes, because the key is the one thing it has to invent.
+    """
+    from proto_tools.tools import ToolRegistry
+
+    return {
+        "ok": False,
+        "error": f"no tool with key {tool_key!r}",
+        "did_you_mean": ToolRegistry.suggest_keys(tool_key),
+        "hint": (
+            "Tool keys are '<model>-<action>', for example 'esmfold-prediction'. Call search_tools() to find one."
+        ),
+    }
+
+
 def get_tool_schema(tool_key: str) -> dict[str, Any]:
     """Return the input, config and output JSON schemas for one tool."""
     from proto_tools.tools import ToolRegistry
 
-    spec = ToolRegistry.get(tool_key)
+    try:
+        spec = ToolRegistry.get(tool_key)
+    except (ValueError, KeyError):
+        return _unknown_key(tool_key)
     return {
         "tool": tool_key,
         "description": (spec.description or "").strip(),
@@ -345,8 +367,32 @@ def get_tool_example(tool_key: str) -> dict[str, Any] | None:
     """
     from proto_tools.tools import ToolRegistry
 
-    example = ToolRegistry.get_example_input(tool_key)
+    try:
+        example = ToolRegistry.get_example_input(tool_key)
+    except (ValueError, KeyError):
+        return _unknown_key(tool_key)
     return None if example is None else _elide(example.model_dump(mode="json"))
+
+
+def get_tool_citation(tool_key: str) -> dict[str, Any]:
+    """Return the BibTeX citation and DOI for the work a tool implements.
+
+    An agent that reports results is expected to attribute the method it used, and the
+    reference is already in the tool's ``cite.bib``. ``bibtex`` is ``None`` for the few
+    tools that register none.
+    """
+    from proto_tools.tools import ToolRegistry
+
+    try:
+        bibtex = ToolRegistry.get_citation(tool_key)
+    except (ValueError, KeyError):
+        return _unknown_key(tool_key)
+    return {
+        "tool": tool_key,
+        "bibtex": bibtex,
+        "doi": ToolRegistry.get_doi(tool_key),
+        "docs_url": ToolRegistry.get_docs_url(tool_key),
+    }
 
 
 def _spill_path(output_dir: Path, key_path: str, suffix: str) -> Path:
@@ -478,7 +524,10 @@ def run_tool(
     """
     from proto_tools.tools import ToolRegistry
 
-    spec = ToolRegistry.get(tool_key)
+    try:
+        spec = ToolRegistry.get(tool_key)
+    except (ValueError, KeyError):
+        return _unknown_key(tool_key)
     if use_example:
         example = ToolRegistry.get_example_input(tool_key)
         if example is None:

--- a/proto_tools/tools/tool_registry.py
+++ b/proto_tools/tools/tool_registry.py
@@ -1533,6 +1533,41 @@ class ToolRegistry:
         return list(cls._registry.values())
 
     @classmethod
+    def suggest_keys(cls, key: str, n: int = 5) -> list[str]:
+        """Return the registered keys a caller most likely meant by ``key``.
+
+        Keys are ``<model>-<action>``, and a wrong guess is usually the model alone, read
+        from a paper or a model card. Three strategies apply in turn, because whole-key
+        edit distance alone is unreliable here: it returns nothing for ``esm2`` or
+        ``boltz2``, and answers ``tmalign`` with the unrelated ``mafft-align``.
+
+        1. Prefix, which catches a model name given without an action. Exact model
+           segments rank ahead of incidental ones, keeping ``esmfold-*`` above
+           ``esmfold2-*``, a different model.
+        2. Fuzzy match on the model segment, which catches a misspelled model
+           (``esmfld``) that whole-key distance scores too poorly to return.
+        3. Fuzzy match on the whole key, which catches a misspelled action.
+
+        Args:
+            key (str): The key a caller supplied, which is not registered.
+            n (int): Most suggestions to return.
+
+        Returns:
+            list[str]: Candidate keys, best first, empty when nothing is close.
+        """
+        guess = key.lower()
+        keys = sorted(cls._registry)
+
+        prefix = [k for k in keys if k.startswith(guess)]
+        if prefix:
+            return sorted(prefix, key=lambda k: (k.split("-")[0] != guess, k))[:n]
+
+        models = sorted({k.split("-")[0] for k in keys})
+        near = difflib.get_close_matches(guess, models, n=2, cutoff=0.6)
+        by_model = [k for model in near for k in keys if k.split("-")[0] == model]
+        return by_model[:n] or difflib.get_close_matches(guess, keys, n=n, cutoff=0.6)
+
+    @classmethod
     def get(cls, key: str) -> ToolSpec:
         """Get tool spec by key.
 
@@ -1546,7 +1581,7 @@ class ToolRegistry:
             ValueError: If key not found in registry
         """
         if key not in cls._registry:
-            suggestions = difflib.get_close_matches(key, cls._registry.keys(), n=3, cutoff=0.6)
+            suggestions = cls.suggest_keys(key)
             hint = f"; did you mean: {', '.join(suggestions)}?" if suggestions else ""
             raise ValueError(f"Unknown tool {key!r} ({len(cls._registry)} registered){hint}")
         return cls._registry[key]

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -16,6 +16,7 @@ _READ_ONLY_SURFACE = {
     "search_tools",
     "get_tool_schema",
     "get_tool_example",
+    "get_tool_citation",
     "run_tool",
 }
 
@@ -45,6 +46,71 @@ def test_proto_exposes_no_deploy_tool():
 
     names = {t.name for t in asyncio.run(build_server("proto").list_tools())}
     assert "deploy_tool" not in names
+
+
+# ── Unknown tool keys ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", ["get_tool_schema", "get_tool_example", "run_tool"])
+def test_an_unknown_key_is_a_result_rather_than_a_protocol_error(verb: str):
+    """A raise reaches the agent as ToolError — "this call is broken" — and ends the attempt.
+
+    The key is the one argument an agent has to invent, so guessing it wrong has to be as
+    recoverable as passing bad arguments already is.
+    """
+    import fastmcp
+
+    from proto_tools.mcp import build_server
+
+    async def call():
+        async with fastmcp.Client(build_server("local")) as client:
+            return await client.call_tool(verb, {"tool_key": "esmfold"})
+
+    result = asyncio.run(call()).data
+    assert result["ok"] is False
+    assert "esmfold-prediction" in result["did_you_mean"]
+    assert "<model>-<action>" in result["hint"]
+
+
+def test_a_model_name_suggests_every_action_registered_for_it():
+    """Whole-key edit distance returns nothing for these, which is the reported failure."""
+    from proto_tools.tools import ToolRegistry
+
+    assert ToolRegistry.suggest_keys("esm2") == ["esm2-embedding", "esm2-gradient", "esm2-sample", "esm2-score"]
+    assert ToolRegistry.suggest_keys("boltz2") == ["boltz2-affinity", "boltz2-prediction"]
+    assert ToolRegistry.suggest_keys("tmalign") == ["tmalign-alignment"], "difflib answers this with mafft-align"
+
+
+def test_a_sibling_model_ranks_below_the_one_named():
+    """`esmfold2` is a different model, so it must not displace `esmfold`'s own actions."""
+    from proto_tools.tools import ToolRegistry
+
+    assert ToolRegistry.suggest_keys("esmfold")[-1] == "esmfold2-prediction"
+
+
+def test_a_misspelled_model_still_resolves():
+    """The fallback exists for typos; whole-key distance scores them too poorly to return."""
+    from proto_tools.tools import ToolRegistry
+
+    assert "esmfold-prediction" in ToolRegistry.suggest_keys("esmfld")
+    assert "esmfold-prediction" in ToolRegistry.suggest_keys("ESMFold"), "a name read from a paper is capitalised"
+
+
+def test_a_citation_is_reachable_for_the_tools_that_register_one():
+    """An agent reporting a result has to attribute the method, and 132 of 134 ship a cite.bib."""
+    from proto_tools.mcp import tools as impl
+
+    cite = impl.get_tool_citation("esmfold-prediction")
+    assert cite["doi"] == "10.1126/science.ade2574"
+    assert "@article" in cite["bibtex"]
+
+
+def test_the_raised_error_still_names_the_key_and_stays_a_ValueError():
+    """Callers outside the MCP — the CLI, the Python API — depend on both."""
+    from proto_tools.tools import ToolRegistry
+
+    with pytest.raises(ValueError, match="Unknown tool 'esm2'"):
+        ToolRegistry.get("esm2")
 
 
 def _unauthenticated(monkeypatch, config_path, **env):


### PR DESCRIPTION
## Problem

`ToolRegistry.get()` raises `ValueError` for an unregistered key, and none of the key-accepting
MCP tools caught it. fastmcp turned that into an MCP protocol error:

```
ToolError: Error calling tool 'get_tool_schema': Unknown tool 'esmfold' (134 registered); did you mean: esmfold-gradient?
```

A protocol error reads as "this call is broken" rather than "try another argument", so it ends the
attempt. That is inconsistent with the same function's handling of bad *arguments*, which already
returns a recoverable `{"ok": false, "error": ..., "hint": ...}`. A bad key is the more likely
mistake of the two: the key is the one thing an agent has to invent, since it reads "ESMFold" in a
paper, not `esmfold-prediction`.

Suggestion quality was the second, separable problem. `difflib` scores whole-key edit distance
against a `<model>-<action>` format, which it handles badly.

## Change

**Two problems, two layers.**

*Suggestion quality is not MCP-specific* — a CLI user typing `proto-tools docs esm2` got no
suggestion either. So `ToolRegistry.suggest_keys()` is new on the registry and feeds `get()`'s
existing hint, which fixes the CLI and every traceback at the same time. Three strategies apply in
turn:

1. **Prefix** — catches a model name given without an action. Exact model segments rank ahead of
   incidental ones, keeping `esmfold-*` above `esmfold2-*`, which is a different model.
2. **Fuzzy on the model segment** — catches a misspelled model (`esmfld`) that whole-key distance
   scores too poorly to return at all.
3. **Fuzzy on the whole key** — catches a misspelled action.

*Error shape is MCP-specific.* A raise is correct for the Python API, and the CLI already catches
`ValueError` and exits 2 with the message. So only `proto_tools/mcp/tools.py` changed to return
rather than raise, via a shared `_unknown_key()` helper wired into `get_tool_schema`,
`get_tool_example`, and `run_tool`.

`ToolRegistry.get()` still raises `ValueError` with the same `Unknown tool {key!r} ({n} registered)`
prefix. Only the hint tail changed, so the six existing assertions across five test files are
unaffected.

### Measured against the reported table

| guess | before | after |
|---|---|---|
| `esmfold` | `esmfold-gradient` (the wrong one) | `esmfold-gradient, esmfold-prediction, esmfold2-prediction` |
| `tmalign` | `mafft-align` (unrelated tool) | `tmalign-alignment` |
| `esm2` | *no suggestion* | all four `esm2-*` actions |
| `boltz2` | *no suggestion* | `boltz2-affinity, boltz2-prediction` |
| `esmc` | *no suggestion* | `esmc-embedding, esmc-sae-features` |
| `ESMFold` | raised, no suggestion | resolves — case-folded |
| `esmfld` | *no suggestion* | `esmfold-*` |

All nine now return a recoverable result through fastmcp; none raise.

## Also: tool citations over MCP

Folded in at the maintainer's request, and it shares the same `_unknown_key` path.

`ToolRegistry.get_citation` / `get_doi` were reachable from the CLI (`proto-tools citation`,
`proto-tools doi`) but not from the MCP at all — while **132 of 134 tools ship a `cite.bib`, 124
with a DOI**. New `get_tool_citation(tool_key)` returns `bibtex`, `doi`, and `docs_url`, so an
agent reporting a result can attribute the method it used. Verified across all 134 tools: nothing
raises, and the only two without a citation are `random-nucleotide-sample` and
`random-protein-sample`, which implement no published method.

## Instructions

The `<model>-<action>` convention is entirely learnable and was written down nowhere the agent
could see, which is the root cause of the guessing. It is now stated in the server instructions for
all three backends.

## Not in this PR

`deploy_tool` also takes a `tool_key`, but already catches `KeyError` from `_app_for` and returns
`{"ok": false, ...}` — it never had the protocol-error bug. Its message carries no suggestions,
which is a separate nicety.

## Tests

There were **no existing tests for MCP behavior on an unknown key**, which is how this shipped.
Added: the raise-to-return contract parametrized across all three verbs, the three model-name cases
that previously returned nothing, sibling-model ranking (`esmfold2` must not displace `esmfold`),
typo and capitalisation handling, a real DOI through the citation verb, and a guard that
`ToolRegistry.get` still raises `ValueError` naming the key — which the CLI and Python API depend
on.

521 tests pass across the MCP, registry, CLI, citation, shared-env, and license-consistency
suites, covering all six pre-existing `Unknown tool` assertions. ruff format and check clean.
