### PR TITLE
Let a deployment name further Modal secrets for every service

### DIFF
--- a/notes/modal-deployment.md
+++ b/notes/modal-deployment.md
@@ -281,6 +281,13 @@ deployment's extensions silently absent is worse than a loud failure:
 - a directory that does not exist, or whose name nothing could import, fails the deploy up front
   rather than inside a subprocess whose output is filtered to phase lines.
 
+Extension code that reaches a credentialed service needs credentials in the container.
+`PROTO_MODAL_SECRETS` names further Modal secrets, attached to the app rather than to each service
+class — Modal gives a function its app's secrets in addition to its own, so a service declaring
+secrets of its own keeps them. The HuggingFace secret is the default member of that list and needs
+no entry; naming others adds to it rather than replacing it, so gated weight downloads keep
+working. A name that does not exist in the workspace fails the deploy.
+
 A mounted directory excludes `.git` and the usual build artefacts. It does *not* exclude `tests`,
 which in someone else's tree may be a package their code imports. Note that `/root` precedes
 site-packages, so a directory sharing a name with an installed package shadows it.
@@ -346,7 +353,7 @@ agent's first orienting call, so the two surfaces differ on purpose.
 
 ## Configuration
 
-Eight environment variables, all optional, read in the environment a deploy runs from.
+Nine environment variables, all optional, read in the environment a deploy runs from.
 
 | Variable | Default | Effect |
 |---|---|---|
@@ -358,6 +365,7 @@ Eight environment variables, all optional, read in the environment a deploy runs
 | `PROTO_MODAL_EXTRA_PACKAGES` | unset | Requirements every service image installs. |
 | `PROTO_MODAL_EXTRA_SOURCE` | unset | Directories every service image carries, importable by their own names. |
 | `PROTO_MODAL_WORKER_PLUGINS` | unset | Modules a worker imports before serving its first call. Also re-read inside the container, which is where the import happens. |
+| `PROTO_MODAL_SECRETS` | unset | Names of further Modal secrets every service receives, alongside the HuggingFace one. |
 
 ### Container wall tiers
 

--- a/proto_tools/modal/app.py
+++ b/proto_tools/modal/app.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 import os
+import re
 
 import modal
 
@@ -45,6 +46,30 @@ def _hf_token_secret() -> modal.Secret:
 
 
 HF_TOKEN_SECRET = _hf_token_secret()
+
+# Additional Modal secrets attached to every service, by name, separated by commas or whitespace.
+# A deployment whose workers reach a private registry, an object store, or any other credentialed
+# service names those secrets here rather than editing each service.
+#
+#     PROTO_MODAL_SECRETS=my-object-store,my-registry proto-tools deploy --apps esm2
+#
+# Names are resolved in the workspace being deployed into; one that does not exist there fails the
+# deploy. The HuggingFace secret is the default member of this list and needs no entry.
+EXTRA_SECRETS_ENV = "PROTO_MODAL_SECRETS"
+
+
+def service_secrets() -> list[modal.Secret]:
+    """Return the secrets every service in every app receives.
+
+    Attached to the app rather than to each service class, since Modal gives a function its app's
+    secrets in addition to its own. A service listing further secrets keeps them.
+
+    Returns:
+        list[modal.Secret]: The HuggingFace secret, then each name in :data:`EXTRA_SECRETS_ENV`.
+    """
+    named = [name for name in re.split(r"[,\s]+", os.getenv(EXTRA_SECRETS_ENV, "")) if name]
+    return [HF_TOKEN_SECRET, *(modal.Secret.from_name(name) for name in named)]
+
 
 # The Modal environment proto-tools deploys into and dispatches to, unless told otherwise.
 #
@@ -117,8 +142,8 @@ SCALEDOWN_WINDOW = int(os.getenv("PROTO_MODAL_SCALEDOWN_WINDOW", "30"))
 
 @functools.cache
 def get_app(name: str) -> modal.App:
-    """Return the memoized ``modal.App`` for ``name``."""
-    return modal.App(name)
+    """Return the memoized ``modal.App`` for ``name``, carrying the secrets every service needs."""
+    return modal.App(name, secrets=service_secrets())
 
 
 def get_app_for_service(service_class_name: str) -> modal.App:
@@ -128,6 +153,7 @@ def get_app_for_service(service_class_name: str) -> modal.App:
 
 __all__ = [
     "CACHE_VOLUME_NAME",
+    "EXTRA_SECRETS_ENV",
     "HF_TOKEN_SECRET",
     "MODEL_CACHE",
     "NO_RETRIES",
@@ -135,4 +161,5 @@ __all__ = [
     "get_app",
     "get_app_for_service",
     "retries_for_service",
+    "service_secrets",
 ]

--- a/proto_tools/modal/app.py
+++ b/proto_tools/modal/app.py
@@ -71,6 +71,20 @@ def service_secrets() -> list[modal.Secret]:
     return [HF_TOKEN_SECRET, *(modal.Secret.from_name(name) for name in named)]
 
 
+def secrets_env() -> dict[str, str]:
+    """Return :data:`EXTRA_SECRETS_ENV` as image env, or empty when unset.
+
+    A container re-imports the service module, so :func:`service_secrets` runs there too. Without
+    the variable it would build a shorter list than the deploy did, and Modal refuses to start a
+    container whose dependency count disagrees with what the deploy registered.
+
+    Returns:
+        dict[str, str]: Mapping to merge into a service image's runtime environment.
+    """
+    raw = os.getenv(EXTRA_SECRETS_ENV)
+    return {EXTRA_SECRETS_ENV: raw} if raw else {}
+
+
 # The Modal environment proto-tools deploys into and dispatches to, unless told otherwise.
 #
 # Naming one matters more than which name it is. Without it, both sides fall back to whatever

--- a/proto_tools/modal/utils.py
+++ b/proto_tools/modal/utils.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import modal
 
+from proto_tools.modal.app import secrets_env
 from proto_tools.modal.hooks import CallContext, apply_payload_hooks, load_plugins, plugin_env, run_with_middleware
 from proto_tools.modal.progress import container_progress
 from proto_tools.utils.base_config import BaseConfig
@@ -179,7 +180,11 @@ def env_for() -> dict[str, str]:
 #
 # The plugin list belongs here rather than in an image layer below the warmup: it is runtime
 # metadata, and renaming a module would otherwise rebuild and re-warm every service.
-RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1", **plugin_env()}
+#
+# The secret names travel with it because a container re-imports the service module and rebuilds
+# the app. Absent, it would name fewer secrets there than the deploy did, and Modal rejects a
+# container whose dependency count disagrees with the deployed function's.
+RUNTIME_ENV: dict[str, str] = {"PROTO_CAPTURE_ERRORS": "1", **plugin_env(), **secrets_env()}
 
 
 # Don't add ``examples`` — :func:`stage_all_excluded_fixtures` reads

--- a/tests/modal_tests/test_service_secrets.py
+++ b/tests/modal_tests/test_service_secrets.py
@@ -51,3 +51,28 @@ def test_every_app_carries_the_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
         assert len(app._local_state.secrets_default) == 2, "an app must carry the default secrets"
     finally:
         get_app.cache_clear()
+
+
+def test_the_secret_names_travel_into_the_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A container rebuilds the app, so it must name the same secrets the deploy did.
+
+    Modal refuses to start a container whose dependency count disagrees with the deployed
+    function's, and the failure is a container that dies on startup while the caller's call
+    hangs through every retry.
+    """
+    import importlib
+
+    from proto_tools.modal import app as app_module
+
+    monkeypatch.setenv(EXTRA_SECRETS_ENV, "one,two")
+    assert app_module.secrets_env() == {EXTRA_SECRETS_ENV: "one,two"}
+
+    utils = importlib.reload(importlib.import_module("proto_tools.modal.utils"))
+    assert utils.RUNTIME_ENV[EXTRA_SECRETS_ENV] == "one,two", "the image must carry the secret names"
+
+
+def test_no_secret_names_add_nothing_to_the_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty variable baked into every image would be noise in each one's environment."""
+    from proto_tools.modal.app import secrets_env
+
+    assert secrets_env() == {}

--- a/tests/modal_tests/test_service_secrets.py
+++ b/tests/modal_tests/test_service_secrets.py
@@ -1,0 +1,53 @@
+"""Secrets every service receives, and the variable that adds to them."""
+
+from __future__ import annotations
+
+import pytest
+
+from proto_tools.modal.app import EXTRA_SECRETS_ENV, HF_TOKEN_SECRET, service_secrets
+
+
+@pytest.fixture(autouse=True)
+def _clear_extra_secrets(monkeypatch: pytest.MonkeyPatch):
+    """A developer with the variable exported would otherwise fail the default-only assertions."""
+    monkeypatch.delenv(EXTRA_SECRETS_ENV, raising=False)
+
+
+def test_the_default_is_the_huggingface_secret_alone() -> None:
+    """Every deployment gets weight downloads without naming anything."""
+    assert service_secrets() == [HF_TOKEN_SECRET]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("one,two", id="comma"),
+        pytest.param("one two", id="whitespace"),
+        pytest.param(" one , two ", id="padded"),
+    ],
+)
+def test_named_secrets_are_added_not_substituted(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    """Replacing the default would silently drop the token gated weight downloads need."""
+    monkeypatch.setenv(EXTRA_SECRETS_ENV, raw)
+    secrets = service_secrets()
+    assert secrets[0] is HF_TOKEN_SECRET
+    assert len(secrets) == 3
+
+
+def test_an_empty_value_adds_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unset variable and one set to empty must behave the same, not add a nameless secret."""
+    monkeypatch.setenv(EXTRA_SECRETS_ENV, "  ")
+    assert service_secrets() == [HF_TOKEN_SECRET]
+
+
+def test_every_app_carries_the_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attached to the app so a service needs no entry of its own; Modal adds them to each function."""
+    from proto_tools.modal.app import get_app
+
+    get_app.cache_clear()
+    monkeypatch.setenv(EXTRA_SECRETS_ENV, "probe-secret")
+    try:
+        app = get_app("proto-tools-secret-probe")
+        assert len(app._local_state.secrets_default) == 2, "an app must carry the default secrets"
+    finally:
+        get_app.cache_clear()


### PR DESCRIPTION
Extension code delivered by #43 can reach a credentialed service — an object store, a private
registry, a metrics endpoint — but a worker has no way to hold those credentials. Every service
attaches exactly one secret, the HuggingFace one, and nothing names another.

`PROTO_MODAL_SECRETS` names further Modal secrets, comma- or whitespace-separated, read where the
deploy runs:

```bash
PROTO_MODAL_SECRETS=my-object-store,my-registry proto-tools deploy --apps tmalign --env proto-env
```

The HuggingFace secret is the default member of that list rather than a special case, so naming
others adds to it. Substituting would silently drop the token gated weight downloads need; a test
asserts the default survives.

## Where they attach

On the app, not on each service class: Modal gives a function its app's secrets in addition to its
own (`secrets = [*local_state.secrets_default, *secrets]`), so a service declaring secrets of its
own keeps them and no service file changes.

The names also travel into the image, alongside the plugin list in `RUNTIME_ENV`. That part is not
cosmetic. A container re-imports the service module and rebuilds the app, so `service_secrets()`
runs there too. Without the variable it names fewer secrets than the deploy registered, and Modal
refuses to hydrate the function:

```
ExecutionError: Function has 3 dependencies but container got 4 object ids.
```

The visible symptom is not an error but a hang: every container dies on startup, Modal retries, and
the caller's `.remote()` blocks. I hit exactly this before adding it — a deploy and its smoke test
both reported success while the tool never returned. A regression test covers it.

A name that does not exist in the workspace fails the deploy.

## Verification

Deployed against Modal, not only unit-tested. With `PROTO_MODAL_SECRETS` naming a secret holding a
known value, and a plugin reporting that variable back from inside the container, a live call
returned the value — so the secret genuinely arrived. The same app then deployed and smoke-tested
clean with the variable unset.

8 new tests. `ruff`, `mypy`, and the modal and style-consistency suites are green.
