### PR TITLE
Cover the MCP surface in agent-context, and stop run_tool claiming Modal for every call

### DIFF
--- a/proto_tools/agent_context.md
+++ b/proto_tools/agent_context.md
@@ -49,6 +49,37 @@ output. Resolve a tool by registry key (`esm2-embedding`), run-function name
 | `proto-tools example-input <tool> [--as-python]` | A minimal valid `Input`, as JSON or as a runnable snippet |
 | `proto-tools example <tool>` | The toolkit example notebook as markdown |
 
+## If you are connected over MCP, not writing Python
+
+The MCP server exposes a fixed set of tools and no Python API: the imports,
+`persist()` / `get()`, and `ToolPool` below do not apply, though the
+`Input -> Config -> run -> Output` shape does. Everything is reached through
+these:
+
+| Tool | Use it for |
+|---|---|
+| `workspace_info` | Where calls land, and whether credentials are configured. Start here if anything looks misconfigured. |
+| `list_tools` | What is available, with each tool's category, one-line summary, and whether it needs a GPU. Pass `category` to narrow. |
+| `search_tools` | Finding a tool by description. Returns the best matches with the score each ranked on. |
+| `get_tool_schema` | The input, config, and output schemas, before a first call. |
+| `get_tool_example` | A known-good example input, showing shape rather than payload. |
+| `get_tool_citation` | BibTeX and DOI for the method, when reporting a result. |
+| `run_tool` | Running one. |
+| `deploy_tool` | Deploying an app to Modal, after the user approves the spend. |
+
+Three things worth knowing before the first call:
+
+- **Tool keys are `<model>-<action>`** — `esmfold-prediction`, not `esmfold`.
+  Several actions usually exist for one model. If a key is rejected, the reply
+  lists near matches; `search_tools` resolves a name you only half know.
+- **Structure inputs take a file path or an http(s) URL** where the schema shows
+  an object, so a file already on disk — another tool's output, say — never has
+  to be read into the call. This is not uniform: an MSA takes its content.
+- **Not every tool needs deploying.** Many are answered in the server's own
+  process, because they need no GPU and no environment, or cannot be deployed at
+  all. Those are listed as available with a note saying so, and `run_tool`
+  reports where a call actually ran in `ran_on`.
+
 ## Don't guess symbol names from the registry key
 
 Model and run-function names come from the toolkit, not the registry key, so

--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -185,12 +185,16 @@ def build_server(device: Device = "modal") -> FastMCP:
         output_dir: str | None = None,
         use_example: bool = False,
     ) -> dict[str, Any]:
-        """Run a deployed tool on the user's Modal compute and return the result.
+        """Run a tool on this session's backend and return the result.
 
         Blocks until it finishes. Most tools return in seconds once warm, but
         the first call after a few minutes idle pays a container start and
         model load, and a few tools (binder design, diffusion) legitimately run
         for many minutes. Check the tool description before calling.
+
+        Some tools are answered in this process whatever the backend, because
+        they need no GPU and no environment, or cannot be deployed at all. The
+        `ran_on` field in the result reports where the call actually ran.
 
         Structure inputs take a file path or an http(s) URL in place of inlined
         content — {"query_structure": "/path/to/file.pdb"} — so a file already on


### PR DESCRIPTION
## What this covers

Two of the three items in the report were already fixed by PRs that merged earlier today, so this
addresses what was left.

**Already shipped, not repeated here:**

- "Tool keys are `<model>-<action>` … appears nowhere" — #44 added `_KEY_CONVENTION` to the
  instructions for all three backends, including the "call `search_tools` rather than guessing"
  advice.
- "Structure inputs accept file paths" — #48 put that in `run_tool`'s docstring and in the elided
  example placeholder.

The report also predates two tools: the surface is eight now, not six (`workspace_info` and
`get_tool_citation`).

## `agent-context` documented an interface an MCP client cannot use

`proto_tools/agent_context.md` is 132 lines with no mention of MCP. Everything concrete in it — the
imports, `persist()` / `get()`, `ToolPool` fan-out — is unreachable for a caller that has eight
tools and no Python interpreter. The `Input -> Config -> run -> Output` shape does still transfer.

Adds a section naming the eight tools and what each is for, plus the three things worth knowing
before a first call: the `<model>-<action>` key convention, that structure inputs take a path or
URL (and that MSAs do not), and that many tools are answered in the server's own process and need
no deployment at all.

### Not a `--mcp` flag

The report proposed one. A flag lives on a CLI verb, and a client connected over MCP cannot run CLI
commands — it has eight tools and no shell — so the flag would serve integrators and shell-capable
agents rather than the MCP agent the issue is about. A section in the existing document reaches
both, and the highest-value sentences already live in the server `INSTRUCTIONS`, which every MCP
agent reads automatically.

### No hardcoded counts

The report cites "33 of 133 tools" answering in-process; the registry is at 135 today, so that
number had already drifted between the report being written and being read. The section says "many"
and points at the per-tool note in `list_tools` output, which cannot go stale.

## `run_tool` claimed every call runs on Modal

Its docstring opened "Run a deployed tool on the user's Modal compute", but the same function serves
`device='local'` and `device='proto'`, and answers 33 tools in this process whatever the backend is.
Generalised, with a pointer to `ran_on`, which already reports where a call actually ran.

## Deliberately not included

Batching guidance ("prefer one `run_tool` call with many inputs"). It is true for tools with a
list-valued input — `esm2-embedding` takes `sequences`, `esmfold-prediction` takes `complexes` — but
not universal: `tmalign-alignment` is pairwise and has no list input, so the advice would be wrong
for it. Held at the maintainer's request, since making tools uniformly iterable would change the
right wording.

## Tests

None. This is documentation and a docstring; the rule in play is that asserting a string contains a
word tests nothing. 8,575 existing tests pass across the MCP, CLI and style-consistency suites, and
ruff is clean.
