### PR TITLE
Say that structure inputs accept a file path or URL

### DIFF
--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -186,6 +186,11 @@ def build_server(device: Device = "modal") -> FastMCP:
         model load, and a few tools (binder design, diffusion) legitimately run
         for many minutes. Check the tool description before calling.
 
+        Structure inputs take a file path or an http(s) URL in place of inlined
+        content — {"query_structure": "/path/to/file.pdb"} — so a file already on
+        disk, such as another tool's output, never has to be read into the call.
+        Other bulky inputs, such as MSAs, take their content rather than a path.
+
         Pass use_example=True to run the tool's canonical example input without
         supplying it — useful for structure tools whose inputs are very large.
 

--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -135,13 +135,15 @@ def build_server(device: Device = "modal") -> FastMCP:
         return impl.list_tools(deployed_only=deployed_only, category=category, device=device)
 
     @mcp.tool
-    def search_tools(query: str, deployed_only: bool = True) -> list[dict[str, Any]]:
-        """Find tools by keyword, matching the tool key and its description.
+    def search_tools(query: str, deployed_only: bool = True, limit: int = 10) -> dict[str, Any]:
+        """Find tools by keyword, matching the tool key, category and summary.
 
         Useful for questions like "what can fold a protein" or "which tools
-        score sequences".
+        score sequences". Returns the best `limit` matches under `hits`, each
+        with the `score` it ranked on, plus `n_total` for how many matched in
+        all — raise `limit` only if the total says it is worth it.
         """
-        return impl.search_tools(query, deployed_only=deployed_only, device=device)
+        return impl.search_tools(query, deployed_only=deployed_only, limit=limit, device=device)
 
     @mcp.tool
     def get_tool_schema(tool_key: str) -> dict[str, Any]:

--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -300,30 +300,63 @@ def _matches(term: str, haystack: str) -> bool:
     return term in haystack or _stem(term) in haystack
 
 
-def search_tools(query: str, deployed_only: bool = True, device: Device = "modal") -> list[dict[str, Any]]:
-    """Find tools by keyword, ranked by how many query terms match.
+# Where a term matched, strongest first. A tool named for what you asked for is a better
+# answer than one that merely mentions it.
+_KEY_SCORE, _CATEGORY_SCORE, _SUMMARY_SCORE = 3, 2, 1
+
+
+def _field_score(term: str, key: str, category: str, summary: str) -> int:
+    """Score one term against one tool, by the strongest field it matches."""
+    if _matches(term, key):
+        return _KEY_SCORE
+    if _matches(term, category):
+        return _CATEGORY_SCORE
+    if _matches(term, summary):
+        return _SUMMARY_SCORE
+    return 0
+
+
+def _no_match_hint() -> str:
+    """Say what to do next, so an empty result does not read as "no such capability"."""
+    from proto_tools.tools import ToolRegistry
+
+    categories = ", ".join(sorted({spec.category for spec in ToolRegistry.list_all()}))
+    return f"Nothing matched. Browse instead with list_tools(category=...); the categories are: {categories}."
+
+
+def search_tools(query: str, deployed_only: bool = True, limit: int = 10, device: Device = "modal") -> dict[str, Any]:
+    """Find tools by keyword, best match first.
 
     Matches per term rather than on the whole string: agents ask in natural
     language ("compare two protein structures"), and a literal substring
     search returns nothing for those, which reads as "no such tool exists"
     rather than "rephrase".
+
+    Returns the top ``limit`` under ``hits``, each carrying the ``score`` it ranked on, with
+    ``n_total`` for how many matched in all. Broad queries match half the catalogue, and an
+    agent that cannot tell first place from fiftieth pays for the whole list to find out.
     """
     terms = [t for t in query.lower().split() if t not in _STOPWORDS and len(t) > 1]
-    terms = [_SYNONYMS.get(t, t) for t in terms]
-    if not terms:
-        return []
+    # Both the term and its expansion are scored: rewriting "fold" to "structure" otherwise
+    # discards the literal token that matches esmfold and foldseek in a key.
+    forms = [{t, _SYNONYMS.get(t, t)} for t in terms]
+    if not forms:
+        return {"hits": [], "n_total": 0, "hint": _no_match_hint()}
 
     scored = []
     for entry in list_tools(deployed_only=deployed_only, device=device):
-        key = entry["tool"]
-        haystack = f"{key} {entry.get('summary') or ''}".lower()
-        # A term in the tool key is a stronger signal than one buried in prose.
-        score = sum(2 if _matches(t, key.lower()) else 1 for t in terms if _matches(t, haystack))
+        key, category = entry["tool"].lower(), (entry.get("category") or "").lower()
+        summary = (entry.get("summary") or "").lower()
+        score = sum(max(_field_score(t, key, category, summary) for t in form) for form in forms)
         if score:
             scored.append((score, entry))
 
-    scored.sort(key=lambda pair: -pair[0])
-    return [entry for _score, entry in scored]
+    # Key order after score, so a tie ranks the same way twice rather than by registry order.
+    scored.sort(key=lambda pair: (-pair[0], pair[1]["tool"]))
+    found = {"hits": [{**entry, "score": score} for score, entry in scored[:limit]], "n_total": len(scored)}
+    if not scored:
+        found["hint"] = _no_match_hint()
+    return found
 
 
 def _unknown_key(tool_key: str) -> dict[str, Any]:

--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -395,20 +395,30 @@ def get_tool_schema(tool_key: str) -> dict[str, Any]:
     }
 
 
-def _elide(value: Any) -> Any:
+def _elide(value: Any, key: str = "") -> Any:
     """Replace bulky leaves with a description of what they hold.
 
     An example exists to show *shape*. Structure tools carry entire PDB files
     in theirs — tens of thousands of characters that tell a caller nothing it
     could not infer from a placeholder, and that overflow a context window.
+
+    Elided structure content says a path is accepted, because the placeholder otherwise reads
+    as "inline this much text to call me", and an agent either does that or gives up on the
+    tool. ``key`` carries the field the value sat under, so only the fields that really take a
+    path say so.
     """
     if isinstance(value, dict):
-        return {k: _elide(v) for k, v in value.items()}
+        return {k: _elide(v, k) for k, v in value.items()}
     if isinstance(value, list):
         if len(value) > 3:
-            return [_elide(v) for v in value[:3]] + [f"<… {len(value) - 3} more items>"]
-        return [_elide(v) for v in value]
+            return [_elide(v, key) for v in value[:3]] + [f"<… {len(value) - 3} more items>"]
+        return [_elide(v, key) for v in value]
     if isinstance(value, str) and len(value) > 200:
+        if key == "structure":
+            return (
+                f"<{len(value):,} characters elided — a file path or http(s) URL is accepted "
+                f"instead, here or in place of the whole field, e.g. '/path/to/structure.pdb'>"
+            )
         return f"<{len(value):,} characters elided — see run_tool(use_example=True)>"
     return value
 
@@ -576,6 +586,10 @@ def run_tool(
 
     ``use_example=True`` runs the tool's canonical example input, so a caller
     can exercise a tool without materialising inputs that may be very large.
+
+    A structure input takes a file path or an http(s) URL where the schema shows an object,
+    so chaining one tool's output file into the next never reads it into the call. This is not
+    uniform across bulky inputs: an MSA takes its content, and a path is rejected.
     """
     from proto_tools.tools import ToolRegistry
 

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -7,8 +7,10 @@ smoke tests, not here.
 import asyncio
 import json
 import os
+from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 _READ_ONLY_SURFACE = {
     "workspace_info",
@@ -368,7 +370,33 @@ def test_example_elides_bulky_values():
     elided = impl._elide({"structure": {"structure": "X" * 90_000, "structure_format": "pdb"}})
     inner = elided["structure"]
     assert inner["structure_format"] == "pdb", "small fields must survive"
-    assert "elided" in inner["structure"] and len(inner["structure"]) < 200
+    assert "elided" in inner["structure"] and len(inner["structure"]) < 250
+
+
+def test_elided_structure_content_says_a_path_is_accepted():
+    """The placeholder otherwise reads as "inline 42,000 characters to call me"."""
+    from proto_tools.mcp import tools as impl
+
+    elided = impl._elide({"query_structure": {"structure": "X" * 90_000, "structure_format": "pdb"}})
+    assert "file path" in elided["query_structure"]["structure"]
+
+    # Only where it is true: an MSA takes its content, so the generic placeholder stands.
+    other = impl._elide({"aligned_sequences": "X" * 90_000})
+    assert "file path" not in other["aligned_sequences"]
+
+
+def test_a_structure_input_really_does_accept_a_path_and_an_msa_does_not():
+    """Guards the asymmetry the docstrings now promise, which is worse to state wrongly than not at all."""
+    from proto_tools.entities.msa import MSA
+    from proto_tools.tools import ToolRegistry
+
+    fixture = Path(__file__).resolve().parents[2] / "proto_tools/tools/structure_alignment/example_input_fixture.pdb"
+    spec = ToolRegistry.get("tmalign-alignment")
+    loaded = spec.input_model(query_structure=str(fixture), reference_structure=str(fixture))
+    assert loaded.query_structure.source == str(fixture), "the path is recorded, and its content loaded"
+
+    with pytest.raises(ValidationError):
+        MSA.model_validate(str(fixture))
 
 
 def test_run_tool_requires_inputs_or_use_example():

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -326,8 +326,39 @@ def test_search_matches_natural_language_queries(monkeypatch):
     # setattr, not assign-then-del: deleting removes the real function for the rest of the
     # session rather than restoring it, and every later test calling it then fails.
     monkeypatch.setattr(impl, "list_tools", lambda **_kwargs: catalogue)
-    hits = impl.search_tools("compare two protein structures")
-    assert [h["tool"] for h in hits][:1] == ["tmalign-alignment"], hits
+    found = impl.search_tools("compare two protein structures")
+    assert [h["tool"] for h in found["hits"]][:1] == ["tmalign-alignment"], found
+
+
+def test_search_is_capped_and_says_how_many_it_left_out():
+    """Broad queries match half the catalogue; the agent should not pay for it to find that out."""
+    from proto_tools.mcp import tools as impl
+
+    found = impl.search_tools("compare two protein structures", deployed_only=False, limit=5, device="local")
+
+    assert len(found["hits"]) == 5
+    assert found["n_total"] > 5, "the total is what tells a caller whether raising the limit is worth it"
+    assert found["hits"][0]["score"] >= found["hits"][-1]["score"], "hits are ordered by the score they carry"
+
+
+def test_search_ranks_a_tool_named_for_the_query_above_one_that_merely_mentions_it():
+    """Rewriting "fold" to "structure" used to discard the token that matches esmfold in the key."""
+    from proto_tools.mcp import tools as impl
+
+    hits = impl.search_tools("fold a protein", deployed_only=False, limit=133, device="local")["hits"]
+    ranked = [h["tool"] for h in hits]
+
+    assert ranked.index("esmfold-prediction") < ranked.index("esm-if1-sample"), "inverse folding is the opposite"
+
+
+def test_a_query_that_matches_nothing_says_what_to_do_instead():
+    """An empty list reads as "no such capability exists" rather than "rephrase"."""
+    from proto_tools.mcp import tools as impl
+
+    found = impl.search_tools("crystallography", deployed_only=False, device="local")
+
+    assert found["hits"] == [] and found["n_total"] == 0
+    assert "list_tools(category=" in found["hint"] and "structure_prediction" in found["hint"]
 
 
 def test_example_elides_bulky_values():


### PR DESCRIPTION
> **Stacked on #47.** Base is `feat/search-tools-limit-and-scores`, not `main`. Merge #47 first;
> the diff shown here is this PR's own.

## Problem

Structure inputs accept a bare path string where the schema advertises an object, and nothing said
so. Both of these are valid for `tmalign-alignment`, but only the second appears anywhere an agent
can see:

```python
{"query_structure": "/path/to/query.pdb"}                       # works, undocumented
{"query_structure": {"structure": "<42,591 chars of PDB>", …}}  # what get_tool_example shows
```

It is not discoverable by experiment either: `{"source": path}` and `{"path": path}` are both
rejected, so an agent that tries the natural object shapes concludes paths are unsupported.

The elision in `get_tool_example` is correct — inlining 85k characters of coordinates would be far
worse — but what an agent takes from it is "to call this tool with my own data I must materialize
42,591 characters into `inputs`". It then either burns most of a context window doing exactly that,
or decides the tool is impractical. This bites hardest on the workflow the toolkit exists for:
chaining a prediction's output file into an alignment or scoring tool, where the file is already on
disk.

## The follow-up, checked — and it changes the wording

The issue asked whether the same coercion applies to other bulky input types, noting that a path
which silently validates for one tool and fails for another is worse than a consistent rule. It is
**not** consistent:

| input | bare path | raw content | http(s) URL |
|---|---|---|---|
| `Structure` | **accepted** | accepted | **accepted**, fetched transparently |
| `MSA` | **rejected** | accepted | — |

`Structure`'s before-validator coerces a path *or* a URL and records it as `source`; `MSA`'s parses
a FASTA string as content and rejects a path.

So the proposed docstring line — "Structure **and sequence** inputs accept a file path string" —
would have been wrong for MSAs, and stating it would have caused the exact failure the issue warned
about. The wording here is scoped to structure inputs, says URLs are accepted too, and states the
exception explicitly rather than leaving an agent to infer a general rule.

## Change

Documentation only. No behaviour changes.

**`_elide` now takes the field name**, so only the fields that really accept a path say so:

```
"<42,591 characters elided — a file path or http(s) URL is accepted instead, here or in
  place of the whole field, e.g. '/path/to/structure.pdb'>"
```

A bulky value under any other key keeps the existing generic placeholder.

**`run_tool`'s docstring**, in both `server.py` (which is what an agent reads in the tool listing)
and the implementation:

> Structure inputs take a file path or an http(s) URL in place of inlined content —
> `{"query_structure": "/path/to/file.pdb"}` — so a file already on disk, such as another tool's
> output, never has to be read into the call. Other bulky inputs, such as MSAs, take their content
> rather than a path.

## Tests

- The elided structure placeholder names the path affordance, and a non-structure field does not
  (guards against re-generalising it).
- A structure input really does accept a path and records it as `source`, and an MSA really does
  reject one. This guards the asymmetry the docstrings now promise — a doc claim that drifts from
  behaviour is worse than no claim.

4,160 tests pass across the MCP, CLI and docstring-style suites. ruff format and check clean.
