### PR TITLE
Retry AlphaFold DB fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/alphafold_db/alphafold_db_fetch.py
+++ b/proto_tools/tools/database_retrieval/alphafold_db/alphafold_db_fetch.py
@@ -22,6 +22,7 @@ from proto_tools.utils import (
     ConfigField,
     InputField,
     build_http_session,
+    request_with_retry,
 )
 from proto_tools.utils.tool_io import Metrics, MetricSpec
 
@@ -506,7 +507,11 @@ def _select_record(
 
 def _fetch_prediction(api_url: str, session: requests.Session) -> list[dict[str, Any]] | None:
     """Fetch prediction metadata list. Returns None on 404."""
-    response = session.get(api_url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(api_url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         logger.debug("AlphaFold DB returned 404 for %s", api_url)
         return None
@@ -519,14 +524,22 @@ def _fetch_prediction(api_url: str, session: requests.Session) -> list[dict[str,
 
 def _fetch_text(url: str, session: requests.Session) -> str:
     """Fetch a remote file as text (used for structure files and MSA A3M)."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     return response.text
 
 
 def _fetch_plddt(url: str, session: requests.Session) -> list[float]:
     """Fetch the per-residue pLDDT confidence array."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     payload = response.json()
     scores = payload.get("confidenceScore")
@@ -537,7 +550,11 @@ def _fetch_plddt(url: str, session: requests.Session) -> list[float]:
 
 def _fetch_pae(url: str, session: requests.Session) -> list[list[float]]:
     """Fetch the PAE matrix as a 2D list of floats."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     payload = response.json()
     if not isinstance(payload, list) or not payload:

--- a/tests/database_retrieval_tests/test_alphafold_db_fetch.py
+++ b/tests/database_retrieval_tests/test_alphafold_db_fetch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from proto_tools.entities.structures.structure import BFactorType, Structure
 from proto_tools.tools.database_retrieval import (
@@ -20,6 +21,7 @@ from proto_tools.tools.database_retrieval import (
     run_alphafold_db_fetch,
     run_uniprot_fetch,
 )
+from proto_tools.tools.database_retrieval.alphafold_db import alphafold_db_fetch
 from proto_tools.tools.database_retrieval.alphafold_db.alphafold_db_fetch import (
     AlphaFoldDBFetchOutput,
     _fetch_pae,
@@ -76,6 +78,36 @@ def test_fetch_prediction_returns_none_on_404():
     result = _fetch_prediction("https://example/api", session)
     assert result is None
     session.get.return_value.json.assert_not_called()
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, payload):
+        self.failures = failures
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = MagicMock()
+        response.status_code = 200
+        response.raise_for_status.return_value = None
+        response.json.return_value = self.payload
+        return response
+
+
+def test_fetch_prediction_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against the AFDB API."""
+    monkeypatch.setattr(alphafold_db_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, payload=[{"modelEntityId": "AF-P04637-F1"}])
+    result = _fetch_prediction("https://example/api", session)
+    assert result == [{"modelEntityId": "AF-P04637-F1"}]
+    assert session.calls == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Same latent bug as #84, found while auditing other `build_http_session` users for the same gap: `alphafold-db-fetch` reuses one session across up to 5 sequential requests per run (prediction metadata, structure file, pLDDT, PAE, MSA A3M) — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- Wired the shared `request_with_retry` helper into all four fetch functions (`_fetch_prediction`, `_fetch_text`, `_fetch_plddt`, `_fetch_pae`).

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/database_retrieval_tests/test_alphafold_db_fetch.py -q -m "not integration"` — 15 passed, including a new regression test reproducing the reused-connection failure directly.
- [x] `pytest tests/database_retrieval_tests/test_alphafold_db_fetch.py -q --integration` (live AlphaFold DB API) — 25 passed, 2 failed. Both failures confirmed pre-existing and unrelated: `alphafold.ebi.ac.uk`'s MSA file endpoint is currently returning 403 to *any* request (verified with a bare `curl`), not something this repo controls.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.