### PR TITLE
Pin PyRosetta for bindcraft so it matches the pinned BindCraft commit

### DIFF
--- a/proto_tools/tools/binder_design/bindcraft/standalone/setup.sh
+++ b/proto_tools/tools/binder_design/bindcraft/standalone/setup.sh
@@ -22,11 +22,15 @@ uv pip install -r requirements.txt
 echo "Installing ColabDesign (pinned, --no-deps)..."
 uv pip install --no-deps "colabdesign @ git+https://github.com/sokrypton/ColabDesign.git@e31a56fe1d9b4de25c8697f3a28b75892941cc72"
 
+# Pinned like BindCraft and ColabDesign above: newer PyRosetta builds take a
+# core.pose.DockingPartners for InterfaceAnalyzerMover.set_interface(), while the pinned
+# BindCraft passes the string form ("A_B") its functions/pyrosetta_utils.py has always used.
+# 2024.42 is contemporaneous with BindCraft v1.2.0 and accepts that string.
 echo "Installing PyRosetta via conda channel..."
 "$MAMBA_BIN" install -y -p "$VENV_PATH" \
     -c https://conda.rosettacommons.org \
     -c conda-forge \
-    pyrosetta
+    "pyrosetta=${BINDCRAFT_PYROSETTA_VERSION:-2024.42}"
 
 # AF2 weights are shared with the alphafold2 toolkit (~5.5 GB, avoid re-download).
 proto_resolve_weights_dir alphafold2


### PR DESCRIPTION
**Stack 3/7** — base: `fix/ipsae-setup-download`

Fixes 3 failures: `test_bindcraft_one_off_sample_full_pipeline`, `test_bindcraft_filter_override_rejects_with_impossible_threshold`, and `test_gpu_tool_eviction_round_trip[bindcraft-design]`.

### Dependency drift, not a code regression

BindCraft and ColabDesign are pinned to commits, but `pyrosetta` was installed **unpinned** from the Rosetta conda channel. A rebuild picked up `2026.30`, where `InterfaceAnalyzerMover.set_interface()` takes a `core.pose.DockingPartners` instead of a string — while the pinned `functions/pyrosetta_utils.py` passes `"A_B"`.

The design trajectory always completed; only interface scoring died. That's why `freebindcraft` (`--no-pyrosetta`) kept passing.

Nothing in the repo changed — the env was rebuilt and pulled a newer PyRosetta than the last time it worked.

### Why pin rather than adapt

- Upstream hasn't touched `pyrosetta_utils.py` since v1.2.0 (2024-11-06), so bumping the BindCraft pin doesn't help.
- BindCraft's own installer never installs PyRosetta, so there's no upstream pin to copy.
- `DockingPartners` exposes a `docking_partners_from_string` factory, but using it means patching pinned upstream source — defeating the point of pinning the commit.

`2024.42` is contemporaneous with the pinned BindCraft v1.2.0 and verified to accept the string form. Overridable via `BINDCRAFT_PYROSETTA_VERSION`.

### Verification

2 slow tests passed (47:16) and 8 device-manager tests passed (23:20) including the eviction round-trip. Rebuilt env confirms `pyrosetta-2024.42+release.3366cf78a3-py3.10`.

### Known limitation

The API break is actually between `2026.19` (accepts `str`) and `2026.26` (rejects it), measured in stack 4/7 — so bindcraft would likely work on a much newer build than `2024.42`. Left as-is since it's verified passing and re-verification is a ~50 min run; worth revisiting.