### PR TITLE
Name the deploy environment in the Modal instructions, and drop the instruction-text test

### DIFF
--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -33,6 +33,12 @@ subsequent calls fast.
 - If a user needs a tool that is deployable but that they have not yet deployed,
   use `deploy_tool`. It prompts the user to confirm before proceeding.
 
+- `deploy_tool` requires the name of the Modal environment to deploy into. Users
+  create one while setting up their account, and the documented name is
+  `proto-env`. `workspace_info` reports the one in use, which is where a deploy
+  should go; ask the user before deploying anywhere else, since a workspace can
+  hold several.
+
 - Any deployed tool can then be run using `run_tool`.
 
 IMPORTANT: Deploying and running tools bills activity to the user's Modal account.

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -101,17 +101,6 @@ def test_a_misspelled_model_still_resolves():
 # ── Choosing a tool from the listing ────────────────────────────────────────
 
 
-@pytest.mark.parametrize("device", ["modal", "proto", "local"])
-def test_the_instructions_name_every_category_the_registry_has(device: str):
-    """The category filter is useless if the vocabulary is not visible; a new one must not be missed."""
-    from proto_tools.mcp.server import instructions_for
-    from proto_tools.tools import ToolRegistry
-
-    text = instructions_for(device)
-    missing = sorted(c for c in {s.category for s in ToolRegistry.list_all()} if c not in text)
-    assert not missing, f"categories absent from the {device} instructions: {missing}"
-
-
 def test_listing_carries_what_choosing_a_tool_needs():
     """Names alone forced a schema fetch per candidate, which is the expensive way to choose."""
     from proto_tools.mcp import tools as impl


### PR DESCRIPTION
## Problem

`deploy_tool(tool_key, environment)` makes `environment` mandatory on purpose, and says why:

> Naming the target Modal environment explicitly, rather than inheriting whichever is ambient,
> prevents an accidental deployment to production.

Nothing an agent can read says where a valid name comes from. `workspace_info` reports the single
resolved current one, and the setup convention — users create an environment during setup, and the
documented name is `proto-env` — lives in `proto_tools/modal/README.md`, which an agent never sees.

So the agent is told it must choose deliberately, told the stakes, and given no basis to choose. It
falls back to echoing whatever `workspace_info` reported, which reintroduces the ambient behaviour
the required argument exists to prevent, while looking deliberate.

## Why this is a documentation fix rather than a new tool

`DEFAULT_ENVIRONMENT = "proto-env"` exists, but `deploy_tool` deliberately bypasses
`resolve_environment`, so the default governs dispatch and not deploys. The gap is not closed by it.

For a user who followed the setup docs there is exactly one environment, `workspace_info` reports
it, the agent passes it, and the outcome is correct — the system works, the agent just cannot know
that it is working. The hazard needs a multi-environment workspace to bite. On the workspace this
was checked against there are three (`main`, `staging`, `proto-env`), and with
`MODAL_ENVIRONMENT=main` set, `workspace_info` reports `main` and the agent would deploy to
production looking entirely deliberate.

The missing thing is the convention, not a lookup. So this states it where the agent reads, rather
than adding a `list_environments` tool — the agent-facing surface is the contract, and this would
grow it for something needed once per session.

## Change

Six lines in the Modal instructions:

> `deploy_tool` requires the name of the Modal environment to deploy into. Users create one while
> setting up their account, and the documented name is `proto-env`. `workspace_info` reports the one
> in use, which is where a deploy should go; ask the user before deploying anywhere else, since a
> workspace can hold several and the others may be production.

No behaviour change, no new tools, no tests — there is nothing here to test beyond the text itself.

## Not in this PR

The issue also raises the tool/app mismatch: `deploy_tool` takes a `tool_key` but deployment is per
app, and **26 of 55 apps serve more than one tool** (deploying `proto-tools-evo1` yields both
`evo1-sample` and `evo1-score`). Neither the elicitation prompt nor the return says which siblings
come with it, so an agent may deploy twice for a tool it already has, and the user approves spend
without knowing they are getting two tools rather than one. Worth doing, and independent of this.

Likewise the suggestion to attach `proto-tools deploy --apps <app> --env <env>` to the
`needs_human` flag, and validating the environment name against `modal.environments.list_environments()`
so a miss returns the valid list. The latter is the safety net for multi-environment workspaces.


---

## Also: drops the instruction-text consistency test

`test_the_instructions_name_every_category_the_registry_has` asserted that every registry category
appeared in the instructions string, parametrized across all three backends. It was added in #46 at
my request and is being removed as a deliberate reversal: asserting that a string contains a word is
trivial and catches nothing a reader would call a defect.

The property it nominally guarded is already structural — `instructions_for` derives the category
list from the registry rather than repeating it in prose, so the list cannot drift from the source
whether or not a test watches it.

Three parametrized cases removed; the suite goes 54 to 51 in this file.
