### PR TITLE
Let the MCP surface answer for a caller other than the process

### DIFF
--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -85,27 +85,39 @@ def answered_in_process_keys() -> set[str]:
     return {spec.key for spec in ToolRegistry.list_all() if runs_in_process(spec.key)}
 
 
-def deployed_keys(device: Device) -> set[str]:
-    """Return the tools ``device`` actually serves, ignoring anything answered in-process."""
+def deployed_keys(device: Device, *, environment: str | None = None, client: Any | None = None) -> set[str]:
+    """Return the tools ``device`` actually serves, ignoring anything answered in-process.
+
+    ``environment`` and ``client`` name whose workspace to ask about. Omitted, the question is
+    answered for this process, which is what a local session wants. A server answering for
+    someone else must pass theirs, or it reports its own deployments as though they were the
+    caller's.
+    """
     if device == "local":
         return set()
     if device == "proto":
         return {key for key, entry in _hosted_catalogue().items() if entry.get("hosted")}
-    live = deployed_apps()
+    live = deployed_apps(environment=environment, client=client)
     return {key for key in _registry() if _app_for(key) in live}
 
 
-def available_keys(device: Device) -> set[str]:
+def available_keys(device: Device, *, environment: str | None = None, client: Any | None = None) -> set[str]:
     """Return the tool keys that can actually run on ``device``."""
     if device == "local":
         # Every registered tool runs here: a standalone env builds on first use, so availability
         # is a question of time and disk rather than of what has been provisioned in advance.
         return _all_registered()
-    return deployed_keys(device) | answered_in_process_keys()
+    return deployed_keys(device, environment=environment, client=client) | answered_in_process_keys()
 
 
-def workspace_info(device: Device = "modal") -> dict[str, Any]:
-    """Report where calls will land, and whether the caller can deploy there."""
+def workspace_info(
+    device: Device = "modal", *, environment: str | None = None, client: Any | None = None
+) -> dict[str, Any]:
+    """Report where calls will land, and whether the caller can deploy there.
+
+    ``environment`` and ``client`` describe whose workspace to report on. Omitted, this describes
+    the process's own, which is what a local session wants.
+    """
     if device == "local":
         from proto_tools.tools import ToolRegistry
         from proto_tools.utils.device import number_of_visible_gpus
@@ -146,7 +158,9 @@ def workspace_info(device: Device = "modal") -> dict[str, Any]:
     from proto_tools.modal.manifest import APP_BUCKETS
 
     try:
-        modal.Client.from_env()  # raises when no credentials are configured
+        # A caller-supplied client already carries credentials; only the process needs checking.
+        if client is None:
+            modal.Client.from_env()  # raises when no credentials are configured
     except Exception as exc:
         return {
             "device": "modal",
@@ -169,28 +183,28 @@ def workspace_info(device: Device = "modal") -> dict[str, Any]:
 
     from proto_tools.modal.app import environment_exists
 
-    environment = resolve_environment()
+    resolved = resolve_environment(environment)
     # Asked before counting, because an environment that does not exist counts zero apps and
     # reads as "nothing deployed yet" — which sends the caller off to deploy into a place that
     # cannot receive it. The one-time setup is the actual answer.
-    if environment_exists(environment) is False:
+    if environment_exists(resolved, client) is False:
         return {
             "device": "modal",
             "authenticated": True,
             "workspace": workspace,
-            "environment": environment,
+            "environment": resolved,
             "environment_exists": False,
             "deployable": False,
-            "error": f"Modal environment {environment!r} has not been created in this workspace.",
-            "hint": f"Create it with: proto-tools deploy --create-env --env {environment}",
+            "error": f"Modal environment {resolved!r} has not been created in this workspace.",
+            "hint": f"Create it with: proto-tools deploy --create-env --env {resolved}",
         }
 
-    deployed = deployed_apps()
+    deployed = deployed_apps(environment=resolved, client=client)
     return {
         "device": "modal",
         "authenticated": True,
         "workspace": workspace,
-        "environment": environment,
+        "environment": resolved,
         "environment_exists": True,
         "apps_deployed": len(deployed),
         "apps_available": len(APP_BUCKETS),
@@ -200,7 +214,12 @@ def workspace_info(device: Device = "modal") -> dict[str, Any]:
 
 
 def list_tools(
-    deployed_only: bool = True, category: str | None = None, device: Device = "modal"
+    deployed_only: bool = True,
+    category: str | None = None,
+    device: Device = "modal",
+    *,
+    environment: str | None = None,
+    client: Any | None = None,
 ) -> list[dict[str, Any]]:
     """List tools, flagged by whether they can actually run on ``device``.
 
@@ -224,10 +243,10 @@ def list_tools(
         if category not in known:
             return [{"ok": False, "error": f"no category named {category!r}", "categories": known}]
 
-    available = available_keys(device)
+    available = available_keys(device, environment=environment, client=client)
     in_process = set() if device == "local" else answered_in_process_keys()
     # Resolved once: on ``modal`` this reads the live app list, which is a network call.
-    deployed = deployed_keys(device)
+    deployed = deployed_keys(device, environment=environment, client=client)
     # The catalogue itself differs by device: the dispatch table lists what a container could
     # serve, which is the right universe for a remote backend but omits the tools answered here.
     catalogue = available if device == "local" else set(_registry()) | in_process
@@ -343,7 +362,15 @@ def _no_match_hint() -> str:
     return f"Nothing matched. Browse instead with list_tools(category=...); the categories are: {categories}."
 
 
-def search_tools(query: str, deployed_only: bool = True, limit: int = 10, device: Device = "modal") -> dict[str, Any]:
+def search_tools(
+    query: str,
+    deployed_only: bool = True,
+    limit: int = 10,
+    device: Device = "modal",
+    *,
+    environment: str | None = None,
+    client: Any | None = None,
+) -> dict[str, Any]:
     """Find tools by keyword, best match first.
 
     Matches per term rather than on the whole string: agents ask in natural
@@ -363,7 +390,7 @@ def search_tools(query: str, deployed_only: bool = True, limit: int = 10, device
         return {"hits": [], "n_total": 0, "hint": _no_match_hint()}
 
     scored = []
-    for entry in list_tools(deployed_only=deployed_only, device=device):
+    for entry in list_tools(deployed_only=deployed_only, device=device, environment=environment, client=client):
         key, category = entry["tool"].lower(), (entry.get("category") or "").lower()
         summary = (entry.get("summary") or "").lower()
         score = sum(max(_field_score(t, key, category, summary) for t in form) for form in forms)
@@ -520,7 +547,15 @@ def _setup_errors(device: Device) -> tuple[type[Exception], ...]:
     return (ModalDispatchError,)
 
 
-def _dispatch(device: Device, tool_key: str, payload: Any, cfg: Any) -> tuple[Any, Device]:
+def _dispatch(
+    device: Device,
+    tool_key: str,
+    payload: Any,
+    cfg: Any,
+    *,
+    environment: str | None = None,
+    client: Any | None = None,
+) -> tuple[Any, Device]:
     """Route one call to the backend ``device`` names, and report where it ran.
 
     The server is a stdio process on the caller's own machine, so "run it here" is always an
@@ -563,7 +598,7 @@ def _dispatch(device: Device, tool_key: str, payload: Any, cfg: Any) -> tuple[An
         return dispatch_to_proto(tool_key, payload, cfg), device
     from proto_tools.modal.client import dispatch_to_modal
 
-    return dispatch_to_modal(tool_key, payload, cfg), device
+    return dispatch_to_modal(tool_key, payload, cfg, environment=environment, client=client), device
 
 
 def _unavailable(device: Device, tool_key: str, error: str) -> dict[str, Any]:
@@ -596,6 +631,9 @@ def run_tool(
     output_dir: str | None = None,
     use_example: bool = False,
     device: Device = "modal",
+    *,
+    environment: str | None = None,
+    client: Any | None = None,
 ) -> dict[str, Any]:
     """Run a tool and return its result, with large fields written to disk.
 
@@ -647,7 +685,7 @@ def run_tool(
     if is_remote(device) and (reason := cfg.remote_unsupported_reason(device)) is not None:
         return {"ok": False, "error": reason, "not_supported_on": device}
     try:
-        result, ran_on = _dispatch(device, tool_key, payload, cfg)
+        result, ran_on = _dispatch(device, tool_key, payload, cfg, environment=environment, client=client)
     except _setup_errors(device) as exc:
         return {"ok": False, **_unavailable(device, tool_key, str(exc))}
     except Exception as exc:

--- a/proto_tools/utils/modal_status.py
+++ b/proto_tools/utils/modal_status.py
@@ -73,8 +73,8 @@ def auth_mechanism() -> str | None:
     return None
 
 
-def deployed_apps() -> set[str]:
-    """Apps that currently resolve in the Modal environment this session dispatches into.
+def deployed_apps(environment: str | None = None, client: Any | None = None) -> set[str]:
+    """Apps that currently resolve in the Modal environment a dispatch would reach.
 
     One hydrate per app, no containers started. Failures read as "not deployed"
     rather than propagating.
@@ -82,17 +82,26 @@ def deployed_apps() -> set[str]:
     The environment is named rather than inherited, and must be: a dispatch resolves
     ``proto-env`` while an unconfigured Modal profile resolves the workspace default, so asking
     ambiently reports on a different environment than the one a call would actually reach.
+
+    Args:
+        environment (str | None): Modal environment to look in. ``None`` resolves the default.
+        client (Any | None): Modal client to ask as. ``None`` uses the process's own credentials,
+            which is what a local caller wants; a server answering for someone else passes theirs,
+            or it would report its own deployments as though they were the caller's.
+
+    Returns:
+        set[str]: App names that resolve.
     """
     import modal
 
     from proto_tools.modal.app import resolve_environment
     from proto_tools.modal.manifest import APP_BUCKETS
 
-    environment = resolve_environment()
+    environment = resolve_environment(environment)
     live = set()
     for app_name, services in APP_BUCKETS.items():
         try:
-            modal.Cls.from_name(app_name, services[0], environment_name=environment).hydrate()
+            modal.Cls.from_name(app_name, services[0], environment_name=environment, client=client).hydrate()
             live.add(app_name)
         except Exception:  # noqa: S112 — an unreachable app is "not deployed", not an error
             continue

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -133,7 +133,7 @@ def test_an_in_process_tool_says_it_needs_no_deployment_and_why(monkeypatch):
     from proto_tools.mcp import tools as impl
 
     monkeypatch.setattr(impl, "_registry", dict)
-    monkeypatch.setattr(impl, "deployed_keys", lambda device: set())
+    monkeypatch.setattr(impl, "deployed_keys", lambda device, **_kwargs: set())
     monkeypatch.setattr(impl, "answered_in_process_keys", lambda: {"bindcraft-design"})
 
     entry = next(e for e in impl.list_tools(device="modal") if e["tool"] == "bindcraft-design")

--- a/tests/modal_tests/test_mcp_local_device.py
+++ b/tests/modal_tests/test_mcp_local_device.py
@@ -91,7 +91,7 @@ def test_a_deployed_tool_is_still_dispatched(monkeypatch) -> None:
 
     sent: dict[str, object] = {}
 
-    def fake_dispatch(tool_key, payload, cfg):
+    def fake_dispatch(tool_key, payload, cfg, **_kwargs):
         sent["tool"] = tool_key
         raise RuntimeError("dispatched")
 


### PR DESCRIPTION
Follow-on to the Modal identity work in #53. That made `dispatch_to_modal` able to act for a caller; this carries the same ability up to the MCP surface.

## The problem

`run_tool`, `list_tools`, `search_tools`, `deployed_keys`, `available_keys`, `workspace_info` and `deployed_apps` all took a `device` but no identity, so each answered for whichever Modal account the *process* happened to hold.

For a local stdio server that is correct: one process, one user. For a server answering on someone else's behalf it is wrong twice over. It would dispatch on its own credentials, and `list_tools(deployed_only=True)` would report its own deployed apps as though they were the caller's.

## The change

Each now takes `environment` and `client`, forwarded down to `dispatch_to_modal` and to the `Cls` lookups behind the deployed-app probe.

Omitted, they resolve from the process exactly as before, so notebooks, the CLI, the local stdio server and library callers are unchanged.

`workspace_info` additionally skips its `Client.from_env()` probe when a client is supplied, since a supplied client already carries credentials and the probe would otherwise report an authenticated caller as unauthenticated.

## Testing

309 passed in `modal_tests` under CI conditions (`HOME` pointed at an empty directory, so no ambient Modal credentials), ruff and format clean.

Two existing tests stubbed these functions with lambdas that did not accept keyword arguments, and were widened rather than reworked, since the behaviour they pin is unchanged.

One pre-existing failure, `test_deployment_packages_are_excluded_from_the_wheel`, needs `tomllib` and fails on Python 3.10 regardless of branch.

## Not in this PR

`deploy_tool` still deploys with the process's own credentials. Deploying on a caller's behalf goes through `deploy_app`, which shells out to the Modal CLI, so it needs credentials passed as subprocess environment rather than as a client. That is a separate mechanism and a separate change.