### PR TITLE
Refuse a structure URL that names the fetching machine's own network

### DIFF
--- a/proto_tools/entities/structures/structure.py
+++ b/proto_tools/entities/structures/structure.py
@@ -33,8 +33,41 @@ from proto_tools.entities.structures.utils import (
 from proto_tools.utils.tool_io import Metrics, MetricValue
 
 
+def _reject_private_address(url: str) -> None:
+    """Refuse a URL naming an address that is not routable on the public internet.
+
+    A structure field accepts a URL, and whoever supplies it does not necessarily own the machine
+    that fetches it -- a server accepting structures fetches on behalf of its callers. Left
+    unchecked that turns the field into a request-forgery primitive: ``169.254.169.254`` for cloud
+    instance credentials, or a private address for a service reachable only from inside.
+
+    Resolved rather than pattern-matched, so a public hostname pointing at a private address is
+    refused too.
+
+    Raises:
+        ValueError: If the host is unresolvable or resolves to a non-public address.
+    """
+    import ipaddress
+    import socket
+    from urllib.parse import urlparse
+
+    host = urlparse(url).hostname
+    if not host:
+        raise ValueError(f"structure URL names no host: {url!r}")
+    try:
+        resolved = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"could not resolve structure URL host {host!r}") from exc
+    for info in resolved:
+        address = ipaddress.ip_address(info[4][0])
+        if not address.is_global:
+            raise ValueError(f"structure URL host {host!r} resolves to the non-public address {address}")
+
+
 def _fetch_structure_url(url: str, timeout: float = 30.0) -> str:
     """Fetch structure-file text content from an ``http(s)`` URL.
+
+    The scheme is already ``http(s)``: every caller reaches this through :func:`looks_like_url`.
 
     Args:
         url (str): URL returning PDB or CIF content.
@@ -45,10 +78,17 @@ def _fetch_structure_url(url: str, timeout: float = 30.0) -> str:
 
     Raises:
         requests.HTTPError: If the request returns an error status.
+        ValueError: If the URL names a non-public address, or answers with a redirect.
     """
     import requests
 
-    response = requests.get(url, timeout=timeout)
+    _reject_private_address(url)
+    # Redirects are not followed: a hijacked host, or one that simply chooses to, could steer the
+    # fetch to an address the check above just refused. ``raise_for_status`` would not catch it,
+    # since a 3xx is not an error status.
+    response = requests.get(url, timeout=timeout, allow_redirects=False)
+    if response.is_redirect:
+        raise ValueError(f"structure URL redirected to {response.headers.get('Location')!r}; not followed")
     response.raise_for_status()
     return response.text
 

--- a/tests/structure_tests/test_selection.py
+++ b/tests/structure_tests/test_selection.py
@@ -338,17 +338,24 @@ def test_base_resolves_url_string(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class Response:
         text = content
+        is_redirect = False
 
         def raise_for_status(self) -> None:
             return None
 
-    def fake_get(request_url: str, timeout: float) -> Response:
+    def fake_get(request_url: str, timeout: float, **kwargs: object) -> Response:
         assert request_url == url
         assert timeout == 30.0
         return Response()
 
+    import socket
+
     import requests
 
+    # ``example.test`` is reserved and does not resolve, and a fetch refuses a host it cannot
+    # resolve before issuing the request. Answer for it, publicly, so this still exercises the
+    # URL-to-Structure path rather than the address check.
+    monkeypatch.setattr(socket, "getaddrinfo", lambda host, port: [(2, 1, 6, "", ("93.184.216.34", 0))])
     monkeypatch.setattr(requests, "get", fake_get)
     inp = _SubInput(structure=url)
     assert isinstance(inp.structure, Structure)

--- a/tests/structure_tests/test_structure_url_fetch.py
+++ b/tests/structure_tests/test_structure_url_fetch.py
@@ -1,0 +1,114 @@
+"""A structure URL cannot be pointed at the fetching machine's own network.
+
+``Structure(structure="https://...")`` fetches transparently, which is convenient when the person
+supplying the URL owns the machine doing the fetch. A server accepting structures from callers is
+the case where they do not, and there the field is a request-forgery primitive: cloud instance
+metadata at ``169.254.169.254``, or a service reachable only from inside a private network.
+
+Offline throughout -- no request leaves the machine.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from proto_tools.entities.structures.structure import _fetch_structure_url
+
+#: Addresses a fetch must refuse, one per reason it is not routable on the public internet.
+PRIVATE_URLS = [
+    "http://169.254.169.254/latest/meta-data/",  # cloud instance metadata
+    "http://127.0.0.1:8000/health",  # loopback
+    "http://10.0.0.5/internal",  # private range
+    "http://192.168.1.1/",  # private range
+    "http://[::1]:8000/",  # loopback, IPv6
+]
+
+
+@pytest.fixture
+def no_requests(monkeypatch):
+    """Fail loudly if anything actually issues a request."""
+    import requests
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError(f"a request was issued: {args!r}")
+
+    monkeypatch.setattr(requests, "get", _forbidden)
+
+
+@pytest.mark.parametrize("url", PRIVATE_URLS)
+def test_a_private_address_is_refused(url, no_requests):
+    """Refused before the request, so nothing reaches the address even once."""
+    with pytest.raises(ValueError, match="non-public address"):
+        _fetch_structure_url(url)
+
+
+def test_a_public_hostname_resolving_somewhere_private_is_refused(monkeypatch, no_requests):
+    """Pattern-matching the URL would miss this; the check resolves the host instead."""
+    import socket
+
+    monkeypatch.setattr(socket, "getaddrinfo", lambda host, port: [(2, 1, 6, "", ("10.1.2.3", 0))])
+    with pytest.raises(ValueError, match="non-public address"):
+        _fetch_structure_url("https://structures.example.com/1abc.cif")
+
+
+def test_an_unresolvable_host_is_refused(monkeypatch, no_requests):
+    """Unresolvable is refused rather than attempted, so failure is one clear error."""
+    import socket
+
+    def _fail(host, port):
+        raise socket.gaierror("nope")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fail)
+    with pytest.raises(ValueError, match="could not resolve"):
+        _fetch_structure_url("https://nonexistent.invalid/1abc.cif")
+
+
+def test_a_redirect_is_not_followed(monkeypatch):
+    """The address check runs before the request, so a redirect would escape it.
+
+    ``raise_for_status`` does not catch this on its own: a 3xx is not an error status.
+    """
+    import requests
+
+    captured: dict = {}
+
+    class _Redirect:
+        status_code = 302
+        is_redirect = True
+        text = ""
+
+        def __init__(self) -> None:
+            self.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_get(url, **kwargs):
+        captured.update(kwargs)
+        return _Redirect()
+
+    monkeypatch.setattr(requests, "get", _fake_get)
+
+    with pytest.raises(ValueError, match="redirected"):
+        _fetch_structure_url("https://files.rcsb.org/download/1TIM.cif")
+    assert captured["allow_redirects"] is False, "requests follows redirects unless told not to"
+
+
+def test_a_public_url_still_fetches(monkeypatch):
+    """The guard must not break the ordinary case it exists to protect."""
+    import requests
+
+    class _Ok:
+        status_code = 200
+        is_redirect = False
+        text = "data_1TIM\n"
+
+        def __init__(self) -> None:
+            self.headers: dict = {}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(requests, "get", lambda url, **kwargs: _Ok())
+
+    assert _fetch_structure_url("https://files.rcsb.org/download/1TIM.cif") == "data_1TIM\n"


### PR DESCRIPTION
A structure field accepts an `http(s)` URL and fetches it transparently. That is convenient when whoever supplies the URL owns the machine doing the fetch; it is a server-side request forgery primitive when they do not, which is the case for anything accepting structures from callers.

Two gaps, both in `_fetch_structure_url`, which every URL fetch funnels through:

- No address restriction. `http://169.254.169.254/latest/meta-data/` reaches cloud instance metadata; a private address reaches services meant to be internal.
- `requests.get` follows redirects by default, so a host could answer 302 and steer the fetch anywhere.

Now the host is resolved and refused unless every address it resolves to is globally routable — resolved rather than pattern-matched, so a public hostname pointing at a private address is refused too — and redirects are not followed. `raise_for_status` would not have caught a 3xx, since it is not an error status.

This matches the guard already used in `proto_tools_api/assets/public_db.py`.

One existing test needed updating: `test_base_resolves_url_string` used `example.test`, which is reserved and does not resolve, so it now stubs the resolver to keep exercising the URL-to-Structure path.