### PR TITLE
Ask Modal for the app listing once instead of per app

### DIFF
--- a/proto_tools/utils/modal_status.py
+++ b/proto_tools/utils/modal_status.py
@@ -7,9 +7,12 @@ SDK at module scope, so the credential checks still answer in that state.
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Both must be set for the SDK to authenticate from the environment.
 TOKEN_VARS = ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET")
@@ -73,11 +76,54 @@ def auth_mechanism() -> str | None:
     return None
 
 
+def _listed_apps(environment: str, client: Any | None) -> set[str]:
+    """Names of the deployed apps in ``environment``, from one call.
+
+    This is the request ``modal app list`` makes, and the SDK's own blocking bridge is what runs
+    it, so a caller holding an ordinary ``modal.Client`` needs no event loop of its own.
+    """
+    import modal
+    from modal._utils.async_utils import synchronizer
+    from modal_proto import api_pb2
+
+    @synchronizer.create_blocking
+    async def _list(asking_as: Any) -> Any:
+        return await asking_as.stub.AppList(api_pb2.AppListRequest(environment_name=environment))
+
+    response = _list(client if client is not None else modal.Client.from_env())
+    return {app.description for app in response.apps if app.state == api_pb2.APP_STATE_DEPLOYED}
+
+
+def _hydrated_apps(environment: str, client: Any | None) -> set[str]:
+    """The same answer, asked one app at a time.
+
+    Kept as the fallback for :func:`deployed_apps` because the fast path reaches into SDK
+    internals: if a Modal upgrade moves them, this still answers, only slowly.
+    """
+    import modal
+
+    from proto_tools.modal.manifest import APP_BUCKETS
+
+    live = set()
+    for app_name, services in APP_BUCKETS.items():
+        try:
+            modal.Cls.from_name(app_name, services[0], environment_name=environment, client=client).hydrate()
+            live.add(app_name)
+        except Exception:  # noqa: S112 — an unreachable app is "not deployed", not an error
+            continue
+    return live
+
+
 def deployed_apps(environment: str | None = None, client: Any | None = None) -> set[str]:
     """Apps that currently resolve in the Modal environment a dispatch would reach.
 
-    One hydrate per app, no containers started. Failures read as "not deployed"
-    rather than propagating.
+    One listing call, no containers started. Failures read as "not deployed" rather than
+    propagating.
+
+    Asking per app instead costs a round trip each, which is seconds across the catalogue and
+    grows with every tool added. Callers use this to describe a whole catalogue at once, so the
+    question is "what is deployed here" rather than "is this one app deployed", and Modal answers
+    that in a single request.
 
     The environment is named rather than inherited, and must be: a dispatch resolves
     ``proto-env`` while an unconfigured Modal profile resolves the workspace default, so asking
@@ -92,17 +138,11 @@ def deployed_apps(environment: str | None = None, client: Any | None = None) -> 
     Returns:
         set[str]: App names that resolve.
     """
-    import modal
-
     from proto_tools.modal.app import resolve_environment
-    from proto_tools.modal.manifest import APP_BUCKETS
 
     environment = resolve_environment(environment)
-    live = set()
-    for app_name, services in APP_BUCKETS.items():
-        try:
-            modal.Cls.from_name(app_name, services[0], environment_name=environment, client=client).hydrate()
-            live.add(app_name)
-        except Exception:  # noqa: S112 — an unreachable app is "not deployed", not an error
-            continue
-    return live
+    try:
+        return _listed_apps(environment, client)
+    except Exception:
+        logger.warning("could not list Modal apps; falling back to per-app lookup", exc_info=True)
+        return _hydrated_apps(environment, client)

--- a/tests/modal_tests/test_call_scoped_dispatch.py
+++ b/tests/modal_tests/test_call_scoped_dispatch.py
@@ -232,27 +232,52 @@ def test_deployed_apps_asks_about_the_dispatch_environment(monkeypatch):
     ``resolve_environment`` picks. That made ``list_tools(deployed_only=True)`` describe a
     different environment's deployments, and hid apps that were in fact deployed.
     """
+    from proto_tools.utils import modal_status
+
+    seen: list[str] = []
+
+    def listed(environment, _client):
+        seen.append(environment)
+        return {"proto-tools-esm2"}
+
+    monkeypatch.setattr(modal_status, "_listed_apps", listed)
+    monkeypatch.delenv("MODAL_ENVIRONMENT", raising=False)
+
+    assert modal_status.deployed_apps() == {"proto-tools-esm2"}
+    assert seen == ["proto-env"], f"asked about the wrong environment: {seen}"
+
+
+def test_deployed_apps_falls_back_when_the_listing_fails(monkeypatch):
+    """A broken fast path must not read as an empty workspace.
+
+    The listing goes through SDK internals, so a Modal upgrade can move it out from under us.
+    Nothing distinguishes "could not ask" from "nothing is deployed" at the call site, and the
+    latter hides every tool a user has — so the slow path has to answer instead.
+    """
     import modal
 
-    from proto_tools.utils.modal_status import deployed_apps
+    from proto_tools.modal.manifest import APP_BUCKETS
+    from proto_tools.utils import modal_status
 
-    seen: list[str | None] = []
+    def refuse(_environment, _client):
+        raise RuntimeError("AppList moved")
+
+    probed: list[str] = []
 
     class _Hydrated:
         def hydrate(self):
             return None
 
-    def cls_from_name(_app, _name, *, environment_name=None, **_kwargs):
-        seen.append(environment_name)
+    def cls_from_name(app_name, _service, *, environment_name=None, **_kwargs):
+        probed.append(environment_name)
         return _Hydrated()
 
+    monkeypatch.setattr(modal_status, "_listed_apps", refuse)
     monkeypatch.setattr(modal.Cls, "from_name", staticmethod(cls_from_name))
     monkeypatch.delenv("MODAL_ENVIRONMENT", raising=False)
 
-    deployed_apps()
-
-    assert seen, "no apps were probed"
-    assert set(seen) == {"proto-env"}, f"probed the wrong environment: {set(seen)}"
+    assert modal_status.deployed_apps() == set(APP_BUCKETS)
+    assert set(probed) == {"proto-env"}, f"fell back onto the wrong environment: {set(probed)}"
 
 
 def test_supplied_client_satisfies_the_credential_check(monkeypatch, tmp_path):


### PR DESCRIPTION
`deployed_apps` hydrated every app in `APP_BUCKETS` in turn, one network round trip each. Measured against a real workspace: **12.2s** for 56 apps, and it grows with every tool added.

The callers use this to describe a whole catalogue at once, so the question is "what is deployed here", not "is this one app deployed". Modal answers that in a single request, the same one `modal app list` makes:

| | time | answer |
|---|---|---|
| per-app hydrate | 12.2s | 55/56 resolve |
| single listing | 0.6s | identical |

Verified against a live workspace: the two agree exactly, including the one app that is genuinely not deployed.

### Why this showed up

proto-tools-api serves this over HTTP so the tools UI can badge each card as deployed or not. A 12s sweep sat on top of the frontend proxy's timeout, so the request often died and the badges silently vanished — the UI cannot tell "still loading" from "could not ask".

### The fallback

The listing uses `modal._utils.async_utils.synchronizer`, the SDK's own blocking bridge (`modal app list` is written the same way). That is internal surface, so the per-app sweep is kept as `_hydrated_apps` and runs if the fast path raises. Nothing distinguishes "could not ask" from "nothing is deployed" at the call site, and the latter hides every tool a user has, so a Modal upgrade moving those internals should cost latency rather than blank the answer.

### Tests

- `test_deployed_apps_asks_about_the_dispatch_environment` — kept, now asserting the environment reaches the listing call.
- `test_deployed_apps_falls_back_when_the_listing_fails` — new; a broken listing still reports the deployed set.

`tests/style_consistency_tests/`, `tests/modal_tests/` and `tests/tool_infra_tests/test_cli.py` pass (9099 passed). One unrelated pre-existing failure locally, `test_deployment_packages_are_excluded_from_the_wheel`, is a `tomllib` import under my local Python 3.10; it fails identically on `main` and CI runs 3.12.