### PR TITLE
Make masking token-aware so codon-level models can use it

### DIFF
--- a/proto_tools/transforms/masking/__init__.py
+++ b/proto_tools/transforms/masking/__init__.py
@@ -12,6 +12,7 @@ from proto_tools.transforms.masking.maskers import (
     MaskingInput,
     MaskingMethod,
     compatible_methods,
+    split_tokens,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "apply_masking_strategy",
     "build_position_score_fn",
     "compatible_methods",
+    "split_tokens",
 ]

--- a/proto_tools/transforms/masking/base.py
+++ b/proto_tools/transforms/masking/base.py
@@ -16,6 +16,7 @@ from proto_tools.transforms.masking.maskers import (
     MaskingInput,
     MaskingMethod,
     compatible_methods,
+    split_tokens,
 )
 from proto_tools.utils import ConfigField
 from proto_tools.utils.sequence import validate_positions_list
@@ -32,32 +33,37 @@ MASK_TOKEN = "_"  # noqa: S105 -- not a password
 # ============================================================================
 
 
-def mutable_mask(seq: str, fixed: list[int] | None = None) -> list[bool]:
+def mutable_mask(seq: str, fixed: list[int] | None = None, token_size: int = 1) -> list[bool]:
     """Return a boolean mask where True = designable (eligible for masking).
 
     Args:
-        seq (str): Protein sequence (e.g. "MKTLLIFLA").
-        fixed (list[int] | None): 1-indexed positions to keep unchanged. Applied uniformly
-            to every sequence in a batch by the caller.
+        seq (str): Sequence to inspect (e.g. "MKTLLIFLA", or "AUGGCC" as codons).
+        fixed (list[int] | None): 1-indexed token positions to keep unchanged. Applied
+            uniformly to every sequence in a batch by the caller.
+        token_size (int): Characters per token.
 
     Returns:
-        list[bool]: List of bools, one per character in *seq*.
+        list[bool]: List of bools, one per token in *seq*.
     """
     fixed_set = set(fixed) if fixed else set()
     return [
-        # Position is designable if it's not already masked
+        # A token is designable if it is not already masked
         # and not in the fixed set (convert 0-indexed i to 1-indexed)
-        c != MASK_TOKEN and (i + 1) not in fixed_set
-        for i, c in enumerate(seq)
+        MASK_TOKEN not in token and (i + 1) not in fixed_set
+        for i, token in enumerate(split_tokens(seq, token_size))
     ]
 
 
-def apply_mask(seq: str, positions: list[int]) -> str:
-    """Replace characters at 0-indexed *positions* with MASK_TOKEN."""
-    chars = list(seq)
+def apply_mask(seq: str, positions: list[int], token_size: int = 1) -> str:
+    """Replace the tokens at 0-indexed *positions* with MASK_TOKEN.
+
+    A masked token keeps its width, so a codon becomes ``"___"`` rather than one character
+    and the reading frame survives masking.
+    """
+    tokens = split_tokens(seq, token_size)
     for p in positions:
-        chars[p] = MASK_TOKEN
-    return "".join(chars)
+        tokens[p] = MASK_TOKEN * token_size
+    return "".join(tokens)
 
 
 def validate_enough_mutable(
@@ -71,7 +77,7 @@ def validate_enough_mutable(
     if count > n_mutable:
         raise ValueError(
             f"Sequence {seq_index}: requested {count} mutations but only "
-            f"{n_mutable} mutable positions available (len={len(seq)})"
+            f"{n_mutable} mutable positions available (length {len(seq)}, {len(mutable)} tokens)"
         )
 
 
@@ -148,7 +154,7 @@ def weighted_sample(
     return [eligible[i] for i in chosen_idx]
 
 
-def apply_masking_strategy(config: Any, inputs: Any, position_score_fn: Any = None) -> Any:
+def apply_masking_strategy(config: Any, inputs: Any, position_score_fn: Any = None, token_size: int = 1) -> Any:
     """Apply a masking strategy to tool inputs, skipping if already masked.
 
     Intended to be called from a sample config's ``preprocess()`` hook.
@@ -164,8 +170,10 @@ def apply_masking_strategy(config: Any, inputs: Any, position_score_fn: Any = No
         inputs (Any): A ``BaseToolInput``-like object with a ``sequences`` field
             and a ``model_copy(update=...)`` method (Pydantic model).
         position_score_fn (Any): Optional callable that takes sequences and returns
-            per-position scores. Built by ``build_position_score_fn()`` in
+            one score per token. Built by ``build_position_score_fn()`` in
             the tool's ``preprocess()`` hook.
+        token_size (int): Characters per token for this tool's model. Passed by the tool
+            rather than configured, since it is fixed by the model's vocabulary.
 
     Returns:
         Any: The (possibly updated) inputs object.
@@ -188,6 +196,7 @@ def apply_masking_strategy(config: Any, inputs: Any, position_score_fn: Any = No
                     inputs.sequences,
                     position_score_fn=position_score_fn,
                     seed=config.seed,
+                    token_size=token_size,
                 )
             }
         )
@@ -304,6 +313,7 @@ class RandomMaskingStrategy(BaseModel):
         sequences: list[str],
         position_score_fn: Callable[..., Any] | None = None,
         seed: int | None = None,
+        token_size: int = 1,
     ) -> list[str]:
         """Apply the masking strategy to a batch of sequences.
 
@@ -320,9 +330,13 @@ class RandomMaskingStrategy(BaseModel):
                 model-based method, it must be supplied explicitly.
             seed (int | None): Random seed for reproducible masking. Creates a seeded
                 RandomState for position selection. If None, uses global numpy RNG.
+            token_size (int): Characters per token, supplied by the calling tool rather
+                than configured: it is a property of the model, not a choice. One for a
+                residue-level model, three for a codon-level one.
 
         Returns:
-            list[str]: List of masked sequences with ``_`` at selected positions.
+            list[str]: List of masked sequences, each selected token replaced by ``_``
+                repeated to the token's width.
         """
         # Lazy-init the masker (persists for the lifetime of this strategy)
         if self._masker is None:
@@ -341,7 +355,7 @@ class RandomMaskingStrategy(BaseModel):
             )
 
         assert self._masker is not None
-        all_scores = self._masker.score(sequences, position_score_fn=position_score_fn)
+        all_scores = self._masker.score(sequences, position_score_fn=position_score_fn, token_size=token_size)
 
         # Create seeded RNG if seed is provided
         rng = np.random.RandomState(seed) if seed is not None else None
@@ -351,7 +365,7 @@ class RandomMaskingStrategy(BaseModel):
 
         results = []
         for i, seq in enumerate(sequences):
-            mutable = mutable_mask(seq, self.fixed_positions)
+            mutable = mutable_mask(seq, self.fixed_positions, token_size)
             eligible = [j for j, m in enumerate(mutable) if m]
             count = _resolve_count(
                 self.num_mutations,
@@ -362,7 +376,7 @@ class RandomMaskingStrategy(BaseModel):
 
             scores = [all_scores[i][j] / temperature for j in eligible]
             chosen = weighted_sample(eligible, scores, count, rng=rng)
-            results.append(apply_mask(seq, chosen))
+            results.append(apply_mask(seq, chosen, token_size))
         return results
 
 

--- a/proto_tools/transforms/masking/maskers.py
+++ b/proto_tools/transforms/masking/maskers.py
@@ -4,7 +4,7 @@ Each masker has:
 - ``requires``: which external input it needs to score positions
   (``None`` = no input needed, e.g. uniform random)
 - ``__init__(strategy)``: stores the strategy reference
-- ``score(sequences, position_score_fn)``: returns per-position scores
+- ``score(sequences, position_score_fn, token_size)``: returns one score per token
 
 The ``MaskingMethod`` Literal and ``MASKERS`` dict are the single source of
 truth for valid method names. ``Masker.requires`` plus a sampling tool's
@@ -47,6 +47,34 @@ class MaskingInput(str, Enum):
 MaskingMethod = Literal["random", "entropy", "max-logit"]
 
 
+def split_tokens(seq: str, token_size: int = 1) -> list[str]:
+    """Split a sequence into the tokens its model reads.
+
+    A token is one character for a residue-level model and three for a codon-level one, so
+    positions, scores and ``fixed_positions`` all count in the units the model actually sees.
+    Masking a character offset instead would land mid-codon and produce a sequence no codon
+    vocabulary can tokenize.
+
+    Args:
+        seq (str): Sequence to split.
+        token_size (int): Characters per token.
+
+    Returns:
+        list[str]: The tokens, in order.
+
+    Raises:
+        ValueError: If ``token_size`` is below 1, or the sequence does not divide evenly.
+    """
+    if token_size < 1:
+        raise ValueError(f"token_size must be at least 1, got {token_size}")
+    if len(seq) % token_size:
+        raise ValueError(
+            f"sequence length {len(seq)} is not a multiple of token_size {token_size}; "
+            f"a codon-level model needs whole codons"
+        )
+    return [seq[i : i + token_size] for i in range(0, len(seq), token_size)]
+
+
 # ============================================================================
 # Masker ABC
 # ============================================================================
@@ -85,9 +113,9 @@ class Masker(ABC):
         class MyCustomMasker(Masker):
             requires = None  # no input needed
 
-            def score(self, sequences, position_score_fn=None):
-                # Return higher scores for positions you want masked
-                return [[1.0 if c == "A" else 0.0 for c in seq] for seq in sequences]
+            def score(self, sequences, position_score_fn=None, token_size=1):
+                # Return one score per token; higher means more likely to be masked
+                return [[1.0 if t.startswith("A") else 0.0 for t in split_tokens(seq, token_size)] for seq in sequences]
     """
 
     requires: ClassVar[MaskingInput | None] = None
@@ -101,17 +129,21 @@ class Masker(ABC):
         self,
         sequences: list[str],
         position_score_fn: Callable[..., Any] | None = None,
+        token_size: int = 1,
     ) -> list[list[float]]:
-        """Score all positions for all sequences.
+        """Score every token of every sequence.
 
         Args:
-            sequences (list[str]): Protein sequences to score.
+            sequences (list[str]): Sequences to score.
             position_score_fn (Callable[..., Any] | None): Callable that takes a list of sequences
-                and returns per-position scores. Required for model-based
+                and returns one score per token. Required for model-based
                 maskers; ``None`` for maskers that don't use a model.
+            token_size (int): Characters per token. A model-based masker ignores it, since
+                the model already emits one row per token; a masker that counts positions
+                itself needs it so it counts tokens rather than characters.
 
         Returns:
-            list[list[float]]: List of per-position scores, one list per sequence.
+            list[list[float]]: List of per-token scores, one list per sequence.
                 Higher = more likely to mask.
         """
 
@@ -130,9 +162,10 @@ class RandomMasker(Masker):
         self,
         sequences: list[str],
         position_score_fn: Callable[..., Any] | None = None,  # noqa: ARG002 — required by abstract Masker interface
+        token_size: int = 1,
     ) -> list[list[float]]:
-        """Score all positions equally (uniform zero scores, no model)."""
-        return [[0.0] * len(seq) for seq in sequences]
+        """Score all tokens equally (uniform zero scores, no model)."""
+        return [[0.0] * len(split_tokens(seq, token_size)) for seq in sequences]
 
 
 class EntropyMasker(Masker):
@@ -144,8 +177,9 @@ class EntropyMasker(Masker):
         self,
         sequences: list[str],
         position_score_fn: Callable[..., Any] | None = None,
+        token_size: int = 1,  # noqa: ARG002 — logits already arrive one row per token
     ) -> list[list[float]]:
-        """Compute per-position Shannon entropy from model logits."""
+        """Compute per-token Shannon entropy from model logits."""
         logits = position_score_fn(sequences)  # type: ignore[misc]
         all_scores = []
         for seq_logits in logits:
@@ -170,8 +204,9 @@ class MaxLogitMasker(Masker):
         self,
         sequences: list[str],
         position_score_fn: Callable[..., Any] | None = None,
+        token_size: int = 1,  # noqa: ARG002 — logits already arrive one row per token
     ) -> list[list[float]]:
-        """Compute negated max-logit per position from model logits."""
+        """Compute negated max-logit per token from model logits."""
         logits = position_score_fn(sequences)  # type: ignore[misc]
         all_scores = []
         for seq_logits in logits:

--- a/tests/masked_models_tests/masking_tests/test_masking_strategies.py
+++ b/tests/masked_models_tests/masking_tests/test_masking_strategies.py
@@ -383,7 +383,7 @@ def test_temperature_low_is_greedy():
     class GreedyTestMasker(Masker):
         requires = None
 
-        def score(self, sequences, position_score_fn=None):
+        def score(self, sequences, position_score_fn=None, token_size=1):
             # Position 0 gets score 2, rest get score 1
             return [[2.0] + [1.0] * (len(seq) - 1) for seq in sequences]
 
@@ -407,7 +407,7 @@ def test_temperature_high_is_uniform():
     class BiasedTestMasker(Masker):
         requires = None
 
-        def score(self, sequences, position_score_fn=None):
+        def score(self, sequences, position_score_fn=None, token_size=1):
             # Position 0 gets a much higher score
             return [[100.0] + [1.0] * (len(seq) - 1) for seq in sequences]
 
@@ -570,3 +570,46 @@ def test_masking_strategy_dedups_fixed_positions(caplog: pytest.LogCaptureFixtur
         strategy = MaskingStrategy(fixed_positions=[1, 1, 2, 3, 2])
     assert strategy.fixed_positions == [1, 2, 3]
     assert any("dropped 2 duplicate position(s)" in rec.message for rec in caplog.records)
+
+
+# ── Token-width masking ─────────────────────────────────────────────────────
+
+
+def test_a_masked_codon_keeps_the_reading_frame():
+    """Masking a character offset would land mid-codon, producing a sequence no vocabulary tokenizes."""
+    masked = RandomMaskingStrategy(num_mutations=2).mask(["AUGGCCUUUAAAGGG"], seed=0, token_size=3)[0]
+
+    assert len(masked) == 15, "a masked codon is three characters wide, not one"
+    codons = [masked[i : i + 3] for i in range(0, 15, 3)]
+    assert codons.count("___") == 2, "two whole codons masked"
+    assert all(c == "___" or "_" not in c for c in codons), f"a mask straddled a codon boundary: {codons}"
+
+
+def test_fixed_positions_are_counted_in_codons_not_characters():
+    """`fixed_positions=[1]` has to mean the start codon, not its first nucleotide."""
+    masked = RandomMaskingStrategy(num_mutations=3, fixed_positions=[1, 5]).mask(
+        ["AUGGCCUUUAAAGGG"], seed=0, token_size=3
+    )[0]
+
+    assert masked.startswith("AUG"), "the start codon was pinned and must survive intact"
+    assert masked.endswith("GGG"), "and so was the last codon"
+    assert masked == "AUG_________GGG", "the three codons between them were the only eligible ones"
+
+
+def test_a_sequence_that_is_not_whole_codons_is_refused():
+    """Silently truncating would shift every downstream position by a base."""
+    with pytest.raises(ValueError, match="not a multiple of token_size"):
+        RandomMaskingStrategy(num_mutations=1).mask(["AUGGC"], seed=0, token_size=3)
+
+
+def test_mask_fraction_and_counts_are_in_tokens():
+    """A fraction of a codon is meaningless; the count has to resolve against codons."""
+    masked = RandomMaskingStrategy(mask_fraction=0.4).mask(["AUGGCCUUUAAAGGG"], seed=0, token_size=3)[0]
+
+    assert masked.count("_") == 6, "0.4 of 5 codons is 2 codons, i.e. 6 characters"
+
+
+def test_too_many_mutations_reports_tokens():
+    """The count that failed is in codons, so the error has to say so to be actionable."""
+    with pytest.raises(ValueError, match="5 tokens"):
+        RandomMaskingStrategy(num_mutations=6).mask(["AUGGCCUUUAAAGGG"], seed=0, token_size=3)


### PR DESCRIPTION
## Why

`proto_tools/transforms/masking/` assumed one character is one token. That holds for every protein
model in the catalogue, so the assumption was never visible — but it is an assumption, not a fact,
and it stops any codon- or k-mer-level model from using the shared masking system at all.

CodonFM (#34) is the first model where it breaks. Its vocabulary is codon→id — `{"AAA": "K",
"AAC": "N", "AAU": "N", …}` — and its mask is a single `<MASK>` entry replacing **one codon**. So
`num_mutations=2` means two codons, six nucleotides, two masks.

Point the current masker at a nucleotide sequence and ask for position 5 and it blanks nucleotide 5,
which lands mid-codon: codon 2 spans characters 4–6. The result is a sequence that cannot be
tokenized at all, because `AT_` is in no codon vocabulary. Not a wrong answer — an impossible one.

Rather than have each nucleotide model reimplement masking, this names the assumption.

## What changed

A `token_size` threaded through the masking path, defaulting to 1.

| function | before | after |
|---|---|---|
| `split_tokens(seq, token_size)` | — | new helper |
| `mutable_mask(seq, fixed, token_size)` | bool per character | bool per **token** |
| `apply_mask(seq, positions, token_size)` | `_` at a character offset | `"_" * token_size` at a token offset |
| `Masker.score(..., token_size)` | score per character | one score per **token** |
| `strategy.mask(..., token_size)` | — | — |
| `apply_masking_strategy(..., token_size)` | — | what tools call from `preprocess()` |

**`token_size` is not configurable, by design.** It is a call-time parameter supplied by the tool,
never a `ConfigField`, so it appears in no JSON schema, cannot reach `get_tool_schema`, and cannot
be set by a user. A model's token width is a property of its vocabulary, not a choice — a caller
who could set it could only set it wrongly.

`fixed_positions` now counts in tokens too, which is what makes it useful for coding sequences:
`fixed_positions=[1]` pins the start codon rather than its first nucleotide.

```
protein (token_size=1):   MKTL_I_LA
codons  (token_size=3):   AUGGCC______GGG      whole codons, reading frame intact
codons, 1 and 5 pinned:   AUG_________GGG      start AUG and final GGG survive
not whole codons:         ValueError: sequence length 5 is not a multiple of token_size 3
```

## Nothing changes at token_size=1

Every existing caller — esm2, esm3, `random_protein_sample`, `random_nucleotide_sample` — is
untouched and passes the default. The 42-test masking suite passing unchanged is the evidence.

## Two things worth knowing

**`split_tokens` lives in `maskers.py`, not `base.py`.** `base.py` imports from `maskers.py`, so
defining it in `base` and calling it from `RandomMasker` would be a circular import. It is
re-exported from the package.

**This breaks custom `Masker` subclasses.** `score()` gained a parameter, and the ABC is a
documented extension point — two test fixtures failed on exactly that, which is the intended signal.
Updated, along with the subclassing example in the docstring. Only `RandomMasker` needs the value;
the model-based maskers take it for interface parity and ignore it, because logits already arrive
one row per token.

## Not in this PR

CodonFM adopting this. That needs a `preprocess()` hook on `CodonFMSampleConfig` **and** its worker
to accept `"___"` as a mask, which means touching the vendored `standalone/src/tokenizer/` in
someone else's open PR. Landing the transform separately lets #34 merge on its own terms.

Worth checking before that work: CodonFM's vocabulary is `AAU`, not `AAT`, so there is a T/U
normalisation somewhere in the input path that any masking format has to survive.

The `"___"` width is an interchange detail — inside the model a masked codon is still a single
`<MASK>` id. The three characters exist so the reading frame survives the string round-trip.

## Tests

Five added, covering codon-width masking on boundaries, `fixed_positions` in codon space, refusal of
a sequence that is not whole codons, `mask_fraction` resolving against codons rather than
characters, and the token-aware error message.

92 pass across the masking and seed suites (87 before), ruff format and check clean.
