### PR TITLE
Deploy into a caller's Modal workspace, and return drift to the caller

### DIFF
--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -7,9 +7,12 @@ import logging
 import os
 from collections.abc import Callable, Coroutine
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from proto_tools.mcp.device import Device, is_remote
+
+if TYPE_CHECKING:  # imported for the annotation only; the runtime import stays inside deploy_tool
+    from proto_tools.modal.deploy import ModalTokens
 from proto_tools.utils.base_config import BaseConfig
 from proto_tools.utils.modal_status import credentials_checked, deployed_apps
 
@@ -711,7 +714,37 @@ def run_tool(
     saved = [v["_saved_to"] for v in _walk_saved(body)]
     # ``ran_on`` because the two can differ: a tool that cannot run remotely is answered here even
     # in a Modal session, and the caller should not have to infer that from the timing.
-    return {"ok": True, "tool": tool_key, "ran_on": ran_on, "result": body, "saved_files": saved}
+    answer = {"ok": True, "tool": tool_key, "ran_on": ran_on, "result": body, "saved_files": saved}
+    if drift := drift_for(tool_key, ran_on, environment=environment, client=client):
+        answer["warnings"] = drift
+    return answer
+
+
+def drift_for(tool_key: str, ran_on: Device, *, environment: str | None = None, client: Any | None = None) -> list[str]:
+    """Return drift warnings for a call that went to Modal, empty for one that did not.
+
+    The dispatch path warns about drift too, but through ``warnings.warn`` and only once per
+    process. That is right for a session on someone's laptop and wrong everywhere else: an MCP
+    caller never sees the process's warnings, and on a server the first caller to reach a stale
+    deployment consumes the warning for everyone after them. Returning it makes drift part of the
+    answer, so every caller who is affected is told.
+
+    Never raises -- :func:`drift_warnings` swallows its own failures, and a check that broke a
+    successful run would be worse than a missed warning.
+    """
+    if ran_on != "modal":
+        return []
+    from proto_tools.modal.app import resolve_environment
+    from proto_tools.modal.fingerprint import drift_warnings
+
+    try:
+        service, _method = _registry()[tool_key]
+    except KeyError:
+        return []
+    # Resolved, because the dispatch resolved it too: a caller who named no environment ran in
+    # proto-env, and reading the manifest from the ambient one compares against a deployment they
+    # never called. Unresolved, this reports nothing in exactly the default configuration.
+    return drift_warnings(tool_key, service, environment=resolve_environment(environment), client=client)
 
 
 def _walk_saved(node: Any) -> list[dict[str, Any]]:
@@ -729,7 +762,12 @@ def _walk_saved(node: Any) -> list[dict[str, Any]]:
 
 
 async def deploy_tool(
-    tool_key: str, environment: str, report: Callable[[str], Coroutine[Any, Any, None]]
+    tool_key: str,
+    environment: str,
+    report: Callable[[str], Coroutine[Any, Any, None]],
+    *,
+    tokens: ModalTokens | None = None,
+    client: Any | None = None,
 ) -> dict[str, Any]:
     """Deploy the Modal app serving one tool, after the caller has approved the spend.
 
@@ -740,14 +778,24 @@ async def deploy_tool(
 
     Args:
         tool_key (str): Tool whose serving app to deploy.
-        environment (str): Modal environment to deploy into.
+        environment (str): Modal environment to deploy into. Resolved the same way a dispatch
+            resolves it, so a deploy and the call that follows it name the same place.
         report (Callable[[str], Coroutine[Any, Any, None]]): Awaited with each build phase.
+        tokens (ModalTokens | None): Deploy into the workspace these tokens name rather than this
+            process's own. A server deploying for a caller passes theirs; a local session leaves
+            this unset, because its workspace is already the caller's.
+        client (Any | None): Modal client for recording fingerprints, opened from ``tokens`` when
+            not given.
 
     Returns:
-        dict[str, Any]: ``ok`` plus the app deployed, or an error.
+        dict[str, Any]: ``ok`` plus the app deployed, or an error carrying the end of the build
+            output, since a caller who is not on this machine cannot read the log themselves.
     """
     import asyncio
+    import contextlib
+    import tempfile
 
+    from proto_tools.modal.app import resolve_environment
     from proto_tools.modal.deploy import deploy_app
 
     try:
@@ -755,14 +803,56 @@ async def deploy_tool(
     except KeyError:
         return {"ok": False, "error": f"{tool_key!r} is not a tool this deployment serves."}
 
+    # ``modal deploy`` omits --env entirely for an empty or absent name, which lands the app in
+    # whichever environment the tokens make active. A dispatch resolves to proto-env instead, so
+    # unresolved the caller watches a deploy succeed and the next call miss it.
+    environment = resolve_environment(environment)
+
     loop = asyncio.get_running_loop()
 
     def emit(phase: str) -> None:
-        # Called from the reader thread; hop back to the loop to send the notification.
-        asyncio.run_coroutine_threadsafe(report(phase), loop)
+        # Called from the reader thread; hop back to the loop to send the notification. A caller
+        # who disconnected mid-build leaves a closed loop, and raising here would abandon the
+        # subprocess unwaited rather than let the deploy they paid for finish.
+        with contextlib.suppress(RuntimeError):
+            asyncio.run_coroutine_threadsafe(report(phase), loop)
 
     await report(f"deploying {app} to {environment}")
-    ok = await asyncio.to_thread(deploy_app, app, environment, emit)
-    if not ok:
-        return {"ok": False, "app": app, "error": "deploy failed; see logs/deploy.*.log for the build output"}
+    # A directory per deploy, so concurrent callers deploying the same app do not share a log file.
+    with tempfile.TemporaryDirectory(prefix="proto-tools-deploy-log-") as logs:
+        ok = await asyncio.to_thread(
+            deploy_app, app, environment, emit, tokens=tokens, client=client, log_dir=Path(logs)
+        )
+        if not ok:
+            return {"ok": False, "app": app, "error": "deploy failed", "build_output": _log_tail(Path(logs))}
     return {"ok": True, "app": app, "environment": environment, "tool": tool_key}
+
+
+#: Lines of build output returned when a deploy fails. Enough for the traceback Modal ends on,
+#: short enough not to bury the rest of the response.
+_LOG_TAIL_LINES = 40
+
+
+def _log_tail(logs: Path) -> str:
+    """Return the end of a deploy log, stripped of the frames that redraw a build tree.
+
+    A build renders an animated tree, so the raw log is mostly the same lines written over and
+    over. Reading it back means dropping those, or the tail is entirely spinner frames.
+
+    The colour codes and the spinner glyph go too. ``for_display`` keeps both, because in a
+    terminal they are what makes the build readable and show it is alive. Nothing here is watching
+    it animate, so they are only noise around the message an agent has to read.
+    """
+    from proto_tools.modal.deploy import _ANSI_ESCAPE, _SPINNER_FRAME, RecentLines, for_display
+
+    lines: list[str] = []
+    for log in sorted(logs.glob("deploy.*.log")):
+        try:
+            raw = log.read_text(errors="replace")
+        except OSError:
+            continue
+        seen = RecentLines()
+        shown = (for_display(line + "\n", seen) for line in raw.splitlines())
+        plain = (_ANSI_ESCAPE.sub("", text) for text in shown if text is not None)
+        lines += [_SPINNER_FRAME.sub("", text).rstrip() for text in plain]
+    return "\n".join(line for line in lines[-_LOG_TAIL_LINES:] if line)

--- a/proto_tools/modal/deploy.py
+++ b/proto_tools/modal/deploy.py
@@ -95,16 +95,6 @@ _DEPLOY_ENV_PASSTHROUGH = (
     "PROTO_MODAL_TIMEOUT_SCALE",
 )
 
-# Five variables are absent from that list because their absence is the point rather than an
-# oversight, and each makes a deployment something other than stock proto-tools:
-# PROTO_MODAL_WORKER_PLUGINS runs arbitrary code in the container, PROTO_MODAL_EXTRA_SOURCE,
-# PROTO_MODAL_EXTRA_PACKAGES and PROTO_MODAL_PROTO_TOOLS add code to the image, and
-# PROTO_MODAL_SECRETS attaches credentials the deploying process holds. A caller deploying into
-# their own workspace gets proto-tools as published, with nothing of the server's attached.
-#
-# PROTO_MODAL_HF_SECRET is absent for a different reason -- deploy_environ sets it rather than
-# dropping it, because unset is the dangerous value. See that function.
-
 
 def deploy_environ(tokens: ModalTokens | None) -> dict[str, str] | None:
     """Build the environment a ``modal deploy`` subprocess runs under.

--- a/proto_tools/modal/deploy.py
+++ b/proto_tools/modal/deploy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import importlib.util
 import io
 import os
@@ -14,6 +15,7 @@ from collections import deque
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
 from proto_tools.modal.app import DEFAULT_ENVIRONMENT, resolve_environment
 from proto_tools.modal.manifest import APP_BUCKETS, SERVICE_TO_MODULE, app_name_for_slug, app_slug, module_name
@@ -31,6 +33,101 @@ Each tool is its own Modal app, so you deploy only what you need.
 Apps go to the 'proto-env' environment unless --env names another one, or
 MODAL_ENVIRONMENT is set. Create it with: modal environment create proto-env
 """
+
+
+@dataclasses.dataclass(frozen=True)
+class ModalTokens:
+    """A Modal token pair, for deploying into a workspace that is not this process's own.
+
+    ``modal deploy`` is a subprocess, so it authenticates by environment rather than by the client
+    object every other Modal call here takes. That makes this the one place a caller's raw
+    credentials are handled, hence the redacting ``__repr__``: a deploy failure raises
+    :class:`subprocess.CalledProcessError`, whose string form carries the command it ran.
+    """
+
+    token_id: str
+    token_secret: str
+    hf_secret: str | None = None
+    """Modal secret in the caller's own workspace holding their HuggingFace token, if they have
+    one. A name rather than a token: it resolves where the app is being deployed, so a caller's
+    token stays in their account and is never sent here. ``None`` deploys anonymously."""
+
+    def __repr__(self) -> str:
+        """Name the token without printing it, so a traceback cannot leak the pair."""
+        return (
+            f"ModalTokens(token_id={self.token_id[:8]!r}..., token_secret='<redacted>', hf_secret={self.hf_secret!r})"
+        )
+
+    def client(self) -> Any:
+        """Open a Modal client for these tokens, for the calls that take one rather than an env."""
+        import modal
+
+        return modal.Client.from_credentials(self.token_id, self.token_secret)
+
+
+# Variables a deploy-as-someone-else subprocess inherits. An allowlist rather than a denylist: this
+# is the boundary between the process's own environment and a caller's build, and a variable added
+# to a deployment later should have to be named here to cross it.
+#
+# The proxy variables and certificate bundles are how a deploy reaches Modal at all on a network
+# that requires them; the PROTO_ ones change what gets built and so must match what this process
+# would have built for itself.
+_DEPLOY_ENV_PASSTHROUGH = (
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "PYTHONPATH",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "PROTO_HOME",
+    "PROTO_MODAL_CACHE_VOLUME",
+    "PROTO_MODAL_SCALEDOWN_WINDOW",
+    "PROTO_MODAL_TIMEOUT_SCALE",
+)
+
+# Five variables are absent from that list because their absence is the point rather than an
+# oversight, and each makes a deployment something other than stock proto-tools:
+# PROTO_MODAL_WORKER_PLUGINS runs arbitrary code in the container, PROTO_MODAL_EXTRA_SOURCE,
+# PROTO_MODAL_EXTRA_PACKAGES and PROTO_MODAL_PROTO_TOOLS add code to the image, and
+# PROTO_MODAL_SECRETS attaches credentials the deploying process holds. A caller deploying into
+# their own workspace gets proto-tools as published, with nothing of the server's attached.
+#
+# PROTO_MODAL_HF_SECRET is absent for a different reason -- deploy_environ sets it rather than
+# dropping it, because unset is the dangerous value. See that function.
+
+
+def deploy_environ(tokens: ModalTokens | None) -> dict[str, str] | None:
+    """Build the environment a ``modal deploy`` subprocess runs under.
+
+    Returns ``None`` when no tokens are given, which leaves the subprocess inheriting this
+    process's environment -- correct for the CLI, where the deploying workspace is the caller's
+    own and the two environments are the same thing.
+
+    With tokens, the caller is someone else, and inheriting would hand them whatever this process
+    holds. The subprocess gets the allowlist, the tokens, and nothing else.
+
+    The HuggingFace secret is named explicitly rather than left to fall through, because
+    falling through reads this machine's token. A caller who manages one in their own workspace
+    gets it attached; a caller who does not deploys anonymously, which is the same thing an
+    unauthenticated ``modal deploy`` would do.
+    """
+    if tokens is None:
+        return None
+    env = {name: os.environ[name] for name in _DEPLOY_ENV_PASSTHROUGH if name in os.environ}
+    env["MODAL_TOKEN_ID"] = tokens.token_id
+    env["MODAL_TOKEN_SECRET"] = tokens.token_secret
+    env["PROTO_MODAL_HF_SECRET"] = tokens.hf_secret or "none"
+    return env
 
 
 def render_entrypoint(app_name: str, services: list[str]) -> str:
@@ -175,6 +272,10 @@ def deploy_app(
     environment: str | None = None,
     on_progress: Callable[[str], None] | None = None,
     verbose: bool = False,
+    *,
+    tokens: ModalTokens | None = None,
+    client: Any | None = None,
+    log_dir: Path | None = None,
 ) -> bool:
     """Deploy one app, rendering its entrypoint fresh from the manifest.
 
@@ -190,24 +291,37 @@ def deploy_app(
             description as the build moves through it. A deploy takes minutes, so a
             caller with no other output needs this to show it has not hung.
         verbose (bool): Stream every line of Modal's output rather than one line per phase.
+        tokens (ModalTokens | None): Deploy into the workspace these tokens name rather than
+            this process's own, with a build environment holding nothing of this process's.
+        client (Any | None): Modal client for recording fingerprints, opened from ``tokens``
+            when not given. A server that already holds a client for this caller should pass it:
+            ``Client.from_credentials`` registers a shutdown hook rather than closing, so one
+            opened per deploy stays open for the life of the process.
+        log_dir (Path | None): Where to write the deploy log, or ``None`` for ``./logs``. A
+            server deploying for several callers gives each one a directory of its own, since
+            the default names the log after the app and two callers deploying the same app
+            would otherwise overwrite each other.
 
     Returns:
         bool: Whether the deploy succeeded.
     """
-    logs_dir = _logs_dir()
+    logs_dir = log_dir if log_dir is not None else _logs_dir()
     logs_dir.mkdir(exist_ok=True, parents=True)
     log_file = logs_dir / f"deploy.{app_slug(app_name)}.log"
 
     with tempfile.TemporaryDirectory(prefix="proto-tools-deploy-") as scratch:
         entrypoint = Path(scratch) / f"{module_name(app_name)}.py"
         entrypoint.write_text(render_entrypoint(app_name, APP_BUCKETS[app_name]))
-        deployed = _run_modal_deploy(app_name, entrypoint, environment, log_file, on_progress, verbose)
+        deployed = _run_modal_deploy(app_name, entrypoint, environment, log_file, on_progress, verbose, tokens)
 
     # Recorded here rather than by the caller, so every route that deploys gets drift detection.
     # An absent manifest reads as "nothing to report", so a path that skipped this would leave the
     # app permanently exempt from the check rather than visibly missing it.
+    #
+    # Written as whoever deployed. Recording against this process's workspace instead would leave
+    # the caller's deployment unfingerprinted and permanently exempt from the drift check.
     if deployed:
-        record_fingerprints([app_name], environment)
+        record_fingerprints([app_name], environment, client=client, tokens=tokens)
     return deployed
 
 
@@ -218,6 +332,7 @@ def _run_modal_deploy(
     log_file: Path,
     on_progress: Callable[[str], None] | None = None,
     verbose: bool = False,
+    tokens: ModalTokens | None = None,
 ) -> bool:
     """Run ``modal deploy`` for one entrypoint, reporting its progress prefixed by app.
 
@@ -230,7 +345,14 @@ def _run_modal_deploy(
     last_phase: str | None = None
     try:
         with open(log_file, "w") as f:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=deploy_environ(tokens),
+            )
             for line in process.stdout or ():
                 f.write(line)  # the log keeps the raw stream, redraw frames and all
                 phase = describe_progress(_ANSI_ESCAPE.sub("", line))
@@ -266,19 +388,44 @@ def deploy_apps(
     return results
 
 
-def record_fingerprints(app_names: list[str], environment: str | None) -> None:
+def record_fingerprints(
+    app_names: list[str],
+    environment: str | None,
+    *,
+    client: Any | None = None,
+    tokens: ModalTokens | None = None,
+) -> None:
     """Record what each app was built from, so clients can detect drift later.
 
     Runs from the same source that was just deployed, so the recorded values
     describe what actually shipped. Best-effort: a failure here leaves a working
     deployment with no drift detection, which beats failing the deploy.
+
+    Args:
+        app_names (list[str]): Apps whose services to record.
+        environment (str | None): Modal environment holding the cache volume.
+        client (Any | None): Modal client to write as, or ``None`` for the process's own. Must
+            name the workspace that was deployed into, or the record describes one deployment
+            while the drift check reads another.
+        tokens (ModalTokens | None): Opened for a client when ``client`` is not given, so a
+            caller's deploy records into their workspace rather than this process's.
     """
     from proto_tools.modal.fingerprint import write_manifest
+
+    if client is None and tokens is not None:
+        try:
+            client = tokens.client()
+        except Exception as exc:
+            # Skipped rather than recorded as this process. Falling back would describe the
+            # caller's deployment on this process's own cache volume, where their drift check
+            # will never look and this one would read it as a deployment of its own.
+            print(f"  ⚠️  could not record fingerprints ({exc})")
+            return
 
     for app_name in sorted(app_names):
         for service in APP_BUCKETS[app_name]:
             try:
-                write_manifest(service, environment)
+                write_manifest(service, environment, client=client)
             except Exception as exc:
                 # Only the failure is worth saying. Recording fingerprints is bookkeeping the
                 # caller did not ask for, and announcing it pushes the deploy result off the end.

--- a/proto_tools/modal/fingerprint.py
+++ b/proto_tools/modal/fingerprint.py
@@ -196,12 +196,19 @@ def manifest_path(service_class: str) -> str:
     return f"{_MANIFEST_DIR}/{service_class}.json"
 
 
-def write_manifest(service_class: str, environment: str | None = None) -> int:
+def write_manifest(service_class: str, environment: str | None = None, client: Any | None = None) -> int:
     """Record the local fingerprints of ``service_class`` onto the cache volume.
 
     Called after a successful deploy, from the same checkout that was deployed,
     so the recorded values describe what actually shipped. Returns the number of
     tools recorded.
+
+    Args:
+        service_class (str): Service whose fingerprints to record.
+        environment (str | None): Modal environment holding the cache volume.
+        client (Any | None): Modal client to write as, or ``None`` for the process's own. Pairs
+            with the same argument on :func:`read_manifest`: a deploy made on someone's behalf
+            must record into their workspace, which is the only one that will read it back.
     """
     import io
 
@@ -217,7 +224,9 @@ def write_manifest(service_class: str, environment: str | None = None) -> int:
 
     from proto_tools.modal.app import CACHE_VOLUME_NAME
 
-    volume = modal.Volume.from_name(CACHE_VOLUME_NAME, environment_name=environment, create_if_missing=True)
+    volume = modal.Volume.from_name(
+        CACHE_VOLUME_NAME, environment_name=environment, client=client, create_if_missing=True
+    )
     with volume.batch_upload(force=True) as batch:
         batch.put_file(io.BytesIO(payload), manifest_path(service_class))
     return len(fps)

--- a/tests/modal_tests/test_deploy_as_caller.py
+++ b/tests/modal_tests/test_deploy_as_caller.py
@@ -1,24 +1,14 @@
 """Deploying into someone else's Modal workspace hands them nothing of the deploying process's.
 
-``modal deploy`` is a subprocess, so unlike every other Modal call here it authenticates by
-environment rather than by a client object. A subprocess inherits its parent's environment by
-default, which for a server deploying on a caller's behalf means handing over whatever that server
-holds: object-store credentials, a database URL, an API key.
+``modal deploy`` is a subprocess, so it authenticates by environment rather than by a client
+object, and a subprocess inherits its parent's environment by default. Given tokens it gets an
+allowlist instead, and these pin what crosses, what does not, and that the subprocess really runs
+under it.
 
-Worse than the secrets is what the inherited variables would *build*. proto-tools reads several of
-them to extend a deployment -- worker plugins that run arbitrary code in the container, extra
-source and packages added to the image, and named secrets attached to the service. A deploy that
-inherited those would build the deploying process's private variant of a tool inside the caller's
-workspace.
+Variable names are literals on purpose: read back from the module under test, moving one into the
+allowlist would shrink the test set instead of failing it.
 
-So a credentialed deploy gets an allowlist and nothing else, and these pin that: what crosses, what
-does not, and that the subprocess is actually run under it.
-
-Every variable name below is a literal on purpose. Reading them back from the module under test
-would make it its own oracle: moving a name into the allowlist -- the exact regression these exist
-to catch -- would shrink the test set instead of failing it.
-
-Offline throughout: no deploy is run, only the environment one would run under.
+Offline throughout -- no deploy is run, only the environment one would run under.
 """
 
 from __future__ import annotations

--- a/tests/modal_tests/test_deploy_as_caller.py
+++ b/tests/modal_tests/test_deploy_as_caller.py
@@ -1,0 +1,276 @@
+"""Deploying into someone else's Modal workspace hands them nothing of the deploying process's.
+
+``modal deploy`` is a subprocess, so unlike every other Modal call here it authenticates by
+environment rather than by a client object. A subprocess inherits its parent's environment by
+default, which for a server deploying on a caller's behalf means handing over whatever that server
+holds: object-store credentials, a database URL, an API key.
+
+Worse than the secrets is what the inherited variables would *build*. proto-tools reads several of
+them to extend a deployment -- worker plugins that run arbitrary code in the container, extra
+source and packages added to the image, and named secrets attached to the service. A deploy that
+inherited those would build the deploying process's private variant of a tool inside the caller's
+workspace.
+
+So a credentialed deploy gets an allowlist and nothing else, and these pin that: what crosses, what
+does not, and that the subprocess is actually run under it.
+
+Every variable name below is a literal on purpose. Reading them back from the module under test
+would make it its own oracle: moving a name into the allowlist -- the exact regression these exist
+to catch -- would shrink the test set instead of failing it.
+
+Offline throughout: no deploy is run, only the environment one would run under.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from proto_tools.modal.deploy import ModalTokens, deploy_app, deploy_environ, record_fingerprints
+
+TOKENS = ModalTokens("ak-tokenid", "as-tokensecret")
+
+#: Variables that turn a deployment into something other than stock proto-tools. Spelled out
+#: rather than imported: these names are the requirement, not whatever the module currently lists.
+EXTENSIONS = (
+    "PROTO_MODAL_WORKER_PLUGINS",
+    "PROTO_MODAL_EXTRA_SOURCE",
+    "PROTO_MODAL_EXTRA_PACKAGES",
+    "PROTO_MODAL_SECRETS",
+    "PROTO_MODAL_PROTO_TOOLS",
+)
+
+#: Credentials a server running this genuinely has set, none of them a caller's business.
+HOST_SECRETS = {
+    "AWS_ACCESS_KEY_ID": "AKIAEXAMPLE",
+    "AWS_SECRET_ACCESS_KEY": "wJalrEXAMPLEKEY",
+    "REDIS_URL": "redis://cache:6379",
+    "DATABASE_URL": "postgres://db/records",
+    "PROTO_API_KEY": "pk-hostkey",
+}
+
+
+class _Process:
+    """A ``modal deploy`` that produces no output and succeeds, so only its environment matters."""
+
+    def __init__(self) -> None:
+        self.stdout: list[str] = []
+        self.returncode = 0
+
+    def wait(self) -> None:
+        return None
+
+
+@pytest.fixture
+def hosted_environ(monkeypatch):
+    """An environment shaped like a server's: its credentials, and every deployment extension set.
+
+    ``PROTO_MODAL_HF_SECRET`` is left deliberately *unset*, which is the dangerous value: it is
+    the one that makes proto-tools fall back to the deploying machine's own HuggingFace token.
+    """
+    for name, value in HOST_SECRETS.items():
+        monkeypatch.setenv(name, value)
+    for name in EXTENSIONS:
+        monkeypatch.setenv(name, f"{name.lower()}-value")
+    monkeypatch.delenv("PROTO_MODAL_HF_SECRET", raising=False)
+    monkeypatch.setenv("HOME", "/home/app")
+
+
+def test_the_cli_still_inherits_its_own_environment():
+    """No tokens means the deploying workspace is the caller's own, so nothing is withheld."""
+    assert deploy_environ(None) is None
+
+
+def test_a_credentialed_deploy_authenticates_as_the_caller(hosted_environ):
+    """The tokens are how the deploy lands in the caller's workspace rather than the server's."""
+    env = deploy_environ(TOKENS)
+    assert env is not None
+    assert env["MODAL_TOKEN_ID"] == TOKENS.token_id
+    assert env["MODAL_TOKEN_SECRET"] == TOKENS.token_secret
+
+
+def test_the_hosts_credentials_do_not_cross(hosted_environ):
+    """The reason this is an allowlist rather than a denylist."""
+    env = deploy_environ(TOKENS)
+    assert env is not None
+    leaked = sorted(name for name in HOST_SECRETS if name in env)
+    assert not leaked, f"reached a caller's deploy subprocess: {leaked}"
+
+
+@pytest.mark.parametrize("name", EXTENSIONS)
+def test_the_deployment_extensions_do_not_cross(hosted_environ, name):
+    """A caller's deploy builds stock proto-tools: no plugins, no extra source, no added secrets."""
+    env = deploy_environ(TOKENS)
+    assert env is not None
+    assert name not in env, f"{name} would have extended a caller's deployment with the server's"
+
+
+def test_the_hosts_huggingface_token_is_never_minted_into_a_callers_workspace(hosted_environ):
+    """The subtlest leak here, and the one that survives an allowlist.
+
+    Unset, ``PROTO_MODAL_HF_SECRET`` makes proto-tools read the deploying machine's own HuggingFace
+    token -- from ``HF_TOKEN``, or from files under ``HOME``, which the allowlist carries -- and
+    attach it as a plaintext Modal secret on an app in the caller's workspace, where they can read
+    it back. So it is set here rather than inherited, and inheriting nothing is not enough.
+    """
+    env = deploy_environ(TOKENS)
+    assert env is not None
+    assert env["PROTO_MODAL_HF_SECRET"] == "none", "an unset value falls back to the machine's token"
+    assert "HF_TOKEN" not in env
+    assert "HUGGING_FACE_HUB_TOKEN" not in env
+
+
+def test_a_caller_can_bring_their_own_huggingface_token(hosted_environ):
+    """Gated weights still work, without the caller's token passing through the deploying process.
+
+    A name, not a token: ``Secret.from_name`` resolves in the workspace being deployed into, so
+    the secret it finds is the caller's own.
+    """
+    env = deploy_environ(ModalTokens("ak-tokenid", "as-tokensecret", hf_secret="my-hf"))
+    assert env is not None
+    assert env["PROTO_MODAL_HF_SECRET"] == "my-hf"
+
+
+def test_what_the_build_needs_does_cross(hosted_environ):
+    """Withholding everything would be safe and useless."""
+    env = deploy_environ(TOKENS)
+    assert env is not None
+    assert env["HOME"] == "/home/app"
+    assert env["PATH"] == os.environ["PATH"]
+
+
+def test_the_subprocess_actually_runs_under_it(hosted_environ, monkeypatch, tmp_path):
+    """Building the environment and then not passing it would leave every test above vacuous."""
+    seen: dict[str, object] = {}
+
+    def _popen(cmd, **kwargs):
+        seen["env"] = kwargs.get("env")
+        return _Process()
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+    monkeypatch.setattr("proto_tools.modal.deploy.record_fingerprints", lambda *a, **k: None)
+
+    deploy_app("proto-tools-tmalign", "proto-env", tokens=TOKENS, log_dir=tmp_path)
+
+    env = seen["env"]
+    assert isinstance(env, dict), "Popen inherited the parent environment despite being given tokens"
+    assert env["MODAL_TOKEN_ID"] == TOKENS.token_id
+    assert "AWS_SECRET_ACCESS_KEY" not in env
+    assert "PROTO_MODAL_WORKER_PLUGINS" not in env
+
+
+def test_fingerprints_are_recorded_into_the_workspace_that_was_deployed(monkeypatch, tmp_path):
+    """Recorded elsewhere, the caller's deployment stays unfingerprinted and exempt from drift."""
+    recorded: list[object] = []
+    monkeypatch.setattr(
+        "proto_tools.modal.fingerprint.write_manifest",
+        lambda service, environment=None, client=None: recorded.append(client) or 1,
+    )
+
+    sentinel = object()
+    monkeypatch.setattr(ModalTokens, "client", lambda self: sentinel)
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: _Process())
+
+    deploy_app("proto-tools-tmalign", "proto-env", tokens=TOKENS, log_dir=tmp_path)
+
+    assert recorded, "a successful deploy recorded no fingerprints at all"
+    assert all(c is sentinel for c in recorded), "fingerprints were written as the deploying process"
+
+
+def test_a_server_can_supply_the_client_rather_than_have_one_opened(monkeypatch, tmp_path):
+    """``Client.from_credentials`` registers a shutdown hook instead of closing.
+
+    One opened per deploy stays open for the life of the process, which is why a long-running
+    server reuses them. Given a client, this must use it rather than open another.
+    """
+    recorded: list[object] = []
+    monkeypatch.setattr(
+        "proto_tools.modal.fingerprint.write_manifest",
+        lambda service, environment=None, client=None: recorded.append(client) or 1,
+    )
+
+    def _refuse(self):
+        raise AssertionError("a client was opened despite one being supplied")
+
+    monkeypatch.setattr(ModalTokens, "client", _refuse)
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: _Process())
+
+    cached = object()
+    deploy_app("proto-tools-tmalign", "proto-env", tokens=TOKENS, client=cached, log_dir=tmp_path)
+
+    assert recorded == [cached]
+
+
+def test_a_deploy_that_succeeded_is_not_lost_to_a_fingerprint_failure(monkeypatch, tmp_path):
+    """The caller has already paid for the build. Bookkeeping must not turn that into an error."""
+
+    def _unreachable(self):
+        raise ConnectionError("transient gRPC failure opening the client")
+
+    monkeypatch.setattr(ModalTokens, "client", _unreachable)
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: _Process())
+
+    assert deploy_app("proto-tools-tmalign", "proto-env", tokens=TOKENS, log_dir=tmp_path) is True
+
+
+def test_fingerprints_are_skipped_rather_than_recorded_in_the_wrong_workspace(monkeypatch, capsys):
+    """Falling back to the deploying process's own client would record against the wrong volume.
+
+    The caller's drift check would never look there, and the deploying process would read the
+    record as though it described a deployment of its own.
+    """
+    written: list[object] = []
+    monkeypatch.setattr(
+        "proto_tools.modal.fingerprint.write_manifest",
+        lambda service, environment=None, client=None: written.append(client) or 1,
+    )
+
+    def _unreachable(self):
+        raise ConnectionError("transient gRPC failure opening the client")
+
+    monkeypatch.setattr(ModalTokens, "client", _unreachable)
+    record_fingerprints(["proto-tools-tmalign"], "proto-env", tokens=TOKENS)
+
+    assert written == [], "a caller's fingerprints were written against the wrong workspace"
+    assert "could not record fingerprints" in capsys.readouterr().out
+
+
+def test_a_local_deploy_records_as_itself(monkeypatch, tmp_path):
+    """The CLI has no tokens, and passing a client it never opened would break it."""
+    recorded: list[object] = []
+    monkeypatch.setattr(
+        "proto_tools.modal.fingerprint.write_manifest",
+        lambda service, environment=None, client=None: recorded.append(client) or 1,
+    )
+    monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: _Process())
+
+    deploy_app("proto-tools-tmalign", "proto-env", log_dir=tmp_path)
+
+    assert recorded == [None]
+
+
+def test_the_token_pair_is_not_printable():
+    """A deploy failure raises CalledProcessError, whose string form carries what it was given."""
+    rendered = f"{TOKENS!r} {TOKENS}"
+    assert TOKENS.token_secret not in rendered
+    assert "<redacted>" in rendered
+
+
+def test_a_failed_deploy_returns_the_build_output_not_a_path(tmp_path):
+    """A caller who is not on this machine cannot read ``logs/deploy.tmalign.log``."""
+    from proto_tools.mcp.tools import _log_tail
+
+    log = tmp_path / "deploy.tmalign.log"
+    log.write_text(
+        "\x1b[38;5;39m⠋\x1b[0m \x1b[1mBuilding image\x1b[0m\n"
+        "\x1b[38;5;39m⠙\x1b[0m \x1b[1mBuilding image\x1b[0m\n"
+        "\x1b[38;5;196mModuleNotFoundError\x1b[0m: no module named 'x'\n"
+    )
+
+    tail = _log_tail(Path(tmp_path))
+    assert "ModuleNotFoundError: no module named 'x'" in tail
+    assert "⠋" not in tail, "spinner frames should be stripped, or the tail is all redraw noise"
+    assert "\x1b[" not in tail, "colour codes are noise around the traceback an agent has to read"

--- a/tests/modal_tests/test_drift_in_result.py
+++ b/tests/modal_tests/test_drift_in_result.py
@@ -1,0 +1,133 @@
+"""A stale deployment is reported to every caller it affects, not to the first one only.
+
+Drift means the deployed tool was built from a different proto-tools than the one calling it. The
+dispatch path already detects this and raises a ``DeploymentDriftWarning``, which is the right
+shape for a session on a laptop and reaches nobody anywhere else: an MCP caller does not see the
+server's ``warnings``, and the warning is emitted once per process, so on a shared server the first
+caller to touch a stale deployment silences it for everyone after them.
+
+That is not hypothetical. A stale protenix deployment failed with ``No package metadata was found
+for proto-tools`` and the drift warning that would have explained it went to a log nobody read.
+
+So ``run_tool`` returns drift as part of the answer. These pin that it is returned, that it is
+returned per call rather than once, and that it never costs a successful run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proto_tools.mcp import tools as impl
+
+TOOL_KEY = "esm2-embedding"
+
+
+@pytest.fixture
+def stale(monkeypatch):
+    """Report every tool as drifted, and count how many times the check is made."""
+    calls: list[tuple[str, str | None, object]] = []
+
+    def _warnings(tool_key, service_class, environment=None, client=None):
+        calls.append((tool_key, environment, client))
+        return [f"{tool_key}: the deployed tool's code differs from your local proto-tools."]
+
+    monkeypatch.setattr("proto_tools.modal.fingerprint.drift_warnings", _warnings)
+    return calls
+
+
+def test_every_caller_is_told_not_just_the_first(stale):
+    """``warnings.warn`` fires once per process. On a server that is one caller out of many."""
+    first = impl.drift_for(TOOL_KEY, "modal", environment="proto-env", client=None)
+    second = impl.drift_for(TOOL_KEY, "modal", environment="proto-env", client=None)
+    assert first and "differs from your local proto-tools" in first[0]
+    assert first == second, "the second caller was told less than the first"
+    assert len(stale) == 2
+
+
+def test_a_caller_who_names_no_environment_is_checked_where_they_actually_ran(stale, monkeypatch):
+    """The default case, and the one an unresolved check silently misses.
+
+    A dispatch resolves ``None`` to ``proto-env`` before it looks anything up. Passing ``None``
+    straight through instead reads the manifest from the caller's *active* environment, which
+    holds a different deployment or none at all -- so the feature reports nothing in exactly the
+    configuration a caller who sends no environment header gets.
+    """
+    monkeypatch.delenv("MODAL_ENVIRONMENT", raising=False)
+
+    impl.drift_for(TOOL_KEY, "modal", environment=None)
+
+    assert stale == [(TOOL_KEY, "proto-env", None)], "the drift check looked somewhere the call did not go"
+
+
+def test_the_check_is_made_against_the_deployment_the_call_reached(stale):
+    """Two callers can name different environments and different workspaces.
+
+    Checking ambiently would compare against whichever deployment this process happens to resolve,
+    which for a hosted server is nobody's.
+    """
+    client = object()
+    impl.drift_for(TOOL_KEY, "modal", environment="someones-env", client=client)
+    assert stale == [(TOOL_KEY, "someones-env", client)]
+
+
+@pytest.mark.parametrize("ran_on", ["local", "proto"])
+def test_a_call_that_never_reached_modal_reports_nothing(stale, ran_on):
+    """There is no deployment to be stale against, and the volume read would be wasted."""
+    assert impl.drift_for(TOOL_KEY, ran_on) == []
+    assert stale == []
+
+
+def test_an_unserved_tool_reports_nothing(stale):
+    """A tool with no deployment has no service to look a manifest up by."""
+    assert impl.drift_for("not-a-real-tool", "modal") == []
+    assert stale == []
+
+
+def test_a_broken_drift_check_never_costs_a_result(monkeypatch):
+    """The run already succeeded and cost GPU time. A bookkeeping read must not discard it."""
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError("volume unreachable")
+
+    # Patched below drift_warnings, which swallows its own failures -- that swallowing is what is
+    # being checked, since drift_for deliberately adds no second layer of its own.
+    monkeypatch.setattr("proto_tools.modal.fingerprint.read_manifest", _explode)
+    assert impl.drift_for(TOOL_KEY, "modal") == []
+
+
+def test_run_tool_attaches_drift_to_a_successful_result(monkeypatch, stale, tmp_path):
+    """Where a caller actually meets it: alongside the result, not instead of it."""
+    from proto_tools.tools import ToolRegistry
+
+    spec = ToolRegistry.get(TOOL_KEY)
+    example = ToolRegistry.get_example_input(TOOL_KEY)
+    assert example is not None
+
+    monkeypatch.setattr(impl, "_dispatch", lambda *a, **k: (_stub_output(spec), "modal"))
+
+    answer = impl.run_tool(TOOL_KEY, inputs=example.model_dump(mode="json"), output_dir=str(tmp_path))
+
+    assert answer["ok"] is True, answer
+    assert answer["warnings"], "a drifted deployment produced a result with no warning on it"
+
+
+def test_run_tool_says_nothing_when_the_deployment_is_aligned(monkeypatch, tmp_path):
+    """An aligned deployment is the normal case and must not add noise to every response."""
+    from proto_tools.tools import ToolRegistry
+
+    spec = ToolRegistry.get(TOOL_KEY)
+    example = ToolRegistry.get_example_input(TOOL_KEY)
+    assert example is not None
+
+    monkeypatch.setattr("proto_tools.modal.fingerprint.drift_warnings", lambda *a, **k: [])
+    monkeypatch.setattr(impl, "_dispatch", lambda *a, **k: (_stub_output(spec), "modal"))
+
+    answer = impl.run_tool(TOOL_KEY, inputs=example.model_dump(mode="json"), output_dir=str(tmp_path))
+
+    assert answer["ok"] is True, answer
+    assert "warnings" not in answer
+
+
+def _stub_output(spec):
+    """The smallest valid output for a tool, so the test exercises run_tool rather than a model."""
+    return spec.output_model(tool_id=spec.key, execution_time=0.0, success=True, results=[])

--- a/tests/modal_tests/test_drift_in_result.py
+++ b/tests/modal_tests/test_drift_in_result.py
@@ -6,9 +6,6 @@ shape for a session on a laptop and reaches nobody anywhere else: an MCP caller 
 server's ``warnings``, and the warning is emitted once per process, so on a shared server the first
 caller to touch a stale deployment silences it for everyone after them.
 
-That is not hypothetical. A stale protenix deployment failed with ``No package metadata was found
-for proto-tools`` and the drift warning that would have explained it went to a log nobody read.
-
 So ``run_tool`` returns drift as part of the answer. These pin that it is returned, that it is
 returned per call rather than once, and that it never costs a successful run.
 """

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -503,7 +503,7 @@ def test_deploy_reports_each_build_phase():
 
     from proto_tools.mcp import tools as impl
 
-    def fake_deploy(app, environment=None, on_progress=None):
+    def fake_deploy(app, environment=None, on_progress=None, verbose=False, *, tokens=None, client=None, log_dir=None):
         for phase in ("building image", "running warmup", "deployed"):
             on_progress(phase)
         return True
@@ -534,9 +534,14 @@ def test_deploy_rejects_a_tool_it_does_not_serve():
     assert out["ok"] is False
 
 
-def test_a_failed_deploy_points_at_the_build_log():
-    """The build output is the only place the cause is recorded."""
+def test_a_failed_deploy_returns_the_build_output():
+    """The build output is returned rather than named.
+
+    It is the only place the cause is recorded, and a caller reaching this over MCP has no access
+    to a log file on the machine that built.
+    """
     import asyncio as _asyncio
+    from pathlib import Path
     from unittest.mock import patch
 
     from proto_tools.mcp import tools as impl
@@ -544,11 +549,15 @@ def test_a_failed_deploy_points_at_the_build_log():
     async def report(_phase: str) -> None:
         return None
 
-    with patch("proto_tools.modal.deploy.deploy_app", lambda *a, **k: False):
+    def fake_deploy(app, environment=None, on_progress=None, verbose=False, *, tokens=None, client=None, log_dir=None):
+        Path(log_dir, "deploy.tmalign.log").write_text("ImportError: cannot import name 'x'\n")
+        return False
+
+    with patch("proto_tools.modal.deploy.deploy_app", fake_deploy):
         out = _asyncio.run(impl.deploy_tool("tmalign-alignment", "some-env", report))
 
     assert out["ok"] is False
-    assert "log" in out["error"]
+    assert "ImportError" in out["build_output"]
 
 
 def test_build_output_is_summarised_not_streamed():


### PR DESCRIPTION
Two changes so a server can deploy and dispatch on someone else's behalf.

**Deploy as the caller.** `modal deploy` is a subprocess, so it authenticates by environment rather than by a client object. Given `ModalTokens`, that environment is now built from an allowlist rather than inherited: the deploying process's own credentials do not cross, and neither do the variables that extend a deployment (`PROTO_MODAL_WORKER_PLUGINS`, `PROTO_MODAL_EXTRA_SOURCE`, `PROTO_MODAL_EXTRA_PACKAGES`, `PROTO_MODAL_SECRETS`, `PROTO_MODAL_PROTO_TOOLS`), so a caller gets stock proto-tools. `PROTO_MODAL_HF_SECRET` is set rather than dropped, because unset makes proto-tools mint the deploying machine's own HuggingFace token into the target workspace; a caller can name a secret in their own workspace instead.

Fingerprints are recorded as whoever deployed, `deploy_app` takes a `log_dir` so concurrent deploys of the same app do not share a log, and a failed deploy returns the build output instead of naming a log file on a machine the caller cannot reach.

**Drift reaches the caller.** `run_tool` returns drift warnings in its result. Previously they went through `warnings.warn`, deduped once per process, so on a shared server the first caller to reach a stale deployment silenced it for everyone after them.

No change to the CLI path: without tokens the subprocess inherits its environment exactly as before.