### PR TITLE
Scan the final motif window in fimo, refresh stale meme fixtures with real sequence

### DIFF
--- a/proto_tools/tools/gene_annotation/meme/meme_fimo_scan.py
+++ b/proto_tools/tools/gene_annotation/meme/meme_fimo_scan.py
@@ -194,9 +194,15 @@ class MEMEFimoScanOutput(BaseToolOutput):
 # Tool Implementation
 # ============================================================================
 def example_input() -> Any:
-    """Minimal valid input for testing and examples."""
+    """Minimal valid input for testing and examples.
+
+    One repeat-spacer-repeat unit taken verbatim from the bundled S. pyogenes SF370
+    CRISPR1 locus, so the bundled direct-repeat motif occurs twice on the forward strand.
+    """
+    repeat = "GTTTTAGAGCTATGCTGTTTTGAATGGTCCCAAAAC"
+    spacer = "TGCGCTGGTTGATTTCTTCTTGCGCTTTTT"
     return MEMEFimoScanInput(
-        sequences=["GTTGAGCTGGTCAACAAGTTGAGCTGGTCAAC"],
+        sequences=[repeat + spacer + repeat],
         motifs=str(Path(__file__).parent / "examples" / "example.meme"),
     )
 

--- a/proto_tools/tools/gene_annotation/meme/standalone/run.py
+++ b/proto_tools/tools/gene_annotation/meme/standalone/run.py
@@ -57,6 +57,14 @@ def _is_complementable(motif: Any) -> bool:
     return motif.alphabet.size == 4 and {"A", "C", "G"} <= symbols and ("T" in symbols or "U" in symbols)
 
 
+# pymemesuite slides its scoring window over ``range(length - width)``, one position
+# short of the end, so an occurrence ending at the final base is never scored. Appending
+# a single base makes that last window fall inside the loop; the padded window itself
+# stays outside it, so no spurious site is scored. 'N' is valid in both the nucleotide
+# and protein alphabets.
+_END_PAD = "N"
+
+
 def _sequence_index(name: str) -> int | None:
     """Parse the 0-based input index from a ``seq_{i}`` sequence name."""
     try:
@@ -74,7 +82,8 @@ def run_fimo_scan(input_data: dict[str, Any]) -> dict[str, Any]:
     Returns one match list per input sequence, aligned by position, so the result
     maps 1:1 onto the input ``sequences`` (the tool's iterable contract).
     """
-    sequences = [Sequence(seq, name=f"seq_{i}".encode()) for i, seq in enumerate(input_data["sequences"])]
+    lengths = [len(seq) for seq in input_data["sequences"]]
+    sequences = [Sequence(seq + _END_PAD, name=f"seq_{i}".encode()) for i, seq in enumerate(input_data["sequences"])]
     motifs, background = _read_motifs(input_data["motifs_path"])
 
     # FIMO only reverse-complements nucleotide alphabets; mirror the CLI by scanning
@@ -100,12 +109,15 @@ def run_fimo_scan(input_data: dict[str, Any]) -> dict[str, Any]:
                 continue
             # FIMO reports start <= stop with strand separate; pymemesuite gives
             # strand-oriented coordinates, so normalize to (min, max).
+            start, stop = int(min(element.start, element.stop)), int(max(element.start, element.stop))
+            if stop > lengths[idx]:  # window overlapping the end pad, not a real site
+                continue
             results[idx].append(
                 {
                     "motif_id": motif_id,
                     "motif_alt_id": motif_alt_id,
-                    "start": int(min(element.start, element.stop)),
-                    "stop": int(max(element.start, element.stop)),
+                    "start": start,
+                    "stop": stop,
                     "strand": element.strand,
                     "score": float(element.score),
                     "pvalue": float(element.pvalue),

--- a/tests/gene_annotation_tests/test_meme_fimo_scan.py
+++ b/tests/gene_annotation_tests/test_meme_fimo_scan.py
@@ -17,9 +17,41 @@ from tests.tool_infra_tests.test_export_functionality import validate_output
 
 _MEME_DIR = Path(__file__).parent.parent.parent / "proto_tools" / "tools" / "gene_annotation" / "meme"
 EXAMPLE_MEME_FILE = _MEME_DIR / "examples" / "example.meme"
+_LOCUS_FASTA = _MEME_DIR / "examples" / "spyogenes_crispr_locus.fasta"
 
-# Consensus GAGCTGGTCA appears twice on the forward strand.
-SAMPLE_SEQUENCE = "GTTGAGCTGGTCAACAAGTTGAGCTGGTCAAC"
+
+def _reverse_complement(seq: str) -> str:
+    """Return the reverse complement of a DNA sequence."""
+    return seq.translate(str.maketrans("ACGT", "TGCA"))[::-1]
+
+
+# Every DNA fixture below is a verbatim slice of the bundled S. pyogenes SF370 CRISPR1
+# locus, the same sequence example.meme's direct-repeat motif was derived from.
+LOCUS = "".join(line for line in _LOCUS_FASTA.read_text().splitlines() if not line.startswith(">"))
+
+# The 36 bp direct repeat, and the array's first two copies of it (separated by a 30 bp spacer).
+_R1 = LOCUS.index("GTTTTAGAGCTATGCTGTTTTGAATGGTCCCAAAAC")
+_R2 = LOCUS.index("GTTTTAGAGCTATGCTGTTTTGAATGGTCCCAAAAC", _R1 + 1)
+CRISPR_REPEAT = LOCUS[_R1 : _R1 + 36]
+
+# One repeat-spacer-repeat unit: the motif occurs twice on the forward strand.
+SAMPLE_SEQUENCE = LOCUS[_R1 : _R2 + len(CRISPR_REPEAT)]
+
+# 30 bp of the array's leader sequence ending flush with the first repeat's final base.
+LEADER_THEN_REPEAT = LOCUS[_R1 - 30 : _R1 + len(CRISPR_REPEAT)]
+
+# The minus strand of the first repeat-plus-spacer unit, so the repeat's reverse
+# complement sits flush against the 3' end.
+REPEAT_SPACER_MINUS = _reverse_complement(LOCUS[_R1:_R2])
+
+# A 60 bp stretch well upstream of the array, carrying no occurrence of the repeat.
+NO_MATCH_SEQUENCE = LOCUS[600:660]
+
+# Human histone H3.1 N-terminal tail (UniProt P68431), minus the initiator Met that is
+# removed in vivo — so positions match the standard residue numbering. The 'ARKS' motif
+# occurs twice, at A7-S10 and A25-S28: the H3K9 and H3K27 methylation sites.
+H3_TAIL = "ARTKQTARKSTGGKAPRKQLATKAARKSAPATGGVKKPH"
+H3_MOTIF_CONSENSUS = "ARKS"
 
 
 # ── Input validation ─────────────────────────────────────────────────────
@@ -48,7 +80,7 @@ def test_fimo_scan_basic_execution():
     assert result.num_matches >= 1
 
     match = result.results[0].matches[0]
-    assert match.motif_id == "MA0TEST"
+    assert match.motif_id == "SPYO_CRISPR1"
     assert match.strand in {"+", "-"}
     assert 0 < match.pvalue <= 1e-4
     assert match.start <= match.stop
@@ -57,7 +89,7 @@ def test_fimo_scan_basic_execution():
 @pytest.mark.integration
 def test_fimo_scan_results_align_to_inputs():
     """Output is 1:1 with inputs; a sequence with no occurrences yields an empty bundle."""
-    inputs = MEMEFimoScanInput(sequences=[SAMPLE_SEQUENCE, "AAAAAAAAAAAAAAAA"], motifs=str(EXAMPLE_MEME_FILE))
+    inputs = MEMEFimoScanInput(sequences=[SAMPLE_SEQUENCE, NO_MATCH_SEQUENCE], motifs=str(EXAMPLE_MEME_FILE))
     result = run_meme_fimo_scan(inputs, MEMEFimoScanConfig())
 
     assert result.success is True
@@ -78,13 +110,46 @@ def test_fimo_scan_single_strand_finds_forward_matches():
     assert all(m.strand == "+" for r in result.results for m in r.matches)
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("sequence", "strand"),
+    [(LEADER_THEN_REPEAT, "+"), (REPEAT_SPACER_MINUS, "-")],
+    ids=["forward", "reverse"],
+)
+def test_fimo_scan_finds_motif_flush_against_sequence_end(sequence, strand):
+    """An occurrence ending at the final base is reported, on either strand.
+
+    pymemesuite's sliding window stops one position short of the sequence end, so
+    without a pad the last window is never scored and the hit is silently lost.
+    """
+    inputs = MEMEFimoScanInput(sequences=sequence, motifs=str(EXAMPLE_MEME_FILE))
+    result = run_meme_fimo_scan(inputs, MEMEFimoScanConfig())
+
+    assert result.num_matches == 1
+    match = result.results[0].matches[0]
+    assert (match.start, match.stop) == (31, len(sequence))  # flush against the 3' end
+    assert match.strand == strand
+
+
+@pytest.mark.integration
+def test_fimo_scan_sequence_exactly_motif_width_is_scanned():
+    """A sequence exactly as long as the motif yields its single window's match."""
+    inputs = MEMEFimoScanInput(sequences=CRISPR_REPEAT, motifs=str(EXAMPLE_MEME_FILE))
+    result = run_meme_fimo_scan(inputs, MEMEFimoScanConfig())
+
+    assert result.num_matches == 1
+    match = result.results[0].matches[0]
+    assert (match.start, match.stop) == (1, len(CRISPR_REPEAT))
+
+
 def _write_protein_motif(path: Path) -> None:
-    """Write a minimal 3-position protein motif (consensus MKL) in MEME format."""
+    """Write the histone H3 'ARKS' methylation-site motif in MEME format."""
     aa = "ACDEFGHIKLMNPQRSTVWY"
-    rows = "\n".join(" ".join("0.81" if c == dom else "0.01" for c in aa) for dom in "MKL")
+    rows = "\n".join(" ".join("0.81" if c == dom else "0.01" for c in aa) for dom in H3_MOTIF_CONSENSUS)
     path.write_text(
         f"MEME version 4\n\nALPHABET= {aa}\n\n"
-        f"MOTIF P1 prot\nletter-probability matrix: alength= 20 w= 3 nsites= 20 E= 0\n{rows}\n"
+        f"MOTIF H3_ARKS meth_site\n"
+        f"letter-probability matrix: alength= 20 w= {len(H3_MOTIF_CONSENSUS)} nsites= 20 E= 0\n{rows}\n"
     )
 
 
@@ -97,11 +162,12 @@ def test_fimo_scan_protein_motif_is_forward_only(tmp_path):
     """
     motif = tmp_path / "prot.meme"
     _write_protein_motif(motif)
-    inputs = MEMEFimoScanInput(sequences="AAAMKLAAAMKLAAA", motifs=str(motif))
-    result = run_meme_fimo_scan(inputs, MEMEFimoScanConfig(both_strands=True, threshold=1e-2))
+    inputs = MEMEFimoScanInput(sequences=H3_TAIL, motifs=str(motif))
+    result = run_meme_fimo_scan(inputs, MEMEFimoScanConfig(both_strands=True, threshold=1e-3))
 
     assert result.success is True
-    assert result.num_matches >= 1
+    # The H3K9 and H3K27 sites, both on the given strand.
+    assert [(m.start, m.stop) for m in result.results[0].matches] == [(7, 10), (25, 28)]
     assert all(m.strand == "+" for r in result.results for m in r.matches)
 
 


### PR DESCRIPTION
**Stack 1/7** — base: `main`

Fixes 4 failing `test_meme_fimo_scan.py` tests, and a silent correctness bug found while diagnosing them.

### Stale fixtures (the reported failures)

e617752e replaced `example.meme`'s synthetic `MA0TEST` motif with the real 36 bp *S. pyogenes* CRISPR1 direct repeat and updated the notebook, but not the test fixture or `example_input()`. `SAMPLE_SEQUENCE` was 32 bp — shorter than the motif itself — so every DNA scan correctly returned zero matches. This also meant the shipped `example_input()` returned zero matches, which the registry surfaces in docs and the CLI.

### A real bug: the final window was never scanned

`pymemesuite` 0.1.0a4 slides its window over `range(length - width)` (`fimo.pyx:214`), one position short of the end, so **any motif occurrence flush against the 3' end was silently dropped**, on either strand. A 36 bp sequence containing an exact 36 bp match returned nothing.

Fixed by appending one sentinel base before scanning: that pulls the final real window into the loop while the padded window itself stays outside it, so no spurious site is scored. Matches overlapping the pad are filtered defensively in case upstream fixes the off-by-one.

### Fixtures are now real sequence

Every DNA fixture is a verbatim slice of the bundled locus, located by finding the repeat in the FASTA rather than hardcoded, so realism can't drift if the asset is regenerated. The protein test's `AAAMKLAAAMKLAAA` homopolymer is replaced by the histone H3.1 tail (UniProt P68431), where `ARKS` occurs at the real H3K9 and H3K27 methylation sites.

### Verification

9 passed. Boundary hits return the exact 36 bp sequence with no pad leakage; the 6 kb locus scan is unchanged at 9 hits. Style suite green.