### PR TITLE
Install ipsae.py into the venv so it shares the environment's lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,6 @@ analyses/*
 **/standalone/standalone_helpers.sh
 **/shared_envs/*/standalone_helpers.sh
 
-# Vendored upstream scripts fetched by standalone setup.sh (not committed)
-proto_tools/tools/structure_scoring/ipsae/standalone/ipsae.py
-
 # BLAST database artifacts generated when run_create_blast_db runs with default
 # config alongside the example_input fixture (.ndb, .nhr, .nin, .nsq, etc.)
 proto_tools/tools/sequence_alignment/blast/example_input_fixture.*

--- a/proto_tools/tools/structure_scoring/ipsae/standalone/inference.py
+++ b/proto_tools/tools/structure_scoring/ipsae/standalone/inference.py
@@ -12,6 +12,28 @@ from standalone_helpers import get_logger
 logger = get_logger(__name__)
 
 
+def _resolve_ipsae_script() -> str:
+    """Return the path to ipsae.py, which setup.sh installs into the venv.
+
+    An override is honored first, then the venv location; the directory holding this
+    module is a last resort so an ejected standalone keeps working.
+    """
+    override = os.environ.get("IPSAE_SCRIPT_PATH")
+    candidates = [
+        *([override] if override else []),
+        os.path.join(sys.prefix, "share", "ipsae", "ipsae.py"),
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "ipsae.py"),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+
+    raise FileNotFoundError(
+        f"ipsae: ipsae.py not found (looked in {candidates}); "
+        "set IPSAE_SCRIPT_PATH or rebuild the environment so setup.sh downloads it"
+    )
+
+
 def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
     """Run IPSAE scoring on a cofolded complex.
 
@@ -28,11 +50,7 @@ def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
     pae_cutoff: float = float(input_dict.get("pae_cutoff", 10))
     dist_cutoff: float = float(input_dict.get("dist_cutoff", 10))
 
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    ipsae_script = os.path.join(script_dir, "ipsae.py")
-
-    if not os.path.isfile(ipsae_script):
-        raise FileNotFoundError(f"ipsae: ipsae.py not found at {ipsae_script}; run setup.sh first")
+    ipsae_script = _resolve_ipsae_script()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         pdb_path = os.path.join(tmp_dir, "complex.pdb")

--- a/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
+++ b/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
@@ -7,18 +7,39 @@ echo "Setting up IPSAE standalone environment..."
 pip install uv
 uv pip install numpy
 
+# Print the SHA-256 of a file, or nothing when it is missing (Linux sha256sum, macOS shasum).
+sha256_of() {
+    [ -f "$1" ] || return 0
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
 # Download ipsae.py from DunbrackLab, pinned to a specific commit for reproducibility.
 # curl is on PATH via the host or the foundation env.
 # -f makes curl exit nonzero on HTTP 4xx/5xx so a 404 doesn't silently land HTML in ipsae.py.
 # Install into the venv so the script shares the environment's lifecycle: a rebuilt env
 # re-downloads it, and a checkout that did not run setup.sh cannot appear already set up.
+# The download is checked against a pinned digest rather than trusted for merely existing,
+# so a truncated or altered file is re-fetched instead of being cached as good.
 IPSAE_COMMIT="${IPSAE_COMMIT:-6174cf9e71cb1bd660cc805856a18c4871a6dec3}"
+IPSAE_SHA256="${IPSAE_SHA256:-10cf9b08c68c91e06cb28526cf2026f47a3980c9048fd3226d13e3304eaf1c27}"
 IPSAE_URL="https://raw.githubusercontent.com/DunbrackLab/IPSAE/${IPSAE_COMMIT}/ipsae.py"
 INSTALL_DIR="${PREFIX:-$VENV_PATH}/share/ipsae"
 mkdir -p "$INSTALL_DIR"
-if [ ! -f "$INSTALL_DIR/ipsae.py" ]; then
+
+if [ "$(sha256_of "$INSTALL_DIR/ipsae.py")" != "$IPSAE_SHA256" ]; then
     echo "Downloading ipsae.py..."
-    curl -fsSL "$IPSAE_URL" -o "$INSTALL_DIR/ipsae.py"
+    curl -fsSL "$IPSAE_URL" -o "$INSTALL_DIR/ipsae.py.part"
+    DOWNLOADED_SHA256="$(sha256_of "$INSTALL_DIR/ipsae.py.part")"
+    if [ "$DOWNLOADED_SHA256" != "$IPSAE_SHA256" ]; then
+        rm -f "$INSTALL_DIR/ipsae.py.part"
+        echo "ERROR: ipsae.py checksum mismatch (expected $IPSAE_SHA256, got $DOWNLOADED_SHA256)" >&2
+        exit 1
+    fi
+    mv "$INSTALL_DIR/ipsae.py.part" "$INSTALL_DIR/ipsae.py"
 fi
 
 echo "IPSAE setup complete!"

--- a/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
+++ b/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
@@ -10,12 +10,15 @@ uv pip install numpy
 # Download ipsae.py from DunbrackLab, pinned to a specific commit for reproducibility.
 # curl is on PATH via the host or the foundation env.
 # -f makes curl exit nonzero on HTTP 4xx/5xx so a 404 doesn't silently land HTML in ipsae.py.
+# Install into the venv so the script shares the environment's lifecycle: a rebuilt env
+# re-downloads it, and a checkout that did not run setup.sh cannot appear already set up.
 IPSAE_COMMIT="${IPSAE_COMMIT:-6174cf9e71cb1bd660cc805856a18c4871a6dec3}"
 IPSAE_URL="https://raw.githubusercontent.com/DunbrackLab/IPSAE/${IPSAE_COMMIT}/ipsae.py"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ ! -f "$SCRIPT_DIR/ipsae.py" ]; then
+INSTALL_DIR="${PREFIX:-$VENV_PATH}/share/ipsae"
+mkdir -p "$INSTALL_DIR"
+if [ ! -f "$INSTALL_DIR/ipsae.py" ]; then
     echo "Downloading ipsae.py..."
-    curl -fsSL "$IPSAE_URL" -o "$SCRIPT_DIR/ipsae.py"
+    curl -fsSL "$IPSAE_URL" -o "$INSTALL_DIR/ipsae.py"
 fi
 
 echo "IPSAE setup complete!"


### PR DESCRIPTION
**Stack 2/7** — base: `fix/fimo-dna-scan-zero-matches`

Fixes 3 erroring `test_ipsae_scoring.py` tests (`FileNotFoundError: ipsae.py not found`).

### Root cause: the artifact lived outside the env it belongs to

`setup.sh` downloaded the pinned upstream `ipsae.py` into **its own source directory**, with `.gitignore` hiding it. So the script lived in the working tree while the environment was tracked separately. The evidence was in `setup.log`: it printed "IPSAE setup complete!" but never "Downloading ipsae.py..." — the `[ ! -f ]` guard found a file from an earlier run and skipped the download.

That split makes the failure unrecoverable. The setup hash covers `setup.sh`, `requirements.txt`, `env_vars.txt` and `python_version.txt` — not the downloaded file. Once the env is `SUCCESS`, setup never re-runs, so a tree missing the untracked file fails on every call forever. **Two checkouts sharing one `proto_cache` hit this as soon as either tree is cleaned.**

Fix follows the `crispr_tracr_rna` precedent: download to `$VENV_PATH/share/ipsae`, resolve via `sys.prefix`, with an `IPSAE_SCRIPT_PATH` override and a script-dir fallback so ejected standalones still work. The now-obsolete `.gitignore` entry is removed.

### Second commit: verify the download

`curl` output was accepted for merely existing, so an interrupted fetch would be cached as good and never repaired. Now compared against a pinned SHA-256, downloaded to a `.part` file and moved into place only once it matches.

*(Stack 6/7 later moves this onto the shared `proto_download_verified` helper.)*

### Verification

9 passed. Env rebuilt, logged the download, placed the 45140-byte file in `share/ipsae/` with the repo tree clean. Guard tested in isolation: missing → downloads; valid → skips; truncated → repairs; wrong digest → aborts leaving no `.part`.

### Note

`test_all_links_reachable[structure_scoring/ipsae]` also failed in the same run but was **transient** — the repo and pinned raw URL both return 200 and the test passes on retry. No fix needed.