### PR TITLE
Name the discovery field for what it is, and give both tools one envelope

### DIFF
--- a/proto_tools/mcp/server.py
+++ b/proto_tools/mcp/server.py
@@ -130,7 +130,7 @@ def build_server(device: Device = "modal") -> FastMCP:
         return impl.workspace_info(device)
 
     @mcp.tool
-    def list_tools(deployed_only: bool = True, category: str | None = None) -> list[dict[str, Any]]:
+    def list_tools(deployed_only: bool = True, category: str | None = None) -> dict[str, Any]:
         """List available bioinformatics tools, with what each one is for.
 
         Each entry carries its category, a one-line summary, and whether it
@@ -140,17 +140,24 @@ def build_server(device: Device = "modal") -> FastMCP:
         Defaults to only those actually deployed in this workspace. Pass
         deployed_only=False to see the full catalogue, including tools the
         user would have to deploy first.
+
+        Entries arrive under `tools`, the same as search_tools, each with the
+        key to run under `tool_key`.
         """
-        return impl.list_tools(deployed_only=deployed_only, category=category, device=device)
+        found = impl.list_tools(deployed_only=deployed_only, category=category, device=device)
+        return {"tools": found, "n_total": len(found)}
 
     @mcp.tool
     def search_tools(query: str, deployed_only: bool = True, limit: int = 10) -> dict[str, Any]:
         """Find tools by keyword, matching the tool key, category and summary.
 
         Useful for questions like "what can fold a protein" or "which tools
-        score sequences". Returns the best `limit` matches under `hits`, each
+        score sequences". Returns the best `limit` matches under `tools`, each
         with the `score` out of 100 it ranked on, plus `n_total` for how many
         matched in all — raise `limit` only if the total says it is worth it.
+
+        Run what you find by its `tool_key`, exactly as given. A display name
+        is not a key, and inferring one produces a tool that does not exist.
         """
         return impl.search_tools(query, deployed_only=deployed_only, limit=limit, device=device)
 

--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -263,7 +263,7 @@ def list_tools(
         if category is not None and spec.category != category:
             continue
         entry: dict[str, Any] = {
-            "tool": key,
+            "tool_key": key,
             "category": spec.category,
             "summary": spec.description,
             "uses_gpu": spec.uses_gpu,
@@ -419,22 +419,24 @@ def search_tools(
     search returns nothing for those, which reads as "no such tool exists"
     rather than "rephrase".
 
-    Returns the top ``limit`` under ``hits``, each carrying the ``score`` out of 100 it ranked
+    Returns the top ``limit`` under ``tools``, each carrying the ``score`` out of 100 it ranked
     on, with ``n_total`` for how many matched in all. Broad queries match half the catalogue,
     and an agent that cannot tell first place from fiftieth pays for the whole list to find out.
+
+    Take the key to run from each entry's ``tool_key``. A display name is not a key.
     """
     terms = [_stem(t) for t in re.split(r"[^a-z0-9]+", query.lower()) if t not in _STOPWORDS and len(t) > 1]
     # Both the term and its expansion are scored: rewriting "fold" to "structure" otherwise
     # discards the literal token that matches esmfold and foldseek in a key.
     forms = [{t, _stem(_SYNONYMS.get(t, t))} for t in terms]
     if not forms:
-        return {"hits": [], "n_total": 0, "hint": _no_match_hint()}
+        return {"tools": [], "n_total": 0, "hint": _no_match_hint()}
 
     scored = []
     for entry in list_tools(deployed_only=deployed_only, device=device, environment=environment, client=client):
         score = _tool_score(
             forms,
-            _tokens(entry["tool"]),
+            _tokens(entry["tool_key"]),
             _tokens(entry.get("category") or ""),
             _tokens(entry.get("summary") or ""),
         )
@@ -442,8 +444,8 @@ def search_tools(
             scored.append((score, entry))
 
     # Key order after score, so a tie ranks the same way twice rather than by registry order.
-    scored.sort(key=lambda pair: (-pair[0], pair[1]["tool"]))
-    found = {"hits": [{**entry, "score": score} for score, entry in scored[:limit]], "n_total": len(scored)}
+    scored.sort(key=lambda pair: (-pair[0], pair[1]["tool_key"]))
+    found = {"tools": [{**entry, "score": score} for score, entry in scored[:limit]], "n_total": len(scored)}
     if not scored:
         found["hint"] = _no_match_hint()
     return found
@@ -477,7 +479,7 @@ def get_tool_schema(tool_key: str) -> dict[str, Any]:
     except (ValueError, KeyError):
         return _unknown_key(tool_key)
     return {
-        "tool": tool_key,
+        "tool_key": tool_key,
         "description": (spec.description or "").strip(),
         "input_schema": spec.input_model.model_json_schema(),
         "config_schema": spec.config_model.model_json_schema(),
@@ -543,7 +545,7 @@ def get_tool_citation(tool_key: str) -> dict[str, Any]:
     except (ValueError, KeyError):
         return _unknown_key(tool_key)
     return {
-        "tool": tool_key,
+        "tool_key": tool_key,
         "bibtex": bibtex,
         "doi": ToolRegistry.get_doi(tool_key),
         "docs_url": ToolRegistry.get_docs_url(tool_key),
@@ -773,7 +775,7 @@ def run_tool(
     saved = [v["_saved_to"] for v in _walk_saved(body)]
     # ``ran_on`` because the two can differ: a tool that cannot run remotely is answered here even
     # in a Modal session, and the caller should not have to infer that from the timing.
-    answer = {"ok": True, "tool": tool_key, "ran_on": ran_on, "result": body, "saved_files": saved}
+    answer = {"ok": True, "tool_key": tool_key, "ran_on": ran_on, "result": body, "saved_files": saved}
     if drift := drift_for(tool_key, ran_on, environment=environment, client=client):
         answer["warnings"] = drift
     return answer
@@ -884,7 +886,7 @@ async def deploy_tool(
         )
         if not ok:
             return {"ok": False, "app": app, "error": "deploy failed", "build_output": _log_tail(Path(logs))}
-    return {"ok": True, "app": app, "environment": environment, "tool": tool_key}
+    return {"ok": True, "app": app, "environment": environment, "tool_key": tool_key}
 
 
 #: Lines of build output returned when a deploy fails. Enough for the traceback Modal ends on,

--- a/tests/modal_tests/test_mcp.py
+++ b/tests/modal_tests/test_mcp.py
@@ -105,7 +105,7 @@ def test_listing_carries_what_choosing_a_tool_needs():
     """Names alone forced a schema fetch per candidate, which is the expensive way to choose."""
     from proto_tools.mcp import tools as impl
 
-    entry = next(e for e in impl.list_tools(device="local") if e["tool"] == "esmfold-prediction")
+    entry = next(e for e in impl.list_tools(device="local") if e["tool_key"] == "esmfold-prediction")
 
     assert entry["category"] == "structure_prediction"
     assert entry["summary"] and entry["uses_gpu"] is True
@@ -136,7 +136,7 @@ def test_an_in_process_tool_says_it_needs_no_deployment_and_why(monkeypatch):
     monkeypatch.setattr(impl, "deployed_keys", lambda device, **_kwargs: set())
     monkeypatch.setattr(impl, "answered_in_process_keys", lambda: {"bindcraft-design"})
 
-    entry = next(e for e in impl.list_tools(device="modal") if e["tool"] == "bindcraft-design")
+    entry = next(e for e in impl.list_tools(device="modal") if e["tool_key"] == "bindcraft-design")
 
     assert entry["runs_in_process"] is True
     assert "no deployment is needed" in entry["note"]
@@ -354,14 +354,14 @@ def test_search_matches_natural_language_queries(monkeypatch):
     from proto_tools.mcp import tools as impl
 
     catalogue = [
-        {"tool": "tmalign-alignment", "app": "a", "deployed": True},
-        {"tool": "esm2-score", "app": "b", "deployed": True},
+        {"tool_key": "tmalign-alignment", "app": "a", "deployed": True},
+        {"tool_key": "esm2-score", "app": "b", "deployed": True},
     ]
     # setattr, not assign-then-del: deleting removes the real function for the rest of the
     # session rather than restoring it, and every later test calling it then fails.
     monkeypatch.setattr(impl, "list_tools", lambda **_kwargs: catalogue)
     found = impl.search_tools("compare two protein structures")
-    assert [h["tool"] for h in found["hits"]][:1] == ["tmalign-alignment"], found
+    assert [h["tool_key"] for h in found["tools"]][:1] == ["tmalign-alignment"], found
 
 
 def test_search_is_capped_and_says_how_many_it_left_out():
@@ -370,17 +370,17 @@ def test_search_is_capped_and_says_how_many_it_left_out():
 
     found = impl.search_tools("compare two protein structures", deployed_only=False, limit=5, device="local")
 
-    assert len(found["hits"]) == 5
+    assert len(found["tools"]) == 5
     assert found["n_total"] > 5, "the total is what tells a caller whether raising the limit is worth it"
-    assert found["hits"][0]["score"] >= found["hits"][-1]["score"], "hits are ordered by the score they carry"
+    assert found["tools"][0]["score"] >= found["tools"][-1]["score"], "hits are ordered by the score they carry"
 
 
 def test_search_ranks_a_tool_named_for_the_query_above_one_that_merely_mentions_it():
     """Rewriting "fold" to "structure" used to discard the token that matches esmfold in the key."""
     from proto_tools.mcp import tools as impl
 
-    hits = impl.search_tools("fold a protein", deployed_only=False, limit=133, device="local")["hits"]
-    ranked = [h["tool"] for h in hits]
+    tools = impl.search_tools("fold a protein", deployed_only=False, limit=133, device="local")["tools"]
+    ranked = [h["tool_key"] for h in tools]
 
     assert ranked.index("esmfold-prediction") < ranked.index("esm-if1-sample"), "inverse folding is the opposite"
 
@@ -391,7 +391,7 @@ def test_a_query_that_matches_nothing_says_what_to_do_instead():
 
     found = impl.search_tools("crystallography", deployed_only=False, device="local")
 
-    assert found["hits"] == [] and found["n_total"] == 0
+    assert found["tools"] == [] and found["n_total"] == 0
     assert "list_tools(category=" in found["hint"] and "structure_prediction" in found["hint"]
 
 

--- a/tests/modal_tests/test_mcp_local_device.py
+++ b/tests/modal_tests/test_mcp_local_device.py
@@ -34,7 +34,7 @@ def test_every_registered_tool_is_available_locally() -> None:
     """Nothing is provisioned in advance here, so the catalogue is the registry itself."""
     from proto_tools.mcp import tools as impl
 
-    listed = {entry["tool"] for entry in impl.list_tools(deployed_only=True, device="local")}
+    listed = {entry["tool_key"] for entry in impl.list_tools(deployed_only=True, device="local")}
     assert listed == {spec.key for spec in ToolRegistry.list_all()}
     assert _LOCAL_ONLY_TOOL in listed, "a tool with no deployment still runs on this machine"
 
@@ -92,14 +92,14 @@ def test_a_deployed_tool_is_still_dispatched(monkeypatch) -> None:
     sent: dict[str, object] = {}
 
     def fake_dispatch(tool_key, payload, cfg, **_kwargs):
-        sent["tool"] = tool_key
+        sent["tool_key"] = tool_key
         raise RuntimeError("dispatched")
 
     monkeypatch.setattr(client, "dispatch_to_modal", fake_dispatch)
     example = ToolRegistry.get_example_input("esm2-embedding")
     result = impl.run_tool("esm2-embedding", inputs=example.model_dump(mode="json"), device="modal")
 
-    assert sent["tool"] == "esm2-embedding"
+    assert sent["tool_key"] == "esm2-embedding"
     assert result["ok"] is False
 
 
@@ -126,7 +126,7 @@ def test_the_remote_catalogue_includes_tools_answered_in_process() -> None:
     """An agent on a remote device can still call a tool that has no deployment."""
     from proto_tools.mcp import tools as impl
 
-    listed = {entry["tool"]: entry for entry in impl.list_tools(deployed_only=True, device="modal")}
+    listed = {entry["tool_key"]: entry for entry in impl.list_tools(deployed_only=True, device="modal")}
     entry = listed.get(_LOCAL_ONLY_TOOL)
     assert entry is not None, "a local_only tool is usable on modal, so it belongs in the catalogue"
     assert entry["available"] is True


### PR DESCRIPTION
`list_tools` and `search_tools` describe the same catalogue and answered in
two different shapes: one a bare list, the other `hits` with `n_total`. A
caller that learned the shape from one was wrong about the other.

Both now return `tools` and `n_total`.

Each entry's key field was `tool`, while the parameter it feeds is `tool_key`.
Renamed so reading and passing use one name. Applied to the run and deploy
answers too, which carried the same field, rather than leaving a fresh
inconsistency behind the one being removed.