### PR TITLE
Pin PyRosetta for germinal so it matches the pinned Germinal commit

### DIFF
--- a/proto_tools/tools/binder_design/germinal/standalone/setup.sh
+++ b/proto_tools/tools/binder_design/germinal/standalone/setup.sh
@@ -44,11 +44,15 @@ uv pip install -e "$GERMINAL_DIR"
 echo "Installing colabfold (--no-deps)..."
 uv pip install --no-deps colabfold==1.6.1
 
+# Pinned like the Germinal commit above: PyRosetta builds from 2026.26 onward take a
+# core.pose.DockingPartners for InterfaceAnalyzerMover.set_interface(), while the pinned
+# Germinal passes the string form ("A_B") in germinal/filters/pyrosetta_utils.py.
+# 2026.19 is contemporaneous with the pinned commit and accepts that string.
 echo "Installing PyRosetta via conda channel..."
 "$MAMBA_BIN" install -y -p "$VENV_PATH" \
     -c https://conda.rosettacommons.org \
     -c conda-forge \
-    pyrosetta
+    "pyrosetta=${GERMINAL_PYROSETTA_VERSION:-2026.19}"
 
 # Chai-1 (default validation backend; aarch64 lacks sm_121 support).
 if [ "$(uname -m)" = "aarch64" ]; then


### PR DESCRIPTION
**Stack 4/7** — base: `fix/bindcraft-pyrosetta-interface`

Preemptive: **no test was failing**. germinal carries the same latent break as bindcraft.

### The problem

Germinal is pinned to a commit whose `germinal/filters/pyrosetta_utils.py:109` calls `iam.set_interface("A_B")` — identical to BindCraft — but `pyrosetta` was installed unpinned, so a rebuild can pick up a build that rejects the string and break the filter stage.

`score_interface` is called from the live filter pipeline (`filter_utils.py:114,154`), so this is reachable code, not dead.

### API boundary, measured

| version | `set_interface` |
|---|---|
| `2026.19` | `str` — accepts `"A_B"` |
| `2026.26` | `DockingPartners` — rejects it |

Germinal's pinned commit is from **2026-04-24**, so `2026.19` is contemporaneous and verified compatible — far better than dragging germinal back to bindcraft's `2024.42`. Overridable via `GERMINAL_PYROSETTA_VERSION`.

### The pyrosetta toolkit is deliberately NOT pinned

`structure_scoring/pyrosetta` needs no change, and pinning it would be **actively wrong**. Its `standalone/inference.py:13-26` already adapts to both APIs via `getattr(pose, "DockingPartners", None)`. Staying unpinned is what lets one source work on linux-aarch64 (frozen at 2023.11, old API) and linux-64 (2026.30, new API). A hard pin would break aarch64, where no newer build exists.

### Verification

Env resolved cleanly with `2026.19`; the exact `score_interface()` setup path germinal calls succeeds in the rebuilt env; 9 non-slow germinal tests pass.

**Limitation:** verified via `ensure_ready()` plus a smoke test, **not** germinal's three GPU e2e campaigns. This confirms the pin resolves and the API path works — not that a full campaign passes end-to-end.