### PR TITLE
PARADE: select cell lines by name, not just anonymized code

### DIFF
--- a/proto_tools/tools/sequence_scoring/parade/README.md
+++ b/proto_tools/tools/sequence_scoring/parade/README.md
@@ -15,7 +15,7 @@ PARADE (Prediction And RAtional DEsign of mRNA UTRs) is a LegNet convolutional m
 
 PARADE ([Khoroshkin et al., 2024](https://doi.org/10.1101/2024.12.31.630783)) is a generative framework for designing UTRs with tailored cell-type-specific activity. Its predictive core adapts the DREAM-challenge LegNet architecture: an EfficientNet-style convolutional network with squeeze-and-excite blocks that reads a one-hot UTR sequence plus a reading-frame positional channel and, for activity, broadcast cell-condition channels.
 
-The activity models are trained per construct type — one for 5' UTRs and one for 3' UTRs — and condition on a panel of anonymized cell-line codes (`c1`, `c2`, `c4`, `c6`, `c17`, and, for 3' UTRs, `c13`), returning a predicted activity mass-center for each. A separate 3' UTR model predicts mRNA stability as an RNA/gDNA log-ratio. The featurization matches the upstream reference pipeline exactly, so predictions reproduce the published values.
+The activity models are trained per construct type — one for 5' UTRs and one for 3' UTRs — and condition on a panel of named cell lines (`c1` MDA-MB-231, `c2` HepG2, `c4` Jurkat, `c6` SW480, `c17` NALM6, and, for 3' UTRs only, `c13` PA-1), returning a predicted activity mass-center for each. A separate 3' UTR model predicts mRNA stability as an RNA/gDNA log-ratio. The featurization matches the upstream reference pipeline exactly, so predictions reproduce the published values.
 
 ## Tools
 
@@ -30,7 +30,7 @@ Use this tool to rank UTR designs by predicted activity, screen candidate UTRs f
 #### Usage Tips
 
 - **Pick the construct type.** Set `construct_type` to `utr5` or `utr3`; it selects the matching checkpoint and cell-code panel.
-- **Cell codes are panel-specific.** `c13` exists only for `utr3`. Leave `cell_types` empty to return the full panel for the construct type.
+- **Cell codes are panel-specific.** `c13` exists only for `utr3`. Select a cell line by either its code (`c2`) or its cell-line name (`HepG2`, case-insensitive). Leave `cell_types` empty to return the full panel for the construct type.
 - **Match the training length.** Upstream trained the 5' UTR model on ~50-nt inserts and the 3' UTR model on ~240-nt (roughly 200–300 nt) inserts; the model accepts any length (adaptive pooling) but predictions are only meaningful near the training regime.
 - **Mixed lengths batch together.** Different-length sequences in one call are batched per length group; RNA input (`U`) is accepted and mapped to `T`.
 
@@ -59,7 +59,7 @@ Use this tool inside gradient-based UTR design loops (e.g. Fast SeqProp) to maxi
 #### Usage Tips
 
 - **Logits are batched.** Pass logits with shape `B x L x 4` in `A,C,G,T` order; use `B=1` for a single candidate.
-- **Terms target cell codes.** Each loss term names a `cell_type`, a `direction` (`max`/`min`), and a `weight`; all codes must be in the `construct_type` panel.
+- **Terms target cell codes.** Each loss term names a `cell_type` — its code (`c2`) or cell-line name (`HepG2`, case-insensitive) — a `direction` (`max`/`min`), and a `weight`; all must be in the `construct_type` panel.
 - **Soft/hard mixing controls relaxation.** `soft=1.0, hard=0.0` is fully soft; increasing `hard` uses a straight-through hard-forward estimator.
 
 ## Toolkit Notes

--- a/proto_tools/tools/sequence_scoring/parade/__init__.py
+++ b/proto_tools/tools/sequence_scoring/parade/__init__.py
@@ -25,21 +25,25 @@ from proto_tools.tools.sequence_scoring.parade.parade_stability import (
     run_parade_stability,
 )
 from proto_tools.tools.sequence_scoring.parade.shared_data_models import (
+    PARADE_CELL_LINE_NAMES,
     PARADE_CELL_TYPES,
     PARADE_CHECKPOINTS,
     PARADE_COMMIT,
     ParadeActivityMetrics,
     ParadeCellType,
     ParadeConstructType,
+    resolve_cell_type,
 )
 
 __all__ = [
     # Shared constants and types
+    "PARADE_CELL_LINE_NAMES",
     "PARADE_CELL_TYPES",
     "PARADE_CHECKPOINTS",
     "PARADE_COMMIT",
     "ParadeCellType",
     "ParadeConstructType",
+    "resolve_cell_type",
     # Activity
     "ParadeActivityInput",
     "ParadeActivityConfig",

--- a/proto_tools/tools/sequence_scoring/parade/parade_activity.py
+++ b/proto_tools/tools/sequence_scoring/parade/parade_activity.py
@@ -4,7 +4,7 @@ import csv
 import json
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, Field, ValidationInfo, computed_field, field_validator
 
@@ -53,10 +53,7 @@ class ParadeActivityConfig(ParadeCheckpointConfig):
     cell_types: list[ParadeCellType] = ConfigField(
         title="Cell Types",
         default_factory=list,
-        description=(
-            "PARADE cell lines to return by code ('c2') or name ('HepG2', case-insensitive); "
-            "empty returns the full panel for the construct type."
-        ),
+        description="Cell lines to return by code ('c2') or name ('HepG2'); empty returns the full panel.",
     )
 
     @field_validator("cell_types", mode="before")
@@ -165,7 +162,7 @@ class ParadeActivityOutput(BaseToolOutput):
 
         A display aid derived from ``cell_types``; ``scores`` stays keyed by the canonical code.
         """
-        return {code: PARADE_CELL_LINE_NAMES[code] for code in self.cell_types}
+        return {code: PARADE_CELL_LINE_NAMES[cast(ParadeCellType, code)] for code in self.cell_types}
 
     def __len__(self) -> int:
         """Return the number of per-sequence results."""
@@ -203,7 +200,9 @@ class ParadeActivityOutput(BaseToolOutput):
                 ],
                 "construct_type": self.construct_type,
                 "cell_types": self.cell_types,
-                "cell_line_names": {code: PARADE_CELL_LINE_NAMES[code] for code in self.cell_types},
+                "cell_line_names": {
+                    code: PARADE_CELL_LINE_NAMES[cast(ParadeCellType, code)] for code in self.cell_types
+                },
             }
             with open(path, "w") as f:
                 json.dump(data, f, indent=2)
@@ -211,7 +210,9 @@ class ParadeActivityOutput(BaseToolOutput):
         if file_format == "csv":
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                cell_headers = [f"{PARADE_CELL_LINE_NAMES[code]} ({code})" for code in self.cell_types]
+                cell_headers = [
+                    f"{PARADE_CELL_LINE_NAMES[cast(ParadeCellType, code)]} ({code})" for code in self.cell_types
+                ]
                 writer.writerow(["sequence_index", "sequence", "sequence_length", *cell_headers])
                 for idx, result in enumerate(self.results):
                     writer.writerow(

--- a/proto_tools/tools/sequence_scoring/parade/parade_activity.py
+++ b/proto_tools/tools/sequence_scoring/parade/parade_activity.py
@@ -9,12 +9,14 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationInfo, computed_field, field_validator
 
 from proto_tools.tools.sequence_scoring.parade.shared_data_models import (
+    PARADE_CELL_LINE_NAMES,
     PARADE_CELL_TYPES,
     ParadeActivityMetrics,
     ParadeCellType,
     ParadeCheckpointConfig,
     ParadeConstructType,
     ParadeSequenceInput,
+    resolve_cell_type,
     resolve_checkpoint_source,
 )
 from proto_tools.tools.tool_registry import tool
@@ -32,9 +34,10 @@ class ParadeActivityConfig(ParadeCheckpointConfig):
             (5' UTR) or ``"utr3"`` (3' UTR). Selects the checkpoint and the cell-code
             panel. Matching the upstream predictor, the model scores the bare insert
             (no reporter flanks are added).
-        cell_types (list[ParadeCellType]): PARADE cell codes to return. Empty means
-            the full panel for ``construct_type``. Requested codes must belong to
-            that panel.
+        cell_types (list[ParadeCellType]): PARADE cell lines to return, each given by
+            code (``"c2"``) or cell-line name (``"HepG2"``, case-insensitive); names are
+            resolved to canonical codes. Empty means the full panel for ``construct_type``.
+            Requested codes must belong to that panel.
         checkpoint (str): Optional override for the pinned checkpoint — a local ``.ckpt`` path or an
             ``https`` link (a schemeless ``host.tld/path`` is accepted). Caller overrides run on local
             devices only (rejected on ``device="proto"``). Empty uses the pinned per-target checkpoint.
@@ -50,18 +53,25 @@ class ParadeActivityConfig(ParadeCheckpointConfig):
     cell_types: list[ParadeCellType] = ConfigField(
         title="Cell Types",
         default_factory=list,
-        description="PARADE cell codes to return; empty returns the full panel for the construct type.",
+        description=(
+            "PARADE cell lines to return by code ('c2') or name ('HepG2', case-insensitive); "
+            "empty returns the full panel for the construct type."
+        ),
     )
 
     @field_validator("cell_types", mode="before")
     @classmethod
     def normalize_cell_types(cls, value: Any) -> list[Any]:
-        """Normalize a single cell code to a list."""
+        """Normalize a single selector to a list and resolve names or codes to canonical codes."""
         if value is None:
             return []
         if isinstance(value, str):
-            return [value]
-        return value  # type: ignore[no-any-return]
+            value = [value]
+        if not isinstance(value, list):
+            return value  # type: ignore[no-any-return]
+        # Resolve every str selector (a cell code or cell-line name) to its canonical code; leave
+        # non-str items untouched so the field's type validation rejects them with a clear error.
+        return [resolve_cell_type(item) if isinstance(item, str) else item for item in value]
 
     @field_validator("construct_type")
     @classmethod
@@ -123,6 +133,9 @@ class ParadeActivityOutput(BaseToolOutput):
         construct_type (str): UTR model used, derived from ``results`` (computed field).
         cell_types (list[str]): Cell codes in each result, derived from ``results``
             (computed field).
+        cell_line_names (dict[str, str]): ``{code: cell-line name}`` for the present codes,
+            a display aid derived from ``cell_types`` (computed field); ``scores`` stays
+            code-keyed.
     """
 
     results: list[ParadeActivityResult] = Field(
@@ -144,6 +157,15 @@ class ParadeActivityOutput(BaseToolOutput):
     def cell_types(self) -> list[str]:
         """Cell codes present in each result, derived from ``results`` (computed field)."""
         return [code for code, _ in self.results[0].scores.items()] if self.results else []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def cell_line_names(self) -> dict[str, str]:
+        """Human-readable cell-line name for each present code, ``{code: name}`` (computed field).
+
+        A display aid derived from ``cell_types``; ``scores`` stays keyed by the canonical code.
+        """
+        return {code: PARADE_CELL_LINE_NAMES[code] for code in self.cell_types}
 
     def __len__(self) -> int:
         """Return the number of per-sequence results."""
@@ -181,6 +203,7 @@ class ParadeActivityOutput(BaseToolOutput):
                 ],
                 "construct_type": self.construct_type,
                 "cell_types": self.cell_types,
+                "cell_line_names": {code: PARADE_CELL_LINE_NAMES[code] for code in self.cell_types},
             }
             with open(path, "w") as f:
                 json.dump(data, f, indent=2)
@@ -188,7 +211,8 @@ class ParadeActivityOutput(BaseToolOutput):
         if file_format == "csv":
             with open(path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["sequence_index", "sequence", "sequence_length", *self.cell_types])
+                cell_headers = [f"{PARADE_CELL_LINE_NAMES[code]} ({code})" for code in self.cell_types]
+                writer.writerow(["sequence_index", "sequence", "sequence_length", *cell_headers])
                 for idx, result in enumerate(self.results):
                     writer.writerow(
                         [
@@ -229,6 +253,9 @@ def run_parade_activity(
     instance: Any = None,
 ) -> ParadeActivityOutput:
     """Predict cell-type-specific UTR activity with PARADE.
+
+    A requested cell line may be given by code (``"c2"``) or by cell-line name (``"HepG2"``,
+    case-insensitive); names are resolved to canonical codes and the scores stay code-keyed.
 
     Args:
         inputs (ParadeActivityInput): UTR sequences to score.

--- a/proto_tools/tools/sequence_scoring/parade/parade_gradient.py
+++ b/proto_tools/tools/sequence_scoring/parade/parade_gradient.py
@@ -14,6 +14,7 @@ from proto_tools.tools.sequence_scoring.parade.shared_data_models import (
     ParadeConstructType,
     _SafeCheckpointUrlConfigMixin,
     normalize_checkpoint_override,
+    resolve_cell_type,
     resolve_checkpoint_source,
 )
 from proto_tools.tools.tool_registry import tool
@@ -38,8 +39,9 @@ class ParadeGradientLossTerm(BaseModel):
     """One differentiable PARADE UTR-activity objective term.
 
     Attributes:
-        cell_type (ParadeCellType): PARADE cell code to optimize; must be in the
-            configured ``construct_type`` panel.
+        cell_type (ParadeCellType): PARADE cell to optimize, given by code (``"c2"``) or
+            cell-line name (``"HepG2"``, case-insensitive); resolved to its canonical code,
+            which must be in the configured ``construct_type`` panel.
         direction (ParadeObjectiveDirection): ``"max"`` minimizes
             ``1 - sigmoid((raw - center) / scale)``; ``"min"`` minimizes
             ``sigmoid((raw - center) / scale)``.
@@ -50,7 +52,11 @@ class ParadeGradientLossTerm(BaseModel):
 
     model_config = ConfigDict(extra="forbid", validate_assignment=True, frozen=True)
 
-    cell_type: ParadeCellType = Field(default="c2", title="Cell Type", description="PARADE cell code to optimize.")
+    cell_type: ParadeCellType = Field(
+        default="c2",
+        title="Cell Type",
+        description="PARADE cell to optimize, by code ('c2') or cell-line name ('HepG2', case-insensitive).",
+    )
     direction: ParadeObjectiveDirection = Field(
         default="max",
         title="Direction",
@@ -76,6 +82,14 @@ class ParadeGradientLossTerm(BaseModel):
         title="Sigmoid Scale",
         description="Sigmoid steepness in raw-activity units; larger values produce a wider transition",
     )
+
+    @field_validator("cell_type", mode="before")
+    @classmethod
+    def _resolve_cell_type(cls, value: Any) -> Any:
+        """Accept a cell code ('c2') or cell-line name ('HepG2') and resolve it to its canonical code."""
+        if isinstance(value, str):
+            return resolve_cell_type(value)
+        return value
 
 
 class ParadeGradientInput(BaseToolInput):

--- a/proto_tools/tools/sequence_scoring/parade/shared_data_models.py
+++ b/proto_tools/tools/sequence_scoring/parade/shared_data_models.py
@@ -42,17 +42,65 @@ PARADE_CHECKPOINTS: dict[str, dict[str, str]] = {
     },
 }
 
-# PARADE anonymized cell-line codes exposed (queryable) per UTR construct type -- the codes the
-# upstream tutorial predicts on. These are a subset of the model's trained condition channels: the
-# vendored ``CELLTYPE_CODES_UTR3`` map also has ``c10``, which the checkpoint conditions on but the
-# upstream pipeline never queries, so it is intentionally omitted from the queryable panel here.
-# The model still conditions on all of its trained channels via broadcast one-hot inputs.
+# PARADE's queryable cell-line panel per UTR construct type -- the lines the upstream tutorial
+# predicts on. Each code identifies a human cell line (see ``PARADE_CELL_LINE_NAMES``); the codes
+# remain the canonical identifiers the model is conditioned on, while callers may select a line by
+# either its code or its name. These are a subset of the model's trained condition channels: the
+# vendored ``CELLTYPE_CODES_UTR3`` map also has ``c10`` (an extra, unnamed channel) which the
+# checkpoint conditions on but the upstream pipeline never queries, so it is intentionally omitted
+# from the queryable panel here. The model still conditions on all its trained channels via
+# broadcast one-hot inputs.
 ParadeConstructType = Literal["utr5", "utr3"]
 ParadeCellType = Literal["c1", "c2", "c4", "c6", "c17", "c13"]
 PARADE_CELL_TYPES: dict[str, tuple[ParadeCellType, ...]] = {
     "utr5": ("c1", "c2", "c4", "c6", "c17"),
     "utr3": ("c1", "c2", "c4", "c6", "c17", "c13"),
 }
+
+# Human-readable identities for the queryable panel codes. The upstream PARADE release and paper
+# refer to these conditions only by anonymized code; naming them lets callers select a cell line by
+# name (e.g. ``"HepG2"``) instead of the opaque code. Codes stay canonical -- a name is resolved to
+# its code at the input boundary and the model is always addressed by code. ``c13`` is 3'UTR-only.
+PARADE_CELL_LINE_NAMES: dict[ParadeCellType, str] = {
+    "c1": "MDA-MB-231",
+    "c2": "HepG2",
+    "c4": "Jurkat",
+    "c6": "SW480",
+    "c17": "NALM6",
+    "c13": "PA-1",
+}
+
+# Case-insensitive lookup that accepts either a code (``"c2"``) or a cell-line name (``"HepG2"``).
+_CELL_SELECTOR_TO_CODE: dict[str, ParadeCellType] = {
+    **{code.lower(): code for code in PARADE_CELL_LINE_NAMES},
+    **{name.lower(): code for code, name in PARADE_CELL_LINE_NAMES.items()},
+}
+
+
+def resolve_cell_type(value: str) -> ParadeCellType:
+    """Resolve a PARADE cell selector to its canonical code.
+
+    Accepts either a cell code (``"c2"``) or a cell-line name (``"HepG2"``), matched
+    case-insensitively after stripping surrounding whitespace; a code is returned unchanged.
+    Panel membership (which codes are valid for a given construct type) is enforced separately
+    by the tool configs -- this only maps a name or code to a code.
+
+    Args:
+        value (str): A PARADE cell code or cell-line name.
+
+    Returns:
+        ParadeCellType: The canonical cell code.
+
+    Raises:
+        ValueError: If ``value`` is not a known code or cell-line name.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"PARADE cell type must be a string, got {type(value).__name__}")
+    code = _CELL_SELECTOR_TO_CODE.get(value.strip().lower())
+    if code is None:
+        known = ", ".join(f"{name} ({code})" for code, name in PARADE_CELL_LINE_NAMES.items())
+        raise ValueError(f"Unknown PARADE cell type {value!r}; expected a cell code or cell-line name: {known}")
+    return code
 
 _VALID_INPUT_CHARS = "N"  # U is normalized to T; A/C/G/T come from DNA_NUCLEOTIDES.
 
@@ -364,10 +412,10 @@ class ParadeActivityMetrics(Metrics):
             "type": "float",
             "min": None,
             "max": None,
-            "description": f"Predicted PARADE UTR activity for cell code {code}.",
+            "description": f"Predicted PARADE UTR activity for {PARADE_CELL_LINE_NAMES[code]} (cell code {code}).",
             "better_values_are": "context-dependent",
         }
-        for code in ("c1", "c2", "c4", "c6", "c17", "c13")
+        for code in PARADE_CELL_LINE_NAMES
     }
 
 

--- a/proto_tools/tools/sequence_scoring/parade/shared_data_models.py
+++ b/proto_tools/tools/sequence_scoring/parade/shared_data_models.py
@@ -102,6 +102,7 @@ def resolve_cell_type(value: str) -> ParadeCellType:
         raise ValueError(f"Unknown PARADE cell type {value!r}; expected a cell code or cell-line name: {known}")
     return code
 
+
 _VALID_INPUT_CHARS = "N"  # U is normalized to T; A/C/G/T come from DNA_NUCLEOTIDES.
 
 _CUSTOM_CHECKPOINT_REJECTED = (

--- a/tests/sequence_scoring_tests/test_parade.py
+++ b/tests/sequence_scoring_tests/test_parade.py
@@ -308,6 +308,72 @@ def test_parade_activity_config_rejects_offpanel_and_duplicate_cells() -> None:
         ParadeActivityConfig(construct_type="utr3", cell_types=["c2", "c2"])
 
 
+def test_parade_resolve_cell_type_accepts_codes_and_names() -> None:
+    """resolve_cell_type maps a code or a (case/whitespace-insensitive) cell-line name to its code."""
+    from proto_tools.tools.sequence_scoring.parade.shared_data_models import resolve_cell_type
+
+    assert resolve_cell_type("c2") == "c2"  # a code passes through unchanged
+    assert resolve_cell_type("HepG2") == "c2"  # name -> code
+    assert resolve_cell_type("hepg2") == "c2"  # case-insensitive
+    assert resolve_cell_type(" HepG2 ") == "c2"  # surrounding whitespace stripped
+    assert resolve_cell_type("MDA-MB-231") == "c1"
+    assert resolve_cell_type("PA-1") == "c13"
+    with pytest.raises(ValueError, match="Unknown PARADE cell type"):
+        resolve_cell_type("nope")
+
+
+def test_parade_cell_line_names_are_the_expected_panel_members() -> None:
+    """PARADE_CELL_LINE_NAMES holds exactly the six pairs, each keyed by a member of some panel."""
+    from proto_tools.tools.sequence_scoring.parade.shared_data_models import (
+        PARADE_CELL_LINE_NAMES,
+        PARADE_CELL_TYPES,
+    )
+
+    assert PARADE_CELL_LINE_NAMES == {
+        "c1": "MDA-MB-231",
+        "c2": "HepG2",
+        "c4": "Jurkat",
+        "c6": "SW480",
+        "c17": "NALM6",
+        "c13": "PA-1",
+    }
+    panel_codes = {code for panel in PARADE_CELL_TYPES.values() for code in panel}
+    assert all(code in panel_codes for code in PARADE_CELL_LINE_NAMES)
+
+
+def test_parade_activity_config_resolves_cell_line_names() -> None:
+    """cell_types accepts cell-line names and codes, normalizing both to canonical codes."""
+    from proto_tools.tools.sequence_scoring.parade import ParadeActivityConfig
+
+    by_name = ParadeActivityConfig(cell_types=["HepG2", "Jurkat"])
+    assert by_name.cell_types == ["c2", "c4"]
+    assert by_name.resolved_cell_types == ["c2", "c4"]
+    # A name and a code can be mixed in the same request.
+    assert ParadeActivityConfig(cell_types=["HepG2", "c4"]).cell_types == ["c2", "c4"]
+    # A single string selector normalizes to a one-item code list.
+    assert ParadeActivityConfig(cell_types="HepG2").cell_types == ["c2"]
+
+
+def test_parade_activity_config_rejects_offpanel_and_unknown_names() -> None:
+    """A name resolving to an off-panel code, or an unknown name, is rejected on the config."""
+    from proto_tools.tools.sequence_scoring.parade import ParadeActivityConfig
+
+    # PA-1 resolves to c13, which is 3'UTR-only and therefore off the utr5 panel.
+    with pytest.raises(ValidationError, match="not in the utr5 panel"):
+        ParadeActivityConfig(construct_type="utr5", cell_types=["PA-1"])
+    with pytest.raises(ValidationError, match="Unknown PARADE cell type"):
+        ParadeActivityConfig(cell_types=["nope"])
+
+
+def test_parade_gradient_loss_term_resolves_cell_line_name() -> None:
+    """A loss-term cell_type given as a cell-line name resolves to its canonical code."""
+    from proto_tools.tools.sequence_scoring.parade import ParadeGradientConfig, ParadeGradientLossTerm
+
+    assert ParadeGradientLossTerm(cell_type="HepG2").cell_type == "c2"
+    config = ParadeGradientConfig(loss_terms=[ParadeGradientLossTerm(cell_type="HepG2")])
+    assert config.loss_terms[0].cell_type == "c2"
+
+
 def test_parade_activity_run_dispatches_and_maps_scores(monkeypatch) -> None:
     """run_parade_activity dispatches to the worker and pivots per-cell scores."""
     import proto_tools.tools.sequence_scoring.parade.parade_activity as parade_activity


### PR DESCRIPTION
## Summary

Let callers select PARADE cell lines by **human-readable name** (e.g. `HepG2`) in
addition to the existing panel codes (`c2`). Names resolve to codes at the input
boundary; codes stay canonical everywhere internal and on the wire to the model, so
the change is backward-compatible.

## Motivation

PARADE's activity/gradient tools address cell lines only by anonymized code (`c1`,
`c2`, `c4`, `c6`, `c17`, and `c13` for 3'UTR). Callers had to memorize the codes.
This names them so a cell line can be selected the way people actually refer to it.

## What's in it

- **`shared_data_models.py`** — adds `PARADE_CELL_LINE_NAMES` (c1 MDA-MB-231, c2 HepG2,
  c4 Jurkat, c6 SW480, c17 NALM6, c13 PA-1) and `resolve_cell_type()`, which maps a
  code (`"c2"`) or a cell-line name (`"HepG2"`, case-insensitive, whitespace-tolerant)
  to the canonical code.
- **`parade_activity.py` / `parade_gradient.py`** — the `cell_types` / loss-term
  `cell_type` inputs now accept a code **or** a name; both resolve to codes *before*
  panel-membership validation, so panel enforcement and the model dispatch are
  unchanged (an out-of-panel name, e.g. `PA-1` on a `utr5` config, is still rejected).
- **Output** — activity results gain a `cell_line_names` map (`{code: name}`) and CSV
  columns read `HepG2 (c2)`; metric descriptions name the line. **`scores` stay keyed
  by code**, so existing programmatic consumers are unaffected.
- **README** — documents the named panel and code-or-name input.

## Backward compatibility

Non-breaking: codes remain the canonical identifiers the model is conditioned on and
the keys of `scores`. The vendored `standalone/` reference pipeline is not touched —
it continues to receive codes. Existing code passing `cell_types=["c2", ...]` behaves
exactly as before.

## Testing

`pytest tests/sequence_scoring_tests/test_parade.py` — **6 new tests** (name/code
resolution, case-insensitivity, mixed name+code input, panel enforcement, unknown-name
errors) plus the existing suite: **26 passed, 1 skipped** (torch-only) on the non-GPU
subset locally. The GPU/model tests run through the untouched `standalone/` path.
