### PR TITLE
Retry PubChem fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/pubchem/pubchem_fetch.py
+++ b/proto_tools/tools/database_retrieval/pubchem/pubchem_fetch.py
@@ -22,6 +22,7 @@ from proto_tools.utils import (
     ConfigField,
     InputField,
     build_http_session,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -429,10 +430,14 @@ def _resolve_to_cids(inputs: PubChemFetchInput, session: requests.Session) -> li
 
     if inputs.inchi is not None:
         url = f"{_PUBCHEM_BASE}/compound/inchi/cids/JSON"
-        response = session.post(
-            url,
-            data={"inchi": inputs.inchi},
-            timeout=_REQUEST_TIMEOUT_SECONDS,
+        response = request_with_retry(
+            lambda: session.post(
+                url,
+                data={"inchi": inputs.inchi},
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            ),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
         )
     else:
         if inputs.name is not None:
@@ -441,7 +446,11 @@ def _resolve_to_cids(inputs: PubChemFetchInput, session: requests.Session) -> li
             url = f"{_PUBCHEM_BASE}/compound/smiles/{quote(inputs.smiles, safe='')}/cids/JSON"
         else:
             url = f"{_PUBCHEM_BASE}/compound/inchikey/{quote(inputs.inchikey or '', safe='')}/cids/JSON"
-        response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+        response = request_with_retry(
+            lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
 
     if response.status_code == 404:
         return []
@@ -458,7 +467,11 @@ def _fetch_properties(
     """Fetch the requested property bundle for a CID. Returns (record, url)."""
     props = ",".join(config.properties)
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/property/{props}/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     properties = response.json()["PropertyTable"]["Properties"]
     if not properties:
@@ -476,7 +489,11 @@ def _fetch_synonyms(cid: int, session: requests.Session) -> list[str]:
     other malformed shape raises KeyError via direct dict access.
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/synonyms/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()
@@ -494,7 +511,11 @@ def _fetch_descriptions(cid: int, session: requests.Session) -> list[str]:
     contribute a Title).
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/description/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()
@@ -509,7 +530,11 @@ def _fetch_aids(cid: int, session: requests.Session) -> list[int]:
     For common compounds (e.g., aspirin) this can return thousands of IDs.
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/aids/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()

--- a/tests/database_retrieval_tests/test_pubchem_fetch.py
+++ b/tests/database_retrieval_tests/test_pubchem_fetch.py
@@ -6,6 +6,7 @@ Tests for the PubChem fetch tool.
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -13,6 +14,7 @@ from proto_tools.tools.database_retrieval import (
     PubChemFetchInput,
     run_pubchem_fetch,
 )
+from proto_tools.tools.database_retrieval.pubchem import pubchem_fetch
 from proto_tools.tools.database_retrieval.pubchem.pubchem_fetch import (
     _fetch_properties,
     _fetch_synonyms,
@@ -59,6 +61,35 @@ def test_resolve_to_cids_parses_response(status_code, payload, expected):
     session.get.return_value = response
     cids = _resolve_to_cids(PubChemFetchInput(name="anything"), session)
     assert cids == expected
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, payload):
+        self.failures = failures
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = self.payload
+        return response
+
+
+def test_resolve_to_cids_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against PubChem PUG REST."""
+    monkeypatch.setattr(pubchem_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, payload={"IdentifierList": {"CID": [2244]}})
+    cids = _resolve_to_cids(PubChemFetchInput(name="aspirin"), session)
+    assert cids == [2244]
+    assert session.calls == 3
 
 
 def test_fetch_properties_raises_when_property_table_empty():


### PR DESCRIPTION
## Summary
- Same latent bug as #84: `pubchem-fetch` reuses one session across up to 5 sequential requests per run (CID resolution, properties, synonyms, descriptions, assay IDs) — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- Wired the shared `request_with_retry` helper into all five fetch functions (`_resolve_to_cids`, `_fetch_properties`, `_fetch_synonyms`, `_fetch_descriptions`, `_fetch_aids`).

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/database_retrieval_tests/test_pubchem_fetch.py -q -m "not integration"` — 11 passed, including a new regression test reproducing the reused-connection failure directly.
- [x] `pytest tests/database_retrieval_tests/test_pubchem_fetch.py -q --integration` (live PubChem PUG REST API) — 25 passed, 0 failed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.