### PR TITLE
Spill oversized leaves inside a list, not the whole list

### DIFF
--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -524,9 +524,14 @@ def _summarize(value: Any, key_path: str, output_dir: Path) -> Any:
     if isinstance(value, dict):
         return {k: _summarize(v, f"{key_path}.{k}" if key_path else k, output_dir) for k, v in value.items()}
     if isinstance(value, list):
-        rendered = json.dumps(value, default=str)
+        items = [
+            _summarize(v, f"{key_path}.{i}" if key_path else str(i), output_dir) if isinstance(v, dict) else v
+            for i, v in enumerate(value)
+        ]
+        rendered = json.dumps(items, default=str)
         if len(rendered) <= INLINE_CHAR_LIMIT:
-            return value
+            return items
+        # Many small items: nothing left to spill individually, so the list goes out whole.
         path = _spill_path(output_dir, key_path, "json")
         path.write_text(rendered)
         return {"_saved_to": str(path), "_kind": "json", "_items": len(value), "_bytes": len(rendered)}

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -301,6 +301,49 @@ def test_summarize_recurses_into_nested_structures(tmp_path):
     assert "_saved_to" in out["outer"]["inner"]
 
 
+def test_summarize_spills_inside_list_items_not_the_whole_list(tmp_path):
+    """A list is sized after its leaves spill, so small siblings of a bulky field stay inline.
+
+    Regression for a real failure: esmfold2-prediction returned its whole
+    ``structures`` list as one placeholder, because a Structure crosses the
+    limit on its coordinate string alone. That took ``metrics`` — pLDDT, pTM,
+    the numbers the call was made for — to disk with it, leaving an agent a
+    result it could not judge without reading the file back.
+    """
+    from proto_tools.mcp import tools as impl
+
+    structure = {"structure": "ATOM" * 40_000, "metrics": {"plddt": 0.91, "ptm": 0.92}}
+    out = impl._summarize({"structures": [structure]}, "", tmp_path)
+
+    assert isinstance(out["structures"], list), "the list itself must survive"
+    assert out["structures"][0]["metrics"] == {"plddt": 0.91, "ptm": 0.92}
+    assert "_saved_to" in out["structures"][0]["structure"]
+
+
+def test_summarize_still_spills_a_list_of_small_items(tmp_path):
+    """Per-leaf spilling cannot shrink a long list of small values, so the list still goes out whole."""
+    from proto_tools.mcp import tools as impl
+
+    out = impl._summarize({"per_residue": list(range(5_000))}, "", tmp_path)
+    assert "_saved_to" in out["per_residue"]
+
+
+def test_summarize_writes_a_numeric_matrix_as_one_file(tmp_path):
+    """A PAE matrix has no small siblings to rescue, so it spills whole rather than row by row.
+
+    Model output is full-precision, which puts a single row over the limit on its own —
+    descending into the matrix would write a file per row and call it an improvement.
+    """
+    from proto_tools.mcp import tools as impl
+
+    pae = [[3.578874111175537 + i + j * 1e-6 for j in range(150)] for i in range(150)]
+    out = impl._summarize({"metrics": {"plddt": 0.914555549621582, "pae": pae}}, "", tmp_path)
+
+    assert out["metrics"]["plddt"] == 0.914555549621582, "small metrics stay inline"
+    assert "_saved_to" in out["metrics"]["pae"]
+    assert len(list(tmp_path.iterdir())) == 1, "the matrix is one file, not one per row"
+
+
 def test_search_matches_natural_language_queries(monkeypatch):
     """Agents ask in prose; a literal substring search returns nothing for that.
 


### PR DESCRIPTION
## The problem

`_summarize` sized a result's list as one unit, without recursing into it. A `Structure` crosses `INLINE_CHAR_LIMIT` on its coordinate string alone (~155 KB of mmCIF), so the whole `structures` list spilled and took `metrics` with it. The agent got back a result carrying no scores at all.

Found while folding GFP (UniProt P42212) through the MCP:

```json
{
  "ok": true,
  "tool": "esmfold2-prediction",
  "ran_on": "modal",
  "result": {
    "success": true,
    "structures": {"_saved_to": ".../structures.json", "_kind": "json", "_items": 1, "_bytes": 160806}
  }
}
```

Nothing there says whether the fold is any good. The numbers the call was made for were inside the spilled file:

```
plddt    0.9146
ptm      0.9154
avg_pae  3.579
```

Recovering them meant loading the JSON and indexing `[0]["metrics"]`, which is the round trip the spill mechanism exists to avoid. An agent that wants to report or gate on confidence has to do that on every structure-prediction call.

Worth noting that `_elide` already treats lists correctly on the example path: it maps over elements and replaces only the oversized leaves. The two functions disagreed about lists.

## The change

Recurse into dict items first, size the list after, so the decision is made at the leaf. The same payload now returns:

```json
"structures": [
  {
    "structure": {"_saved_to": ".../structures_0_structure.txt", "_kind": "text", "_bytes": 158367},
    "structure_format": "cif",
    "b_factor_type": "pLDDT",
    "source": "esmfold2-prediction",
    "metrics": {"primary_metric": "plddt", "plddt": 0.9146, "ptm": 0.9154, "avg_pae": 3.579}
  }
]
```

Only dict items are descended into. A numeric array has no small siblings worth rescuing, and at the precision a model actually emits, one row of a PAE matrix clears the limit on its own, so descending would write a file per row. An earlier revision of this patch did exactly that, turning one 238x238 matrix into 239 files; rounded test data hid it, and full-precision data exposed it. `test_summarize_writes_a_numeric_matrix_as_one_file` now pins that, and the whole-list spill remains the fallback for a long list of small values.

Indexing the key path (`structures.0.structure`) also gives spilled items distinct filenames, where before two large fields under one list key would have collided.

`_walk_saved` needed no change; it already recurses into lists, so `saved_files` reports the per-item paths.

## Verification

- New test `test_summarize_spills_inside_list_items_not_the_whole_list` fails on `main` with exactly the reported shape (`_items: 1`, `_bytes: 160060`) and passes here.
- New test `test_summarize_still_spills_a_list_of_small_items` guards the fallback.
- Drove a real `ESMFold2Output` through the live MCP surface with `fastmcp.Client`, substituting only the GPU compute: the genuine 155 KB mmCIF, the genuine metrics, plus a full-precision 238x238 PAE matrix as `include_pae_matrix` emits. Before: one `<SPILLED json 1,278,880B>` placeholder and no scores. After: `plddt` / `ptm` / `avg_pae` inline, coordinates in `structures_0_structure.txt`, matrix in `structures_0_metrics_pae.json`, two files total.
- `tests/modal_tests` and `tests/functional_tests` pass. Two failures are unrelated and reproduce on a clean checkout of this branch point: `test_deployment_packages_are_excluded_from_the_wheel` and `test_the_mcp_console_script_resolves`.

## Follow-up, deliberately not in this PR

The spilled coordinate file lands as `.txt` while holding mmCIF, visible in the output above. `Structure.structure_format` already knows the answer, but threading it into `_spill_path` means a leaf-level function learning about its siblings, which is a design call worth making separately. Happy to open it as a second PR.
