### PR TITLE
Retry UniProt fetches through a reset connection

### DIFF
--- a/proto_tools/proto/_client.py
+++ b/proto_tools/proto/_client.py
@@ -162,6 +162,10 @@ def _request_with_retry(
     ``ConnectionError``, and the tool wrapper's own retry would resubmit the whole job
     rather than re-poll the one already running.
 
+    Not the same function as ``proto_tools.utils.http_session.request_with_retry``: this one also
+    retries retryable HTTP status codes and reads ``Retry-After`` off the response, which needs
+    the request-dispatch shape below rather than a generic callable.
+
     Args:
         session (requests.Session): Authenticated session to send on.
         method (str): HTTP method.

--- a/proto_tools/tools/database_retrieval/uniprot/uniprot_fetch.py
+++ b/proto_tools/tools/database_retrieval/uniprot/uniprot_fetch.py
@@ -22,6 +22,7 @@ from proto_tools.utils import (
     ConfigField,
     InputField,
     build_http_session,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -286,10 +287,14 @@ def _fetch_entry(
 ) -> dict[str, Any] | None:
     """Fetch a UniProtKB entry by accession. Returns None on 404."""
     params = {"fields": ",".join(fields)} if fields else None
-    response = session.get(
-        f"{_UNIPROT_BASE}/uniprotkb/{uniprot_id}.json",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_UNIPROT_BASE}/uniprotkb/{uniprot_id}.json",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if response.status_code == 404:
         logger.debug("UniProt ID '%s' not found", uniprot_id)
@@ -323,10 +328,18 @@ def _search_entry(
         }
         if fields:
             params["fields"] = ",".join(fields)
-        response = session.get(
-            f"{_UNIPROT_BASE}/uniprotkb/search",
-            params=params,
-            timeout=_REQUEST_TIMEOUT_SECONDS,
+
+        def _get(params: dict[str, Any] = params) -> requests.Response:
+            return session.get(
+                f"{_UNIPROT_BASE}/uniprotkb/search",
+                params=params,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+
+        response = request_with_retry(
+            _get,
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
         )
         if response.status_code >= 400:
             logger.warning(

--- a/proto_tools/tools/tool_registry.py
+++ b/proto_tools/tools/tool_registry.py
@@ -24,6 +24,7 @@ from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+import requests
 import yaml
 from pydantic import BaseModel, Field, field_serializer
 
@@ -47,8 +48,11 @@ IGNORED_WARNING_SUBSTRINGS = [
 MAX_RETRIES = 3
 RETRY_DELAY = 2.0  # Base delay in seconds (exponential backoff: 2s, 4s, 8s)
 
-# TimeoutError excluded: retrying with the same limit would just time out again
-_RETRYABLE_EXCEPTIONS = (ConnectionError,)
+# TimeoutError excluded: retrying with the same limit would just time out again.
+#
+# requests.exceptions.ConnectionError does not subclass the builtin one (its MRO is
+# RequestException -> OSError), so a tool raising it via `requests` was never retried here.
+_RETRYABLE_EXCEPTIONS = (ConnectionError, requests.exceptions.ConnectionError)
 
 # Set PROTO_CAPTURE_ERRORS=1 to capture tool exceptions into success=False outputs instead of raising.
 _CAPTURE_ERRORS_ENV_VAR = "PROTO_CAPTURE_ERRORS"

--- a/proto_tools/utils/__init__.py
+++ b/proto_tools/utils/__init__.py
@@ -17,7 +17,7 @@ from proto_tools.utils.device_manager import SUPPORTED_DEVICE_PREFIXES, Allocati
 from proto_tools.utils.env_runner import run_in_env
 from proto_tools.utils.export_names import build_export_name, sanitize_field
 from proto_tools.utils.gradient_models import GradientInput, GradientOutput, GradientValue
-from proto_tools.utils.http_session import build_http_session
+from proto_tools.utils.http_session import build_http_session, request_with_retry
 from proto_tools.utils.logging_config import get_logger, setup_logging
 from proto_tools.utils.msa import extract_msa_sequences
 from proto_tools.utils.polling import StatusExtractor, extract_text_status, poll_until_complete
@@ -130,6 +130,7 @@ __all__ = [
     "SUPPORTED_DEVICE_PREFIXES",
     # HTTP
     "build_http_session",
+    "request_with_retry",
     "extract_text_status",
     "poll_until_complete",
     "StatusExtractor",

--- a/proto_tools/utils/http_session.py
+++ b/proto_tools/utils/http_session.py
@@ -1,8 +1,14 @@
 """proto_tools/utils/http_session.py.
 
 Shared HTTP session builder with retry logic.
+
+``request_with_retry`` below and ``proto_tools.proto._client._request_with_retry`` both retry on
+``requests.exceptions.ConnectionError`` but aren't merged: the client's version also retries HTTP
+status codes and needs the response in hand to read ``Retry-After``, which a generic callable
+can't give it.
 """
 
+import random
 import time
 from collections.abc import Callable
 from typing import TypeVar
@@ -12,6 +18,9 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 _RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+
+#: Spreads retries across callers hitting the same failure at once; not a security primitive.
+_JITTER_FRACTION = 0.1
 
 T = TypeVar("T")
 
@@ -45,29 +54,35 @@ def request_with_retry(
     *,
     retries: int,
     backoff_seconds: float,
+    retryable_exceptions: tuple[type[BaseException], ...] = (requests.exceptions.ConnectionError,),
 ) -> T:
-    """Retry *call* on a dropped connection, with the same backoff the session's own retries use.
+    """Retry *call* on a transient failure, with the same backoff the session's own retries use.
 
     ``HTTPAdapter``'s ``Retry`` only covers what urllib3 catches inside its own connection pool.
-    A server that closes a pooled keep-alive connection between requests raises
-    ``ConnectionResetError`` while urllib3 is *sending* the next request on it, which surfaces as
-    ``requests.exceptions.ConnectionError`` above the adapter's retry logic rather than through it
-    -- seen against ``rest.uniprot.org`` with ``http_retries=2`` already configured and still
-    failing outright. Catching it here closes that gap without guessing at a given urllib3 version's
-    exact retry coverage.
+    A server that closes a pooled keep-alive connection raises ``ConnectionResetError`` while
+    urllib3 is *sending* the next request on it, which surfaces as
+    ``requests.exceptions.ConnectionError`` above the adapter rather than through it. This retries
+    that case explicitly instead.
 
     Args:
-        call (Callable[[], T]): Zero-argument callable making the request, so this has no opinion
-            on the request's shape and can wrap any ``session.get``/``.post`` call.
-        retries (int): Extra attempts after the first, matching ``http_retries`` on the tool's
-            config.
-        backoff_seconds (float): Seconds before the first retry, doubling after each attempt after
-            that -- the same schedule ``Retry(backoff_factor=...)`` uses.
+        call (Callable[[], T]): Zero-argument callable making the request; wraps any
+            ``session.get``/``.post`` call.
+        retries (int): Extra attempts after the first.
+        backoff_seconds (float): Delay before the first retry, doubling (and jittered) after each
+            attempt.
+        retryable_exceptions (tuple[type[BaseException], ...]): Exceptions treated as transient.
+            Defaults to the connection-reset case above.
     """
     try:
         return call()
-    except requests.exceptions.ConnectionError:
+    except retryable_exceptions:
         if retries <= 0:
             raise
-        time.sleep(backoff_seconds)
-        return request_with_retry(call, retries=retries - 1, backoff_seconds=backoff_seconds * 2)
+        delay = backoff_seconds * (1 + random.uniform(-_JITTER_FRACTION, _JITTER_FRACTION))  # noqa: S311
+        time.sleep(max(delay, 0.0))
+        return request_with_retry(
+            call,
+            retries=retries - 1,
+            backoff_seconds=backoff_seconds * 2,
+            retryable_exceptions=retryable_exceptions,
+        )

--- a/proto_tools/utils/http_session.py
+++ b/proto_tools/utils/http_session.py
@@ -3,11 +3,17 @@
 Shared HTTP session builder with retry logic.
 """
 
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 _RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+
+T = TypeVar("T")
 
 
 def build_http_session(
@@ -20,6 +26,7 @@ def build_http_session(
     """Build a requests session with retry adapter."""
     retry = Retry(
         total=http_retries,
+        connect=http_retries,
         backoff_factor=backoff_seconds,
         status_forcelist=_RETRY_STATUS_CODES,
         allowed_methods=allowed_methods or ["GET"],
@@ -31,3 +38,36 @@ def build_http_session(
         session.mount("http://", adapter)
     session.headers.update({"User-Agent": user_agent})
     return session
+
+
+def request_with_retry(
+    call: Callable[[], T],
+    *,
+    retries: int,
+    backoff_seconds: float,
+) -> T:
+    """Retry *call* on a dropped connection, with the same backoff the session's own retries use.
+
+    ``HTTPAdapter``'s ``Retry`` only covers what urllib3 catches inside its own connection pool.
+    A server that closes a pooled keep-alive connection between requests raises
+    ``ConnectionResetError`` while urllib3 is *sending* the next request on it, which surfaces as
+    ``requests.exceptions.ConnectionError`` above the adapter's retry logic rather than through it
+    -- seen against ``rest.uniprot.org`` with ``http_retries=2`` already configured and still
+    failing outright. Catching it here closes that gap without guessing at a given urllib3 version's
+    exact retry coverage.
+
+    Args:
+        call (Callable[[], T]): Zero-argument callable making the request, so this has no opinion
+            on the request's shape and can wrap any ``session.get``/``.post`` call.
+        retries (int): Extra attempts after the first, matching ``http_retries`` on the tool's
+            config.
+        backoff_seconds (float): Seconds before the first retry, doubling after each attempt after
+            that -- the same schedule ``Retry(backoff_factor=...)`` uses.
+    """
+    try:
+        return call()
+    except requests.exceptions.ConnectionError:
+        if retries <= 0:
+            raise
+        time.sleep(backoff_seconds)
+        return request_with_retry(call, retries=retries - 1, backoff_seconds=backoff_seconds * 2)

--- a/tests/database_retrieval_tests/test_uniprot_fetch.py
+++ b/tests/database_retrieval_tests/test_uniprot_fetch.py
@@ -4,6 +4,7 @@ Tests for the UniProt fetch tool.
 """
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -11,10 +12,12 @@ from proto_tools.tools.database_retrieval import (
     UniProtFetchInput,
     run_uniprot_fetch,
 )
+from proto_tools.tools.database_retrieval.uniprot import uniprot_fetch
 from proto_tools.tools.database_retrieval.uniprot.uniprot_fetch import (
     _entry_priority,
     _extract_gene_names,
     _extract_pdb_crossrefs,
+    _fetch_entry,
 )
 
 
@@ -65,6 +68,53 @@ def test_extract_pdb_crossrefs():
 
 def test_extract_pdb_crossrefs_empty():
     assert _extract_pdb_crossrefs({}) == []
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return {"primaryAccession": "P13569"}
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int):
+        self.failures = failures
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return _FakeResponse()
+
+
+def test_fetch_entry_retries_connection_reset(monkeypatch):
+    """A connection reset on a reused connection is retried rather than raised.
+
+    Reproduces the ``rest.uniprot.org`` failure directly: urllib3's adapter-level ``Retry`` does
+    not catch a reset that happens while sending on a pooled connection, so ``_fetch_entry`` must.
+    """
+    monkeypatch.setattr(uniprot_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2)
+    entry = _fetch_entry("P13569", session)  # type: ignore[arg-type]
+    assert entry == {"primaryAccession": "P13569"}
+    assert session.calls == 3
+
+
+def test_fetch_entry_gives_up_after_configured_retries(monkeypatch):
+    monkeypatch.setattr(uniprot_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=5)
+    with pytest.raises(requests.exceptions.ConnectionError):
+        _fetch_entry("P13569", session)  # type: ignore[arg-type]
+    assert session.calls == 3
 
 
 def test_entry_priority_distinguishes_reviewed_from_unreviewed():

--- a/tests/tool_infra_tests/test_http_session.py
+++ b/tests/tool_infra_tests/test_http_session.py
@@ -1,0 +1,73 @@
+"""tests/tool_infra_tests/test_http_session.py.
+
+Tests for proto_tools.utils.http_session.request_with_retry.
+"""
+
+import requests
+
+from proto_tools.utils.http_session import request_with_retry
+
+
+def test_retries_until_success_within_budget():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise requests.exceptions.ConnectionError("Connection reset by peer")
+        return "ok"
+
+    assert request_with_retry(flaky, retries=2, backoff_seconds=0.0) == "ok"
+    assert calls["n"] == 3
+
+
+def test_gives_up_after_retries_exhausted():
+    calls = {"n": 0}
+
+    def always_fails():
+        calls["n"] += 1
+        raise requests.exceptions.ConnectionError("nope")
+
+    try:
+        request_with_retry(always_fails, retries=2, backoff_seconds=0.0)
+    except requests.exceptions.ConnectionError:
+        pass
+    else:
+        raise AssertionError("expected ConnectionError to propagate")
+    assert calls["n"] == 3
+
+
+def test_retryable_exceptions_is_configurable():
+    """A caller can widen what counts as transient without re-implementing the backoff."""
+    calls = {"n": 0}
+
+    def flaky_timeout():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise requests.exceptions.Timeout("read timed out")
+        return "ok"
+
+    result = request_with_retry(
+        flaky_timeout,
+        retries=1,
+        backoff_seconds=0.0,
+        retryable_exceptions=(requests.exceptions.Timeout,),
+    )
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+def test_exception_outside_the_configured_set_is_not_retried():
+    calls = {"n": 0}
+
+    def raises_value_error():
+        calls["n"] += 1
+        raise ValueError("not a transient failure")
+
+    try:
+        request_with_retry(raises_value_error, retries=3, backoff_seconds=0.0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError to propagate immediately")
+    assert calls["n"] == 1

--- a/tests/tool_infra_tests/test_tool_registry.py
+++ b/tests/tool_infra_tests/test_tool_registry.py
@@ -952,6 +952,28 @@ def test_retryable_error_succeeds_after_retries(clean_registry, fast_retry):
     assert call_count == 3
 
 
+def test_requests_connection_error_is_retried(clean_registry, fast_retry):
+    """Regression: requests.exceptions.ConnectionError doesn't subclass the builtin one this tuple named.
+
+    A tool raising it via `requests` was never retried here.
+    """
+    import requests
+
+    call_count = 0
+
+    def tool(inputs, config, instance=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise requests.exceptions.ConnectionError("Connection aborted.")
+        return MockToolOutput(result="success")
+
+    result = _register_and_run(clean_registry, "retry-requests-connection-error", tool)
+    assert result.success is True
+    assert result.result == "success"
+    assert call_count == 3
+
+
 def test_retries_exhaust_raises_by_default(clean_registry, fast_retry):
     call_count = 0
 


### PR DESCRIPTION
## Summary

**1. `_fetch_entry`/`_search_entry` in `uniprot_fetch.py`**
- `uniprot-fetch`'s `http_retries`/`backoff_seconds` config already builds a session with urllib3's `Retry` adapter, but that only catches errors urllib3 itself sees inside its own connection pool.
- A server that closes a pooled keep-alive connection between requests raises `ConnectionResetError` while urllib3 is *sending* the next request on it, which surfaces as `requests.exceptions.ConnectionError` above the adapter's retry logic rather than through it — reproduced against `rest.uniprot.org` with `http_retries=2` already configured and still failing outright as `UNEXPECTED_ERROR[protein]` in `sequence-fetch`.
- Added `request_with_retry` in `proto_tools/utils/http_session.py` as an explicit application-level retry for exactly that gap, wired into `_fetch_entry` and `_search_entry`, and gave the adapter an explicit `connect=` budget as well since that costs nothing.

**2. Checked whether this already existed elsewhere — two related fixes came out of that**
- `proto_tools/proto/_client.py` has its own `_request_with_retry`, independently solving the same `requests.exceptions.ConnectionError` problem for Proto's hosted-API client. Not merged into one function — it also retries on HTTP status codes and reads `Retry-After` off the response, which needs the request-dispatch shape rather than a generic callable — but `request_with_retry` now takes a configurable `retryable_exceptions` tuple and jittered backoff so it's a real shared primitive rather than a lesser duplicate, and each file now points at the other.
- `tool_registry.py`'s own per-tool-invocation retry wrapper has named only the builtin `ConnectionError` since it was written, but `requests.exceptions.ConnectionError` does **not** subclass it (MRO is `RequestException → OSError`). So the wrapper meant to retry "network drops" for every registered tool call has never actually caught the connection-reset error most HTTP-based tools raise through `requests` — the same failure class `uniprot-fetch` hit, just one layer up. Fixed by listing both; neither makes the other redundant.

## Test plan
- [x] `pytest tests/database_retrieval_tests/ tests/tool_infra_tests/test_tool_registry.py tests/tool_infra_tests/test_proto.py tests/tool_infra_tests/test_http_session.py -q -m "not integration"` — 439 passed, including 5 new tests (2 for the uniprot fix, 1 regression test for the `tool_registry.py` bug, 2 for `request_with_retry`'s new configurable-exceptions behavior).
- [x] `pytest tests/ -q -m "not integration"` (full suite) — 12678 passed, 9 failed. All 9 confirmed pre-existing and unrelated (missing `umap` dependency, unrelated MSA-parsing assertions in `test_chai1.py`) — identical failure set with these changes reverted.
- [x] `pytest --integration` against the **live UniProt API** with a varied sweep (human/*E. coli*/*M. tuberculosis*/*S. pyogenes*/viral spike protein, by accession and by gene name) — all resolved to the correct accession and sequence.
- [x] `ruff check` / `ruff format --check` clean on all changed files.
- [x] `mypy proto_tools/` (full repo, matching CI) — no new errors introduced; confirmed by diffing against the same run on `main`.
- [x] Verified against `1e0bd8f5` — the exact commit `proto-tools-api`'s submodule is currently pinned to.

Opened as a draft for review before merging.