### PR TITLE
Make replayed progress attributable to the call that produced it

### DIFF
--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -555,6 +555,7 @@ def _dispatch(
     *,
     environment: str | None = None,
     client: Any | None = None,
+    progress_partition: str | None = None,
 ) -> tuple[Any, Device]:
     """Route one call to the backend ``device`` names, and report where it ran.
 
@@ -598,7 +599,12 @@ def _dispatch(
         return dispatch_to_proto(tool_key, payload, cfg), device
     from proto_tools.modal.client import dispatch_to_modal
 
-    return dispatch_to_modal(tool_key, payload, cfg, environment=environment, client=client), device
+    return (
+        dispatch_to_modal(
+            tool_key, payload, cfg, environment=environment, client=client, progress_partition=progress_partition
+        ),
+        device,
+    )
 
 
 def _unavailable(device: Device, tool_key: str, error: str) -> dict[str, Any]:
@@ -634,6 +640,7 @@ def run_tool(
     *,
     environment: str | None = None,
     client: Any | None = None,
+    progress_partition: str | None = None,
 ) -> dict[str, Any]:
     """Run a tool and return its result, with large fields written to disk.
 
@@ -685,7 +692,15 @@ def run_tool(
     if is_remote(device) and (reason := cfg.remote_unsupported_reason(device)) is not None:
         return {"ok": False, "error": reason, "not_supported_on": device}
     try:
-        result, ran_on = _dispatch(device, tool_key, payload, cfg, environment=environment, client=client)
+        result, ran_on = _dispatch(
+            device,
+            tool_key,
+            payload,
+            cfg,
+            environment=environment,
+            client=client,
+            progress_partition=progress_partition,
+        )
     except _setup_errors(device) as exc:
         return {"ok": False, **_unavailable(device, tool_key, str(exc))}
     except Exception as exc:

--- a/proto_tools/modal/client.py
+++ b/proto_tools/modal/client.py
@@ -346,6 +346,7 @@ def _live_progress(
     *,
     environment: str | None = None,
     client: Any | None = None,
+    partition: str | None = None,
 ) -> Iterator[None]:
     """Stream the workers' log output to this process for the duration of the block.
 
@@ -365,6 +366,9 @@ def _live_progress(
             per environment, so opening a different one leaves the tailer waiting on an empty
             queue while the container fills another.
         client (Any | None): Modal client to open and tail as, or ``None`` for the process's own.
+        partition (str | None): Queue partition to stream through. ``None`` mints one, which is
+            what a caller with a single call in flight wants. A caller serving several supplies
+            its own, so it can recognise its records among the rest.
     """
     present = [one for one in configs if one is not None]
     wanted = has_active_progress_bar() or verbose_level_from_env() > 0 or any(one.verbose > 0 for one in present)
@@ -376,7 +380,9 @@ def _live_progress(
     # started, and on a cold start that is several seconds of a motionless spinner.
     set_substatus(remote_connecting_status("modal"))
 
-    partition = uuid.uuid4().hex
+    # A caller that needs to recognise its own records supplies the partition; anyone else gets
+    # a fresh one and never has to know it exists.
+    partition = partition or uuid.uuid4().hex
     try:
         open_progress_queue(create=True, environment=environment, client=client)
     except Exception:  # a workspace that cannot host the queue simply gets no progress
@@ -416,6 +422,7 @@ def dispatch_to_modal(
     environment: str | None = None,
     scaledown_window: int | None = None,
     client: Any | None = None,
+    progress_partition: str | None = None,
 ) -> BaseToolOutput:
     """Run a tool on Modal apps deployed in the active workspace.
 
@@ -432,6 +439,8 @@ def dispatch_to_modal(
             in a session; see :func:`_bound_method`.
         client (Any | None): Modal client to dispatch as, for a caller acting on behalf of
             someone else. ``None`` lets Modal resolve the process's own credentials.
+        progress_partition (str | None): Queue partition progress streams through, so a caller
+            can recognise its own records. ``None`` mints one.
 
     Returns:
         BaseToolOutput: The validated tool output.
@@ -453,7 +462,10 @@ def dispatch_to_modal(
 
     config = _resolve_device(config, service_class)
     method = _bound_method(app_name, service_class, method_name, key, scaledown_window, environment=env, client=client)
-    with remote_progress("modal"), _live_progress([config], expected_ends=1, environment=env, client=client):
+    with (
+        remote_progress("modal"),
+        _live_progress([config], expected_ends=1, environment=env, client=client, partition=progress_partition),
+    ):
         result: dict[str, Any] = method.remote(
             input_dict=inputs.model_dump(mode="json"),
             config_dict=config.to_transport_dict() if config is not None else {},
@@ -469,6 +481,7 @@ def dispatch_batch_to_modal(
     environment: str | None = None,
     scaledown_window: int | None = None,
     client: Any | None = None,
+    progress_partition: str | None = None,
 ) -> list[BaseToolOutput | Exception]:
     """Run one tool over many inputs via Modal's ``starmap``, fanning out across containers.
 
@@ -484,6 +497,8 @@ def dispatch_batch_to_modal(
             overriding the deployed value.
         client (Any | None): Modal client to dispatch as, for a caller acting on behalf of
             someone else. ``None`` lets Modal resolve the process's own credentials.
+        progress_partition (str | None): Queue partition progress streams through, so a caller
+            can recognise its own records. ``None`` mints one.
 
     Returns:
         list[BaseToolOutput | Exception]: One entry per input, in input order. A chunk that failed
@@ -512,7 +527,9 @@ def dispatch_batch_to_modal(
     outputs: list[BaseToolOutput | Exception] = []
     with (
         remote_progress("modal"),
-        _live_progress(configs, expected_ends=len(inputs), environment=env, client=client),
+        _live_progress(
+            configs, expected_ends=len(inputs), environment=env, client=client, partition=progress_partition
+        ),
     ):
         args = [
             (item.model_dump(mode="json"), one.to_transport_dict() if one is not None else {})

--- a/proto_tools/modal/progress.py
+++ b/proto_tools/modal/progress.py
@@ -40,10 +40,8 @@ _END = "end"
 # a streamed line drives the bar exactly as the same line does in a local run.
 _remote_logger = logging.getLogger("proto_tools.modal.remote")
 
-# Attribute on a replayed record naming the call that produced it. Records reach the logger from a
-# tailer thread, so a process running one call at a time can ignore this, and one running several
-# needs it: without it a handler cannot tell two callers' output apart, and on a shared server that
-# is a leak rather than a display bug.
+# Attribute naming the call a replayed record came from. One call at a time can ignore it; a
+# process replaying for several callers cannot tell their output apart without it.
 CALL_ID_FIELD = "proto_call_id"
 
 
@@ -279,8 +277,7 @@ def stream_modal_progress(
         batch (int): Records to request per poll.
         poll_timeout (float): Seconds to block per poll.
     """
-    # The partition identifies this call, and is carried onto every record so a consumer serving
-    # more than one caller can tell whose output it is reading.
+    # The partition identifies this call, so it rides along on every record.
     consume = on_record or functools.partial(replay_record, call_id=partition)
     try:
         progress_queue = open_progress_queue(environment=environment, client=client)
@@ -314,10 +311,7 @@ def replay_record(record: dict[str, Any], call_id: str | None = None) -> None:
 
     Args:
         record (dict[str, Any]): One streamed record.
-        call_id (str | None): Which call produced it, stamped onto the emitted record. A local
-            session has one call in flight and can ignore it; a process replaying for several
-            callers at once cannot tell whose output a record is without it. See
-            :data:`CALL_ID_FIELD`.
+        call_id (str | None): Which call produced it, stamped on as :data:`CALL_ID_FIELD`.
     """
     message = record.get("m")
     if not message:

--- a/proto_tools/modal/progress.py
+++ b/proto_tools/modal/progress.py
@@ -6,6 +6,7 @@ Holds the container-side logging handler and drainer, and the client-side queue 
 from __future__ import annotations
 
 import contextlib
+import functools
 import logging
 import queue as queue_module
 import threading
@@ -38,6 +39,12 @@ _END = "end"
 # Records replay through the ``proto_tools`` namespace, where SpinnerFromLogsHandler is attached, so
 # a streamed line drives the bar exactly as the same line does in a local run.
 _remote_logger = logging.getLogger("proto_tools.modal.remote")
+
+# Attribute on a replayed record naming the call that produced it. Records reach the logger from a
+# tailer thread, so a process running one call at a time can ignore this, and one running several
+# needs it: without it a handler cannot tell two callers' output apart, and on a shared server that
+# is a leak rather than a display bug.
+CALL_ID_FIELD = "proto_call_id"
 
 
 # ============================================================================
@@ -272,7 +279,9 @@ def stream_modal_progress(
         batch (int): Records to request per poll.
         poll_timeout (float): Seconds to block per poll.
     """
-    consume = on_record or replay_record
+    # The partition identifies this call, and is carried onto every record so a consumer serving
+    # more than one caller can tell whose output it is reading.
+    consume = on_record or functools.partial(replay_record, call_id=partition)
     try:
         progress_queue = open_progress_queue(environment=environment, client=client)
     except Exception:
@@ -295,13 +304,20 @@ def stream_modal_progress(
                     consume(record)
 
 
-def replay_record(record: dict[str, Any]) -> None:
+def replay_record(record: dict[str, Any], call_id: str | None = None) -> None:
     """Re-emit one streamed record locally, into the spinner when there is one.
 
     With a bar on screen every record becomes its subtitle, so a long call reads as one line
     that keeps changing rather than a bar with output scrolling past it. Without a bar, records
     go to the logger as they would on the ``device='proto'`` path, carrying the ``update_status``
     flag so the same line behaves the same way.
+
+    Args:
+        record (dict[str, Any]): One streamed record.
+        call_id (str | None): Which call produced it, stamped onto the emitted record. A local
+            session has one call in flight and can ignore it; a process replaying for several
+            callers at once cannot tell whose output a record is without it. See
+            :data:`CALL_ID_FIELD`.
     """
     message = record.get("m")
     if not message:
@@ -313,5 +329,5 @@ def replay_record(record: dict[str, Any]) -> None:
         int(record.get("l", logging.INFO)),
         "%s",
         message,
-        extra={"update_status": bool(record.get("s", False))},
+        extra={"update_status": bool(record.get("s", False)), CALL_ID_FIELD: call_id},
     )

--- a/proto_tools/proto/__init__.py
+++ b/proto_tools/proto/__init__.py
@@ -185,8 +185,7 @@ def _stream_remote_logs(client: Any, key: str, job_id: str, verbose: int) -> Non
             py_level = _RFC5424_TO_PY_LEVEL.get(getattr(rec, "level", "info"), logging.INFO)
             # Replay the phase flag so the local SpinnerFromLogsHandler drives the bar, exactly like a local run.
             # Strip the worker logger-name prefix from every line so cloud output reads identically to local.
-            # The job id identifies this call, carried onto every record so a consumer serving
-            # more than one caller can tell whose output it is reading.
+            # The job id identifies this call, so it rides along on every record.
             _remote_logger.log(
                 py_level,
                 "%s",

--- a/proto_tools/proto/__init__.py
+++ b/proto_tools/proto/__init__.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from proto_tools.modal.progress import CALL_ID_FIELD
 from proto_tools.tools.tool_registry import ToolRegistry
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.logging_config import verbose_level_from_env
@@ -184,7 +185,14 @@ def _stream_remote_logs(client: Any, key: str, job_id: str, verbose: int) -> Non
             py_level = _RFC5424_TO_PY_LEVEL.get(getattr(rec, "level", "info"), logging.INFO)
             # Replay the phase flag so the local SpinnerFromLogsHandler drives the bar, exactly like a local run.
             # Strip the worker logger-name prefix from every line so cloud output reads identically to local.
-            _remote_logger.log(py_level, "%s", _strip_logger_prefix(msg), extra={"update_status": update_status})
+            # The job id identifies this call, carried onto every record so a consumer serving
+            # more than one caller can tell whose output it is reading.
+            _remote_logger.log(
+                py_level,
+                "%s",
+                _strip_logger_prefix(msg),
+                extra={"update_status": update_status, CALL_ID_FIELD: job_id},
+            )
     except Exception as exc:
         logger.debug("Remote log stream for job %s ended: %s", job_id, exc, exc_info=True)
 

--- a/tests/modal_tests/test_progress_call_id.py
+++ b/tests/modal_tests/test_progress_call_id.py
@@ -1,0 +1,126 @@
+"""Replayed progress records name the call that produced them.
+
+Both remote paths replay a worker's output through a module-level logger: ``device='modal'`` from
+a Modal queue partition, ``device='proto'`` from the server's NDJSON log stream. A session with
+one call in flight needs nothing more, and that is the case these were written for.
+
+A process replaying for several callers at once is a different matter. Without a call id on the
+record, a handler cannot tell two callers' output apart, and progress lines carry sequence names,
+file names and tool parameters — so on a shared server that is a leak rather than a display bug.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from proto_tools.modal.progress import CALL_ID_FIELD, replay_record
+
+
+class _Capture(logging.Handler):
+    """Collects records the way a consumer forwarding progress would."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capture(logger_name: str) -> tuple[_Capture, logging.Logger]:
+    handler = _Capture()
+    logger = logging.getLogger(logger_name)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    return handler, logger
+
+
+def test_a_replayed_record_carries_its_call_id(monkeypatch):
+    """The whole point: a consumer must be able to tell whose output a record is."""
+    monkeypatch.setattr("proto_tools.modal.progress.has_active_progress_bar", lambda: False)
+    handler, logger = _capture("proto_tools.modal.remote")
+    try:
+        replay_record({"m": "Running esmfold", "l": logging.INFO}, call_id="partition-abc")
+    finally:
+        logger.removeHandler(handler)
+
+    assert len(handler.records) == 1
+    assert getattr(handler.records[0], CALL_ID_FIELD) == "partition-abc"
+
+
+def test_two_calls_are_distinguishable_on_one_logger(monkeypatch):
+    """Records from concurrent callers share a logger, so the id is the only thing separating them."""
+    monkeypatch.setattr("proto_tools.modal.progress.has_active_progress_bar", lambda: False)
+    handler, logger = _capture("proto_tools.modal.remote")
+    try:
+        replay_record({"m": "alice's sequence", "l": logging.INFO}, call_id="alice")
+        replay_record({"m": "bob's sequence", "l": logging.INFO}, call_id="bob")
+    finally:
+        logger.removeHandler(handler)
+
+    by_call = {getattr(r, CALL_ID_FIELD): r.getMessage() for r in handler.records}
+    assert by_call == {"alice": "alice's sequence", "bob": "bob's sequence"}
+
+
+def test_a_local_session_still_works_without_one(monkeypatch):
+    """A caller with one call in flight has nothing to attribute and must not be made to care."""
+    monkeypatch.setattr("proto_tools.modal.progress.has_active_progress_bar", lambda: False)
+    handler, logger = _capture("proto_tools.modal.remote")
+    try:
+        replay_record({"m": "Running esmfold", "l": logging.INFO})
+    finally:
+        logger.removeHandler(handler)
+
+    assert len(handler.records) == 1
+    assert getattr(handler.records[0], CALL_ID_FIELD) is None
+
+
+def test_the_spinner_path_is_unchanged(monkeypatch):
+    """With a bar on screen a record becomes its subtitle and never reaches the logger."""
+    seen: list[str] = []
+    monkeypatch.setattr("proto_tools.modal.progress.has_active_progress_bar", lambda: True)
+    monkeypatch.setattr("proto_tools.modal.progress.update_active_substatus", seen.append)
+    handler, logger = _capture("proto_tools.modal.remote")
+    try:
+        replay_record({"m": "Running esmfold", "l": logging.INFO}, call_id="partition-abc")
+    finally:
+        logger.removeHandler(handler)
+
+    assert seen == ["Running esmfold"]
+    assert not handler.records
+
+
+def test_the_tailer_stamps_the_partition_it_is_reading(monkeypatch):
+    """The id has to arrive without the caller passing one, since the tailer owns the partition."""
+    import queue as queue_module
+    import threading
+
+    from proto_tools.modal import progress
+
+    class _Queue:
+        def __init__(self) -> None:
+            self.served = False
+
+        def get_many(self, *_args, **_kwargs):
+            if self.served:
+                raise queue_module.Empty
+            self.served = True
+            return [{"m": "Running esmfold", "l": logging.INFO}, {"t": "end"}]
+
+    monkeypatch.setattr(progress, "open_progress_queue", lambda **_kwargs: _Queue())
+    monkeypatch.setattr(progress, "has_active_progress_bar", lambda: False)
+    handler, logger = _capture("proto_tools.modal.remote")
+    try:
+        progress.stream_modal_progress("partition-xyz", expected_ends=1, stop=threading.Event())
+    finally:
+        logger.removeHandler(handler)
+
+    assert handler.records, "the tailer replayed nothing"
+    assert getattr(handler.records[0], CALL_ID_FIELD) == "partition-xyz"
+
+
+def test_both_remote_paths_agree_on_the_field_name():
+    """One name, imported rather than duplicated, so the two paths cannot drift apart."""
+    from proto_tools.proto import CALL_ID_FIELD as proto_field
+
+    assert proto_field == CALL_ID_FIELD

--- a/tests/modal_tests/test_progress_call_id.py
+++ b/tests/modal_tests/test_progress_call_id.py
@@ -124,3 +124,72 @@ def test_both_remote_paths_agree_on_the_field_name():
     from proto_tools.proto import CALL_ID_FIELD as proto_field
 
     assert proto_field == CALL_ID_FIELD
+
+
+# --------------------------------------------------------------------------
+# A caller supplying its own partition
+# --------------------------------------------------------------------------
+
+
+def test_a_caller_can_name_the_partition_it_will_listen_on(monkeypatch):
+    """Stamping records is only half of it: a caller must know which id is its own.
+
+    The partition is minted inside ``_live_progress``, and nothing returned it, so a process
+    serving several callers received correctly-stamped records it still could not attribute.
+    Supplying the partition closes that.
+    """
+    from proto_tools.modal import client as client_module
+
+    seen: dict[str, str | None] = {}
+
+    def fake_live_progress(_configs, *, expected_ends=1, environment=None, client=None, partition=None):
+        seen["partition"] = partition
+        import contextlib
+
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(client_module, "_live_progress", fake_live_progress)
+    monkeypatch.setattr(client_module, "resolve_tool", lambda _k: ("app", "Service", "run"))
+    monkeypatch.setattr(client_module, "_require_modal_credentials", lambda _c=None: None)
+    monkeypatch.setattr(client_module, "_warn_once_on_drift", lambda *_a, **_k: None)
+    monkeypatch.setattr(client_module, "_warn_once_if_long_running", lambda *_a, **_k: None)
+    monkeypatch.setattr(client_module, "_resolve_device", lambda cfg, _s: cfg)
+    monkeypatch.setattr(client_module, "_validated_output", lambda _k, r: r)
+
+    class _Method:
+        @staticmethod
+        def remote(**_kwargs):
+            return {}
+
+    monkeypatch.setattr(client_module, "_bound_method", lambda *_a, **_k: _Method)
+
+    class _Inputs:
+        @staticmethod
+        def model_dump(**_kwargs):
+            return {}
+
+    client_module.dispatch_to_modal("esm2-embedding", _Inputs(), None, progress_partition="mine-123")
+
+    assert seen["partition"] == "mine-123"
+
+
+def test_omitting_it_still_mints_one(monkeypatch):
+    """A local caller must not have to invent an id it will never look at."""
+    from proto_tools.modal import progress
+
+    class _Queue:
+        def hydrate(self):
+            return None
+
+    monkeypatch.setattr(progress, "open_progress_queue", lambda **_k: _Queue())
+    from proto_tools.modal import client as client_module
+
+    monkeypatch.setattr(client_module, "has_active_progress_bar", lambda: True)
+    monkeypatch.setattr(client_module, "open_progress_queue", lambda **_k: _Queue())
+
+    from proto_tools.utils.base_config import BaseConfig
+
+    config = BaseConfig(verbose=1)
+    with client_module._live_progress([config], expected_ends=1):
+        assert config._progress_partition, "no partition was minted"
+        assert len(config._progress_partition) == 32, "expected a uuid4 hex"


### PR DESCRIPTION
Prerequisite for streaming tool progress from a hosted MCP server. Two halves of one problem, and nothing changes for a local session.

## The problem

Both remote paths replay a worker's output through a module-level logger:

- `device='modal'` — `stream_modal_progress` tails a Modal queue partition, replays through `proto_tools.modal.remote`
- `device='proto'` — `_stream_remote_logs` reads the server's NDJSON stream, replays through `proto_tools.proto.remote`

Each record carried only `extra={"update_status": ...}`. For a session with one call in flight that is exactly right, and is what these were written for.

A process replaying for **several callers at once** cannot use them. Nothing on a record says which call produced it, so a handler receives every concurrent caller's output interleaved with no way to separate it.

That is worse than a display glitch. Progress lines carry sequence names, file names and tool parameters, so on a shared server the interleaving is a **leak between tenants**.

## Half one: name the call on each record

Each path stamps the identifier it already owns — the queue partition for modal, the job id for proto:

```python
extra={"update_status": ..., CALL_ID_FIELD: call_id}
```

Both import one `CALL_ID_FIELD` rather than defining their own, so they cannot drift.

## Half two: let a caller name the partition

Stamping alone is not enough. The partition was minted inside `_live_progress` and never returned, so a server would receive correctly-labelled records and still not know **which label was its own** — the same problem one step further along.

`dispatch_to_modal`, `dispatch_batch_to_modal` and `run_tool` now accept `progress_partition` and thread it down. A caller that needs to recognise its records supplies one; everyone else omits it and gets a fresh uuid exactly as before.

## Nothing changes locally

`replay_record`'s `call_id` and every `progress_partition` default to `None`. A direct caller is unaffected, and the spinner path is untouched: with a bar on screen a record still becomes its subtitle and never reaches the logger.

## Scope

Modal only. `device='proto'` streams under a job id the server assigns, which `submit()` does not surface, so that side needs its own change and is deliberately not half-done here.

## Testing

Eight tests: the stamp, two concurrent calls being distinguishable on one logger, the local no-id case, the spinner path, the tailer stamping its own partition unprompted, both paths agreeing on the field name, a supplied partition reaching `_live_progress`, and omission still minting one.

Mutation-verified: removing the stamp fails four of them.

1915 passed in `modal_tests` + `tool_infra_tests`, 8695 in `style_consistency_tests`, ruff clean, mypy clean on all touched files. One pre-existing failure, `test_deployment_packages_are_excluded_from_the_wheel`, needs `tomllib` and fails on Python 3.10 regardless of branch.