### PR TITLE
Cap search_tools results and return the score they ranked on

### DIFF
--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -135,13 +135,15 @@ def build_server(device: Device = "modal") -> FastMCP:
         return impl.list_tools(deployed_only=deployed_only, category=category, device=device)
 
     @mcp.tool
-    def search_tools(query: str, deployed_only: bool = True) -> list[dict[str, Any]]:
-        """Find tools by keyword, matching the tool key and its description.
+    def search_tools(query: str, deployed_only: bool = True, limit: int = 10) -> dict[str, Any]:
+        """Find tools by keyword, matching the tool key, category and summary.
 
         Useful for questions like "what can fold a protein" or "which tools
-        score sequences".
+        score sequences". Returns the best `limit` matches under `hits`, each
+        with the `score` it ranked on, plus `n_total` for how many matched in
+        all — raise `limit` only if the total says it is worth it.
         """
-        return impl.search_tools(query, deployed_only=deployed_only, device=device)
+        return impl.search_tools(query, deployed_only=deployed_only, limit=limit, device=device)
 
     @mcp.tool
     def get_tool_schema(tool_key: str) -> dict[str, Any]:

--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -300,30 +300,63 @@ def _matches(term: str, haystack: str) -> bool:
     return term in haystack or _stem(term) in haystack
 
 
-def search_tools(query: str, deployed_only: bool = True, device: Device = "modal") -> list[dict[str, Any]]:
-    """Find tools by keyword, ranked by how many query terms match.
+# Where a term matched, strongest first. A tool named for what you asked for is a better
+# answer than one that merely mentions it.
+_KEY_SCORE, _CATEGORY_SCORE, _SUMMARY_SCORE = 3, 2, 1
+
+
+def _field_score(term: str, key: str, category: str, summary: str) -> int:
+    """Score one term against one tool, by the strongest field it matches."""
+    if _matches(term, key):
+        return _KEY_SCORE
+    if _matches(term, category):
+        return _CATEGORY_SCORE
+    if _matches(term, summary):
+        return _SUMMARY_SCORE
+    return 0
+
+
+def _no_match_hint() -> str:
+    """Say what to do next, so an empty result does not read as "no such capability"."""
+    from proto_tools.tools import ToolRegistry
+
+    categories = ", ".join(sorted({spec.category for spec in ToolRegistry.list_all()}))
+    return f"Nothing matched. Browse instead with list_tools(category=...); the categories are: {categories}."
+
+
+def search_tools(query: str, deployed_only: bool = True, limit: int = 10, device: Device = "modal") -> dict[str, Any]:
+    """Find tools by keyword, best match first.
 
     Matches per term rather than on the whole string: agents ask in natural
     language ("compare two protein structures"), and a literal substring
     search returns nothing for those, which reads as "no such tool exists"
     rather than "rephrase".
+
+    Returns the top ``limit`` under ``hits``, each carrying the ``score`` it ranked on, with
+    ``n_total`` for how many matched in all. Broad queries match half the catalogue, and an
+    agent that cannot tell first place from fiftieth pays for the whole list to find out.
     """
     terms = [t for t in query.lower().split() if t not in _STOPWORDS and len(t) > 1]
-    terms = [_SYNONYMS.get(t, t) for t in terms]
-    if not terms:
-        return []
+    # Both the term and its expansion are scored: rewriting "fold" to "structure" otherwise
+    # discards the literal token that matches esmfold and foldseek in a key.
+    forms = [{t, _SYNONYMS.get(t, t)} for t in terms]
+    if not forms:
+        return {"hits": [], "n_total": 0, "hint": _no_match_hint()}
 
     scored = []
     for entry in list_tools(deployed_only=deployed_only, device=device):
-        key = entry["tool"]
-        haystack = f"{key} {entry.get('summary') or ''}".lower()
-        # A term in the tool key is a stronger signal than one buried in prose.
-        score = sum(2 if _matches(t, key.lower()) else 1 for t in terms if _matches(t, haystack))
+        key, category = entry["tool"].lower(), (entry.get("category") or "").lower()
+        summary = (entry.get("summary") or "").lower()
+        score = sum(max(_field_score(t, key, category, summary) for t in form) for form in forms)
         if score:
             scored.append((score, entry))
 
-    scored.sort(key=lambda pair: -pair[0])
-    return [entry for _score, entry in scored]
+    # Key order after score, so a tie ranks the same way twice rather than by registry order.
+    scored.sort(key=lambda pair: (-pair[0], pair[1]["tool"]))
+    found = {"hits": [{**entry, "score": score} for score, entry in scored[:limit]], "n_total": len(scored)}
+    if not scored:
+        found["hint"] = _no_match_hint()
+    return found
 
 
 def _unknown_key(tool_key: str) -> dict[str, Any]:

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -326,8 +326,39 @@ def test_search_matches_natural_language_queries(monkeypatch):
     # setattr, not assign-then-del: deleting removes the real function for the rest of the
     # session rather than restoring it, and every later test calling it then fails.
     monkeypatch.setattr(impl, "list_tools", lambda **_kwargs: catalogue)
-    hits = impl.search_tools("compare two protein structures")
-    assert [h["tool"] for h in hits][:1] == ["tmalign-alignment"], hits
+    found = impl.search_tools("compare two protein structures")
+    assert [h["tool"] for h in found["hits"]][:1] == ["tmalign-alignment"], found
+
+
+def test_search_is_capped_and_says_how_many_it_left_out():
+    """Broad queries match half the catalogue; the agent should not pay for it to find that out."""
+    from proto_tools.mcp import tools as impl
+
+    found = impl.search_tools("compare two protein structures", deployed_only=False, limit=5, device="local")
+
+    assert len(found["hits"]) == 5
+    assert found["n_total"] > 5, "the total is what tells a caller whether raising the limit is worth it"
+    assert found["hits"][0]["score"] >= found["hits"][-1]["score"], "hits are ordered by the score they carry"
+
+
+def test_search_ranks_a_tool_named_for_the_query_above_one_that_merely_mentions_it():
+    """Rewriting "fold" to "structure" used to discard the token that matches esmfold in the key."""
+    from proto_tools.mcp import tools as impl
+
+    hits = impl.search_tools("fold a protein", deployed_only=False, limit=133, device="local")["hits"]
+    ranked = [h["tool"] for h in hits]
+
+    assert ranked.index("esmfold-prediction") < ranked.index("esm-if1-sample"), "inverse folding is the opposite"
+
+
+def test_a_query_that_matches_nothing_says_what_to_do_instead():
+    """An empty list reads as "no such capability exists" rather than "rephrase"."""
+    from proto_tools.mcp import tools as impl
+
+    found = impl.search_tools("crystallography", deployed_only=False, device="local")
+
+    assert found["hits"] == [] and found["n_total"] == 0
+    assert "list_tools(category=" in found["hint"] and "structure_prediction" in found["hint"]
 
 
 def test_example_elides_bulky_values():


### PR DESCRIPTION
> Previously stacked on #46, now merged. Rebased onto `main`, dropping the duplicated
> commit; the `category` weighting below relies on the `category` and `summary` fields #46 added.

## Problem

Recall was already good — 9 of 10 agent-phrased queries put the expected tool in the top 3 — but the
result *sets* were unusable. No `limit`, and the score used for ranking was discarded before
returning, so an agent saw a flat array of 75 tools with no way to tell first place from seventieth.

Three queries cost more than the entire MCP server surface.

**#46 made this worse.** `compare two protein structures` cost 2,865 tokens when the issue was
filed; on the base branch it costs ~4,384, because entries now carry `category`, `summary` and
`uses_gpu`. Trading schema fetches for richer listings raised the price of an unbounded search by
about half, so the cap matters more than it did.

## Change

| query | before | after | n_total |
|---|---|---|---|
| `compare two protein structures` | 4,384 | **650** | 84 |
| `fold a protein` | 4,183 | **619** | 79 |
| `protein language model embeddings` | 3,618 | **449** | 67 |
| `multiple sequence alignment` | 3,322 | **751** | 84 |
| `secondary structure` | 2,018 | **577** | 45 |
| `crystallography` | 0, bare `[]` | **104**, with a hint | 0 |

- **`limit: int = 10`, and the score is returned.** `search_tools` now returns
  `{"hits": [...], "n_total": N}`, each hit carrying the `score` it ranked on. `n_total` is what
  tells a caller whether raising the limit is worth paying for.
- **Both the term and its expansion are scored.** Rewriting `fold` to `structure` discarded the
  literal token that matches `esmfold` and `foldseek` in a key.
- **`category` is scored,** between key and summary. Measured against 7 queries with a known
  expected tool, this is the single biggest ranking win:

  | | correct top-1 |
  |---|---|
  | no category weighting | 4/7 |
  | category weight 1 | 5/7 |
  | **category weight 2** | **6/7** |

- **An empty result says what to do instead**, naming the categories to browse, rather than
  returning `[]` — which reads as "no such capability exists" rather than "rephrase".
- **Ties break on the key**, so the same query ranks the same way twice instead of falling back to
  registry order.

## The one ranking failure is improved but not fixed

`fold a protein` moves `esmfold-prediction` from **10th to 7th**, and it still ranks below
`proteinmpnn`. I am not claiming this fixed.

The cause is worth recording. `proteinmpnn`'s category is literally `inverse_folding`, so the query
term `fold` matches the category of the tool that does the opposite thing:

```
proteinmpnn-gradient   'protein' in key (3) + 'fold' in category inverse_folding (2) = 5
esmfold-prediction     'fold' in key (3)    + 'protein' in summary (1)               = 4
```

Substring matching cannot separate "folding" from "inverse folding". I tried IDF weighting so that
`fold` would outweigh the near-vacuous `protein`; it backfires, because `fold` is a substring of
*alphafold*, *foldseek*, *foldmason* and *folding*, so it is not rare.

What genuinely mitigates it is #46: every hit now carries a `summary`, so an agent sees "Protein
structure prediction using ESMFold" beside ProteinMPNN's inverse-folding line and can tell them
apart — which it could not when this issue was filed. Fixing the rank properly needs tokenised
matching rather than substrings, which is a larger change than this.

## Proposal not taken: the relevance floor

The issue suggested requiring a minimum fraction of query terms to match. Once `limit` exists that
work is already done, and the floor costs real recall — a floor requiring every term took
`protein language model embeddings` from 64 hits to **zero**. `limit` plus visible scores solves the
size problem without that risk.

`two` remains a stopword. The issue notes it as an observation rather than a bug, and ranking gets
`compare two protein structures` right today.

## Tests

- Results are capped, and `n_total` reports what was left out.
- A tool named for the query outranks one that merely mentions it.
- A query matching nothing returns a hint naming the categories.
- The existing natural-language regression test, updated for the new return shape.

4,124 tests pass across the MCP, CLI, registry and docstring-style suites. ruff format and check
clean.

