### PR TITLE
Sample progen2 from its own distribution under minimal(), not the conservative default

### DIFF
--- a/proto_tools/tools/causal_models/progen2/progen2_sample.py
+++ b/proto_tools/tools/causal_models/progen2/progen2_sample.py
@@ -4,7 +4,7 @@ ProGen2 sampling tool.
 """
 
 import logging
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import Field
 
@@ -146,6 +146,20 @@ class ProGen2SampleConfig(CausalModelSampleConfig):
         default=False,
         description="Include per-position logits in the output (large; disable to save memory)",
     )
+
+    @classmethod
+    def minimal(cls, **kwargs: Any) -> "ProGen2SampleConfig":
+        """Sample short sequences from the model's own distribution.
+
+        The shipped ``temperature`` of 0.2 is deliberately conservative, and from a
+        short prompt it concentrates the distribution enough to emit long
+        single-residue repeats: separate draws pick the same token, so duplicate
+        prompts come back identical. Sampling at 1.0 keeps the generated sequences
+        varied, which is what the stochastic-tool test infrastructure exercises.
+        """
+        kwargs.setdefault("temperature", 1.0)
+        kwargs.setdefault("max_new_tokens", 32)
+        return cast("ProGen2SampleConfig", super().minimal(**kwargs))
 
     def remote_unsupported_reason(self, device: RemoteDevice) -> str | None:
         """A local weights directory (``local_path``) isn't present on a hosted worker."""


### PR DESCRIPTION
**Stack 7/7** — base: `fix/metal3d-clean-checkpoint`

Fixes `test_duplicate_inputs_produce_diverse_outputs[progen2-sample]` (`expected 3 distinct outputs, got 2`).

### Not an RNG bug

The other two seed tests pass, including `test_duplicate_inputs_reproducible_across_calls` — the RNG is seeded and advancing between batch elements. `set_torch_seed(seed)` runs once per dispatch and all prompts then draw from the shared torch stream.

The outputs were **degenerate**: `MKTL` + one residue + ~250 identical leucines, with two byte-identical and the third differing at a single position. Classic low-temperature repetition collapse.

### Measured across temperatures

| T | distinct | max single-AA fraction | output |
|---|---|---|---|
| **0.2** (shipped default) | **2/3** | **0.94** | poly-leucine — degenerate |
| 0.5 | 3/3 | 0.38 | protein-like |
| 0.8 | 3/3 | 0.25 | protein-like |
| 1.0 | 3/3 | 0.16 | protein-like |

So the test's *contract* (RNG advances between batch elements) held, while its *proxy* (three distinct outputs) is invalid at a temperature where the distribution is too peaked for different draws to pick different tokens.

### Why `minimal()`, and why not the default

`minimal()` is the sanctioned hook — its docstring exists so test infrastructure can run every tool "without tool-specific hardcoding in test helpers." The alternative, another `if spec.key == ...` branch in `build_inputs_and_config`, is what that docstring discourages.

Crucially this **leaves the shipped default alone**: the README documents `temperature=0.2` as a deliberate conservative choice, so changing it to make a test pass would alter documented user-facing behavior. Tests now sample at 1.0 (the model's own distribution); users get unchanged behavior.

`max_new_tokens` drops 256 → 32, a real cost saving across every seed test (seed tests were 2.32h of the original 10h run). All existing progen2 tests set `max_new_tokens` explicitly, so none depend on the minimal defaults.

### Verification

5 seed tests passed (diversification + both reproducibility), 28 progen2 unit tests passed, style suite green.

### Separate finding, deliberately not changed

`temperature=0.2` produces poly-leucine, contradicting the README's claim that it keeps generations "close to natural-looking sequences." That's a real defaults-vs-docs gap in user-facing behavior, but changing a documented default is a product decision — flagging rather than doing it.