### PR TITLE
Retry RCSB PDB fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/pdb/shared_data_models.py
+++ b/proto_tools/tools/database_retrieval/pdb/shared_data_models.py
@@ -12,7 +12,7 @@ from typing import Any
 import requests
 from pydantic import BaseModel, Field
 
-from proto_tools.utils import BaseConfig
+from proto_tools.utils import BaseConfig, request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,11 @@ class PdbFetchConfig(BaseConfig):
 
 def _request_pdb(session: requests.Session, url: str, source_label: str) -> requests.Response | None:
     """Execute an HTTP GET, returning None on 404."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         logger.debug("No record found at %s: %s", source_label, response.url)
         return None

--- a/tests/database_retrieval_tests/test_pdb_fetch.py
+++ b/tests/database_retrieval_tests/test_pdb_fetch.py
@@ -4,6 +4,7 @@ Tests for the PDB fetch tools (fetch-entry, fetch-fasta).
 """
 
 import pytest
+import requests
 
 from proto_tools.tools.database_retrieval import (
     PdbFetchConfig,
@@ -12,9 +13,11 @@ from proto_tools.tools.database_retrieval import (
     run_pdb_fetch_entry,
     run_pdb_fetch_fasta,
 )
+from proto_tools.tools.database_retrieval.pdb import shared_data_models
 from proto_tools.tools.database_retrieval.pdb.shared_data_models import (
     _chain_ids_from_header,
     _is_protein_sequence,
+    _request_pdb,
 )
 
 
@@ -32,6 +35,37 @@ def test_is_protein_sequence_rna():
 
 def test_is_protein_sequence_empty():
     assert _is_protein_sequence("") is False
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, text: str):
+        self.failures = failures
+        self.text = text
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = requests.Response()
+        response.status_code = 200
+        response.url = "https://example/entry.json"
+        response._content = self.text.encode()
+        return response
+
+
+def test_request_pdb_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against RCSB PDB."""
+    monkeypatch.setattr(shared_data_models, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, text='{"entry": {"id": "1TUP"}}')
+    response = _request_pdb(session, "https://example/entry.json", "pdb-fetch-entry")
+    assert response is not None
+    assert response.json() == {"entry": {"id": "1TUP"}}
+    assert session.calls == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Same latent bug as #84: backs `pdb-fetch-entry` and `pdb-fetch-fasta`, and any orchestrator (e.g. `sequence-fetch`) that reuses one session across a batch of PDB lookups — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- Wired the shared `request_with_retry` helper into the single shared call site, `_request_pdb`, in `shared_data_models.py`.

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/database_retrieval_tests/test_pdb_fetch.py -q -m "not integration"` — 7 passed, including a new regression test reproducing the reused-connection failure directly against a real `requests.Response`.
- [x] `pytest tests/database_retrieval_tests/test_pdb_fetch.py tests/database_retrieval_tests/test_sequence_fetch.py -q --integration` (live RCSB PDB API, including the `sequence-fetch` orchestrator that depends on this helper) — 26 passed, 0 failed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.