### PR TITLE
Verify dataset downloads instead of trusting any file already on disk

### DIFF
--- a/proto_tools/databases/entries/grch37_ensembl_112.py
+++ b/proto_tools/databases/entries/grch37_ensembl_112.py
@@ -27,6 +27,7 @@ ENTRY = DatasetEntry(
                 "Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz"
             ),
             filename=f"{FASTA}.gz",
+            expected_bytes=869_923_173,
         ),
     ],
     total_download_bytes=869_923_173,

--- a/proto_tools/databases/registry.py
+++ b/proto_tools/databases/registry.py
@@ -31,8 +31,10 @@ class DownloadSpec(BaseModel):
         url (str): HTTPS URL to fetch from.
         filename (str): Local filename under the dataset's cache directory.
             Used for resume and post-download verification.
-        sha256 (str | None): Optional SHA-256 of the downloaded file for
-            integrity check.
+        expected_bytes (int | None): Size of the completed file. When set, a
+            cached file of a different size is discarded and fetched again.
+        sha256 (str | None): Optional SHA-256 of the downloaded file, checked
+            once after a download completes.
         required (bool): When False, download failure is non-fatal
             (e.g. taxonomy files needed only for paired-MSA workflows).
     """
@@ -41,6 +43,7 @@ class DownloadSpec(BaseModel):
 
     url: str = Field(description="HTTPS URL to fetch from")
     filename: str = Field(description="Local filename under the dataset cache dir")
+    expected_bytes: int | None = Field(default=None, description="Size of the completed file")
     sha256: str | None = Field(default=None, description="Optional SHA-256 checksum")
     required: bool = Field(default=True, description="Whether failure is fatal")
 

--- a/proto_tools/tools/sequence_alignment/mmseqs2/setup_databases.py
+++ b/proto_tools/tools/sequence_alignment/mmseqs2/setup_databases.py
@@ -40,6 +40,7 @@ Prerequisites:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import subprocess
@@ -60,6 +61,12 @@ from proto_tools.utils.tool_instance import ToolInstance
 
 # Fraction of the cgroup-aware budget allotted to mmseqs index builds (mmseqs sizes splits from physical RAM, so the cap keeps `createindex` from OOMing under Slurm / container memory limits).
 _INDEX_MEMORY_SAFETY_FRACTION = 0.7
+
+# Suffix an in-flight download occupies until it is verified and renamed into place.
+_PARTIAL_SUFFIX = ".part"
+
+# Read size for checksumming, large enough to keep multi-gigabyte datasets I/O bound.
+_HASH_BLOCK_BYTES = 1024 * 1024
 
 # ============================================================================
 # Presets — mirror predictor `preferred_datasets` defaults from the design doc
@@ -131,35 +138,73 @@ def _which_downloader() -> tuple[str, list[str]]:
     raise RuntimeError("No download tool found in PATH. Install aria2c, curl, or wget.")
 
 
+def _wrong_size(path: Path, spec: DownloadSpec) -> str | None:
+    """Describe how ``path``'s size differs from ``spec``, or None when it matches or is unknown."""
+    if spec.expected_bytes is None:
+        return None
+    actual = path.stat().st_size
+    if actual == spec.expected_bytes:
+        return None
+    return f"{actual} bytes on disk, expected {spec.expected_bytes}"
+
+
+def _wrong_checksum(path: Path, spec: DownloadSpec) -> str | None:
+    """Describe how ``path``'s SHA-256 differs from ``spec``, or None when it matches or is unset."""
+    if spec.sha256 is None:
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(_HASH_BLOCK_BYTES), b""):
+            digest.update(block)
+    actual = digest.hexdigest()
+    if actual == spec.sha256:
+        return None
+    return f"sha256 {actual}, expected {spec.sha256}"
+
+
 def _download_file(spec: DownloadSpec, cache_dir: Path, downloader: tuple[str, list[str]]) -> bool:
     """Download a single ``DownloadSpec`` into ``cache_dir``. Returns True on success.
 
-    Idempotent: skips if the target file already exists. ``downloader`` is the
-    ``(name, base_argv)`` tuple resolved once per provisioning run by the
-    caller (so we don't re-``shutil.which`` on every file).
+    Idempotent: an existing file is reused only when its size agrees with ``spec``, so an
+    incomplete file left by an earlier run is fetched again rather than trusted. The transfer
+    lands on a ``.part`` file and is renamed only once verified, so an interrupted download
+    never occupies the final path. ``downloader`` is the ``(name, base_argv)`` tuple resolved
+    once per provisioning run by the caller (so we don't re-``shutil.which`` on every file).
     """
     target = cache_dir / spec.filename
     if target.exists():
-        print(f"  [skip] {spec.filename} already present")
-        return True
+        stale = _wrong_size(target, spec)
+        if stale is None:
+            print(f"  [skip] {spec.filename} already present")
+            return True
+        print(f"  [stale] {spec.filename}: {stale}; downloading again")
+        target.unlink()
 
     name, base_argv = downloader
     print(f"  [download] {spec.filename} via {name}: {spec.url}")
+    partial = target.with_name(target.name + _PARTIAL_SUFFIX)
+    partial.unlink(missing_ok=True)
 
     if name == "aria2c":
-        cmd = [*base_argv, "-o", spec.filename, "-d", str(cache_dir), spec.url]
+        cmd = [*base_argv, "-o", partial.name, "-d", str(cache_dir), spec.url]
     elif name == "curl":
-        cmd = [*base_argv, "-o", str(target), spec.url]
+        cmd = [*base_argv, "-o", str(partial), spec.url]
     else:  # wget
-        cmd = [*base_argv, "-O", str(target), spec.url]
+        cmd = [*base_argv, "-O", str(partial), spec.url]
 
     try:
         subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
+        for problem in (_wrong_size(partial, spec), _wrong_checksum(partial, spec)):
+            if problem is not None:
+                msg = f"{spec.filename} did not download completely: {problem}"
+                raise RuntimeError(msg)
+    except (subprocess.CalledProcessError, RuntimeError) as e:
+        partial.unlink(missing_ok=True)
         if not spec.required:
             print(f"  [warn] optional file {spec.filename} download failed (continuing): {e}")
             return True
         raise
+    partial.replace(target)
     return True
 
 

--- a/tests/sequence_alignment_tests/test_setup_databases.py
+++ b/tests/sequence_alignment_tests/test_setup_databases.py
@@ -7,8 +7,19 @@ from typing import Any
 
 import pytest
 
-from proto_tools.databases import DatasetRegistry, IndexStep
+from proto_tools.databases import DatasetRegistry, DownloadSpec, IndexStep
 from proto_tools.tools.sequence_alignment.mmseqs2 import setup_databases
+
+CURL = ("curl", ["curl", "-L", "--fail"])
+
+
+def _serving(monkeypatch: pytest.MonkeyPatch, payload: bytes) -> None:
+    """Stub the downloader so it writes ``payload`` to whatever path the argv names."""
+
+    def fake_run(cmd: list[str], *_: Any, **__: Any) -> None:
+        Path(cmd[cmd.index("-o") + 1]).write_bytes(payload)
+
+    monkeypatch.setattr(setup_databases.subprocess, "run", fake_run)
 
 
 def test_split_memory_limit_caps_at_safety_fraction(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -108,3 +119,62 @@ def test_ensure_mmseqs_on_path_raises_when_binary_absent(monkeypatch: pytest.Mon
 
     with pytest.raises(RuntimeError, match="mmseqs binary not found"):
         setup_databases._ensure_mmseqs_on_path()
+
+
+def test_incomplete_cached_file_is_downloaded_again(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A cached file whose size disagrees with the spec is replaced, not trusted."""
+    spec = DownloadSpec(url="https://example.invalid/g.fa.gz", filename="g.fa.gz", expected_bytes=8)
+    (tmp_path / "g.fa.gz").write_bytes(b"cut")
+    _serving(monkeypatch, b"complete")
+
+    assert setup_databases._download_file(spec, tmp_path, CURL) is True
+    assert (tmp_path / "g.fa.gz").read_bytes() == b"complete"
+
+
+def test_complete_cached_file_is_reused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A cached file of the declared size is kept without re-downloading."""
+    spec = DownloadSpec(url="https://example.invalid/g.fa.gz", filename="g.fa.gz", expected_bytes=8)
+    (tmp_path / "g.fa.gz").write_bytes(b"complete")
+
+    def explode(*_: Any, **__: Any) -> None:
+        raise AssertionError("should not download an already-complete file")
+
+    monkeypatch.setattr(setup_databases.subprocess, "run", explode)
+
+    assert setup_databases._download_file(spec, tmp_path, CURL) is True
+
+
+def test_short_download_leaves_nothing_at_the_final_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A transfer that ends early raises and leaves neither the target nor the partial file."""
+    spec = DownloadSpec(url="https://example.invalid/g.fa.gz", filename="g.fa.gz", expected_bytes=8)
+    _serving(monkeypatch, b"cut")
+
+    with pytest.raises(RuntimeError, match="did not download completely"):
+        setup_databases._download_file(spec, tmp_path, CURL)
+
+    assert not (tmp_path / "g.fa.gz").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_checksum_mismatch_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A download of the right size but the wrong SHA-256 is discarded."""
+    spec = DownloadSpec(url="https://example.invalid/g.fa.gz", filename="g.fa.gz", sha256="00" * 32)
+    _serving(monkeypatch, b"complete")
+
+    with pytest.raises(RuntimeError, match="did not download completely"):
+        setup_databases._download_file(spec, tmp_path, CURL)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_unverifiable_spec_keeps_previous_behaviour(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without a declared size or checksum, any existing file is still reused."""
+    spec = DownloadSpec(url="https://example.invalid/g.fa.gz", filename="g.fa.gz")
+    (tmp_path / "g.fa.gz").write_bytes(b"whatever")
+
+    def explode(*_: Any, **__: Any) -> None:
+        raise AssertionError("should not download when the file is present and unverifiable")
+
+    monkeypatch.setattr(setup_databases.subprocess, "run", explode)
+
+    assert setup_databases._download_file(spec, tmp_path, CURL) is True


### PR DESCRIPTION
## Problem

`_download_file` writes `curl -o <target>` straight to the final path and reuses any file already
sitting there:

```python
target = cache_dir / spec.filename
if target.exists():
    print(f"  [skip] {spec.filename} already present")
    return True
```

An interrupted transfer therefore leaves a partial file exactly where the next run looks for it, and
because dataset caches are persistent and shared, that file is reused forever. Every later run skips
the download and fails in the index recipe instead, where the cause is not obvious:

```
  [skip] Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz already present
          $ gunzip -f Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz
gzip: Homo_sapiens.GRCh37.dna.primary_assembly.fa.gz: unexpected end of file
```

The cached file was 262.6 MiB against an expected 829.6 MiB. Nothing between the truncated download
and `gunzip` had any reason to notice.

`DownloadSpec.sha256` already existed for this purpose but was never read, and no entry set it.

## Change

- `DownloadSpec` gains `expected_bytes`. When set, a cached file of a different size is discarded
  and fetched again rather than reused.
- Downloads land on a `.part` file and are renamed into place only after they verify, so an
  interrupted transfer never occupies the final path.
- `sha256` is now actually checked, once, after a download completes. It is not re-checked on the
  reuse path: these datasets run to tens of gigabytes, and re-hashing them on every provision would
  cost far more than it saves. Size is what the reuse path checks.
- A failed verification cleans up the partial file, and stays non-fatal for `required=False` specs.
- Populates `expected_bytes` for the GRCh37 entry, confirmed against the `Content-Length` the
  Ensembl release-112 archive serves.

Entries without `expected_bytes` or `sha256` keep the previous behaviour, so this is opt-in per
dataset and no other entry changes meaning.

## Tests

Five cases in `tests/sequence_alignment_tests/test_setup_databases.py`: an incomplete cached file is
re-downloaded, a complete one is reused without a transfer, a short download raises and leaves
neither the target nor the partial file, a size-correct but checksum-wrong download is discarded,
and a spec declaring neither still reuses whatever is present.

Full CPU suite green (12321 passed), `ruff check`, `ruff format --check`, and `mypy proto_tools/`
clean.
