### PR TITLE
Retry NCBI eutils fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/ncbi/shared_data_models.py
+++ b/proto_tools/tools/database_retrieval/ncbi/shared_data_models.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 import requests
 from pydantic import BaseModel, Field
 
-from proto_tools.utils import BaseConfig, ConfigField
+from proto_tools.utils import BaseConfig, ConfigField, request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -158,10 +158,14 @@ def _ncbi_esearch(
         params["reldate"] = reldate
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/esearch.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/esearch.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-esearch"):
         return []
@@ -183,10 +187,14 @@ def _ncbi_esummary(
     }
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/esummary.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/esummary.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-esummary"):
         return None
@@ -221,10 +229,14 @@ def _ncbi_efetch(
 
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/efetch.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/efetch.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-efetch"):
         return None

--- a/tests/database_retrieval_tests/test_ncbi_fetch.py
+++ b/tests/database_retrieval_tests/test_ncbi_fetch.py
@@ -4,6 +4,7 @@ Tests for the NCBI Entrez tools (esearch, esummary, efetch).
 """
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -15,8 +16,10 @@ from proto_tools.tools.database_retrieval import (
     run_ncbi_esearch,
     run_ncbi_esummary,
 )
+from proto_tools.tools.database_retrieval.ncbi import shared_data_models
 from proto_tools.tools.database_retrieval.ncbi.shared_data_models import (
     _accession_from_header,
+    _ncbi_esearch,
     _parse_fasta_records,
 )
 
@@ -34,6 +37,37 @@ def test_ncbi_esummary_requires_identifier():
 def test_ncbi_efetch_requires_identifier():
     with pytest.raises(ValidationError):
         NCBIEfetchInput(db="protein")
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, text: str, url: str = "https://example/esearch.fcgi"):
+        self.failures = failures
+        self.text = text
+        self.url = url
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = requests.Response()
+        response.status_code = 200
+        response.url = self.url
+        response._content = self.text.encode()
+        return response
+
+
+def test_ncbi_esearch_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against NCBI eutils."""
+    monkeypatch.setattr(shared_data_models, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, text='{"esearchresult": {"idlist": ["12345"]}}')
+    ids = _ncbi_esearch("protein", "lacI", 10, NCBIFetchConfig(), session)
+    assert ids == ["12345"]
+    assert session.calls == 3
 
 
 def test_parse_fasta_records():


### PR DESCRIPTION
## Summary
- Same latent bug as #84: backs `ncbi-esearch`, `ncbi-esummary`, and `ncbi-efetch`, and any orchestrator (e.g. `sequence-fetch`) that reuses one session across a batch of NCBI lookups — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- Wired the shared `request_with_retry` helper into all three eutils call sites (`_ncbi_esearch`, `_ncbi_esummary`, `_ncbi_efetch`) in `shared_data_models.py`.

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/database_retrieval_tests/test_ncbi_fetch.py -q -m "not integration"` — 11 passed, including a new regression test reproducing the reused-connection failure directly against a real `requests.Response`.
- [x] `pytest tests/database_retrieval_tests/test_ncbi_fetch.py tests/database_retrieval_tests/test_sequence_fetch.py -q --integration` (live NCBI eutils API, including the `sequence-fetch` orchestrator that depends on these helpers) — 32 passed, 0 failed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.