### PR TITLE
Verify downloaded weights so a truncated checkpoint is re-fetched, not kept

### DIFF
--- a/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
+++ b/proto_tools/tools/structure_scoring/ipsae/standalone/setup.sh
@@ -7,39 +7,17 @@ echo "Setting up IPSAE standalone environment..."
 pip install uv
 uv pip install numpy
 
-# Print the SHA-256 of a file, or nothing when it is missing (Linux sha256sum, macOS shasum).
-sha256_of() {
-    [ -f "$1" ] || return 0
-    if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$1" | cut -d' ' -f1
-    else
-        shasum -a 256 "$1" | cut -d' ' -f1
-    fi
-}
-
 # Download ipsae.py from DunbrackLab, pinned to a specific commit for reproducibility.
-# curl is on PATH via the host or the foundation env.
-# -f makes curl exit nonzero on HTTP 4xx/5xx so a 404 doesn't silently land HTML in ipsae.py.
 # Install into the venv so the script shares the environment's lifecycle: a rebuilt env
 # re-downloads it, and a checkout that did not run setup.sh cannot appear already set up.
-# The download is checked against a pinned digest rather than trusted for merely existing,
-# so a truncated or altered file is re-fetched instead of being cached as good.
 IPSAE_COMMIT="${IPSAE_COMMIT:-6174cf9e71cb1bd660cc805856a18c4871a6dec3}"
 IPSAE_SHA256="${IPSAE_SHA256:-10cf9b08c68c91e06cb28526cf2026f47a3980c9048fd3226d13e3304eaf1c27}"
-IPSAE_URL="https://raw.githubusercontent.com/DunbrackLab/IPSAE/${IPSAE_COMMIT}/ipsae.py"
 INSTALL_DIR="${PREFIX:-$VENV_PATH}/share/ipsae"
 mkdir -p "$INSTALL_DIR"
 
-if [ "$(sha256_of "$INSTALL_DIR/ipsae.py")" != "$IPSAE_SHA256" ]; then
-    echo "Downloading ipsae.py..."
-    curl -fsSL "$IPSAE_URL" -o "$INSTALL_DIR/ipsae.py.part"
-    DOWNLOADED_SHA256="$(sha256_of "$INSTALL_DIR/ipsae.py.part")"
-    if [ "$DOWNLOADED_SHA256" != "$IPSAE_SHA256" ]; then
-        rm -f "$INSTALL_DIR/ipsae.py.part"
-        echo "ERROR: ipsae.py checksum mismatch (expected $IPSAE_SHA256, got $DOWNLOADED_SHA256)" >&2
-        exit 1
-    fi
-    mv "$INSTALL_DIR/ipsae.py.part" "$INSTALL_DIR/ipsae.py"
-fi
+proto_download_verified \
+    "https://raw.githubusercontent.com/DunbrackLab/IPSAE/${IPSAE_COMMIT}/ipsae.py" \
+    "$INSTALL_DIR/ipsae.py" \
+    "$IPSAE_SHA256"
 
 echo "IPSAE setup complete!"

--- a/proto_tools/tools/structure_scoring/metal3d/standalone/setup.sh
+++ b/proto_tools/tools/structure_scoring/metal3d/standalone/setup.sh
@@ -17,19 +17,20 @@ proto_resolve_weights_dir metal3d
 
 DEVA_COMMIT="${DEVA_COMMIT:-ee771f6730d170c83d8e63074be3bdd761b21dee}"
 REPO_BASE="https://raw.githubusercontent.com/gelnesr/dEVA/${DEVA_COMMIT}/models/metal3d/weights"
-declare -A WEIGHTS=(
-    ["metal3d_cat.pth"]="${REPO_BASE}/metal3d_cat.pth"
-    ["metal3d_clean.pth"]="${REPO_BASE}/metal3d_clean.pth"
-    ["metal_0.5A_v3_d0.2_16Abox.pth"]="${REPO_BASE}/metal_0.5A_v3_d0.2_16Abox.pth"
+# Digests of the checkpoints at DEVA_COMMIT. Checked on every run so a truncated
+# download is re-fetched rather than kept because the path exists: a short
+# metal3d_clean.pth still carries the torch zip magic and only fails at torch.load().
+declare -A WEIGHT_SHA256=(
+    ["metal3d_cat.pth"]="e86bea7ebc3513d603626b5d080ed9ab5aef869be916fbaf47446b3a2004ab27"
+    ["metal3d_clean.pth"]="166e5acb62b39fd722aeebc3eb5855328560f78cea855fe68285214b44760c47"
+    ["metal_0.5A_v3_d0.2_16Abox.pth"]="b5a1b0c5ea6c5dcdedfae4e24b8461da107ea78c8b96c7db8f44db532c87246f"
 )
 
-for WEIGHT_FILE in "${!WEIGHTS[@]}"; do
-    if [ ! -f "${WEIGHTS_DIR}/${WEIGHT_FILE}" ]; then
-        echo "Downloading ${WEIGHT_FILE}..."
-        curl -fsSL -o "${WEIGHTS_DIR}/${WEIGHT_FILE}" "${WEIGHTS[$WEIGHT_FILE]}"
-    else
-        echo "${WEIGHT_FILE} already present."
-    fi
+for WEIGHT_FILE in "${!WEIGHT_SHA256[@]}"; do
+    proto_download_verified \
+        "${REPO_BASE}/${WEIGHT_FILE}" \
+        "${WEIGHTS_DIR}/${WEIGHT_FILE}" \
+        "${WEIGHT_SHA256[$WEIGHT_FILE]}"
 done
 
 echo "Metal3D setup complete!"

--- a/proto_tools/utils/standalone_helpers_source/standalone_helpers.sh
+++ b/proto_tools/utils/standalone_helpers_source/standalone_helpers.sh
@@ -19,6 +19,8 @@
 #   proto_resolve_asset_availability <toolkit> <pattern> [license_url] [asset_kind] [hint]  -> sets $ASSET_DIR
 #   proto_check_gated_hf_repo <repo_id> <license_url> [probe_file]
 #   proto_download_gdrive <file_id> <dest>
+#   proto_sha256 <path>
+#   proto_download_verified <url> <dest> <sha256>
 # ============================================================================
 
 
@@ -432,4 +434,60 @@ with open(dest, 'wb') as f:
             break
         f.write(chunk)
 " "$1" "$2"
+}
+
+
+# ---------------------------------------------------------------------------
+# proto_sha256 <path>
+#
+# Print the SHA-256 of a file, or nothing when it is missing. Uses sha256sum on
+# Linux and shasum on macOS.
+# ---------------------------------------------------------------------------
+proto_sha256() {
+    [ -f "$1" ] || return 0
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+
+# ---------------------------------------------------------------------------
+# proto_download_verified <url> <dest> <sha256>
+#
+# Download <url> to <dest>, verifying against <sha256>. A file already at <dest>
+# is kept only when its digest matches, so a truncated or altered download is
+# re-fetched instead of being trusted for merely existing. The transfer lands in
+# a .part file that is moved into place only once it matches, so an interrupted
+# run never leaves something that looks finished. Returns nonzero if the freshly
+# downloaded file does not match, which aborts a `set -e` setup.sh.
+#
+# Example:
+#   proto_download_verified "$URL" "$WEIGHTS_DIR/model.pth" "$MODEL_SHA256"
+#
+# Reference: tools/structure_scoring/metal3d/standalone/setup.sh
+# ---------------------------------------------------------------------------
+proto_download_verified() {
+    local url="$1" dest="$2" expected="$3"
+    local actual
+
+    actual="$(proto_sha256 "$dest")"
+    if [ "$actual" = "$expected" ]; then
+        echo "$(basename "$dest") already present and verified."
+        return 0
+    fi
+    if [ -n "$actual" ]; then
+        echo "$(basename "$dest") failed checksum verification; re-downloading."
+    fi
+
+    echo "Downloading $(basename "$dest")..."
+    curl -fsSL -o "${dest}.part" "$url"
+    actual="$(proto_sha256 "${dest}.part")"
+    if [ "$actual" != "$expected" ]; then
+        rm -f "${dest}.part"
+        echo "ERROR: checksum mismatch for ${url} (expected ${expected}, got ${actual})" >&2
+        return 1
+    fi
+    mv "${dest}.part" "$dest"
 }


### PR DESCRIPTION
**Stack 6/7** — base: `fix/pdockq2-interface-contacts`

Fixes `metal3d-clean` failing to `torch.load()` its checkpoint.

### Genuine corruption, permanently cached

`metal3d_clean.pth` on disk was **12306560 bytes** against **15202392** upstream — truncated. `metal3d_cat.pth` hashed byte-identical to upstream, so only one file was bad.

It never self-healed because of the same `[ ! -f ]` guard ipsae had: the file exists, so setup skips the download every time. And a truncated `.pth` still carries the torch ZIP magic (`504b0304`), so it looks valid right up until `torch.load()` fails — with no recovery short of deleting the file by hand.

### A shared helper instead of a second inline copy

Since this is the second instance of the pattern, it's promoted into `standalone_helpers.sh` rather than inlined again:

- `proto_download_verified <url> <dest> <sha256>` and `proto_sha256 <path>`, documented alongside `proto_download_gdrive`
- metal3d verifies all three checkpoints against pinned digests on every run
- **ipsae is refactored onto the helper**, dropping the inline block added in stack 2/7

### Verification

The fix repaired the corruption automatically: `metal3d_clean.pth` is now 15202392 bytes, digest `166e5acb…` matching upstream, re-downloaded with no manual intervention. 5 metal3d tests passed — `metal3d-clean` genuinely ran and loaded, and `cat`/`original` still pass. ipsae re-verified after the refactor: 9 passed.

Helper tested in isolation: missing → downloads; valid → skips; **truncated → detects and repairs**; wrong digest → aborts with exit 1, no `.part` left.

### Stack note

This PR edits `ipsae/standalone/setup.sh`, which stack 2/7 also touches. Fine in a linear stack since ipsae is an ancestor — but if these are split into independent PRs, this one depends on 2/7.