### PR TITLE
Retry InterPro/iprscan5 fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/interproscan/interproscan_fetch.py
+++ b/proto_tools/tools/database_retrieval/interproscan/interproscan_fetch.py
@@ -27,6 +27,7 @@ from proto_tools.utils import (
     build_http_session,
     extract_text_status,
     poll_until_complete,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -437,7 +438,12 @@ def _direct_lookup(
         if next_url in seen_urls:
             raise ValueError(f"InterPro pagination cursor revisited URL {next_url!r} for '{accession}'")
         seen_urls.add(next_url)
-        response = session.get(next_url, timeout=_REQUEST_TIMEOUT_SECONDS)
+        current_url = next_url
+
+        def _get(url: str = current_url) -> requests.Response:
+            return session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+
+        response = request_with_retry(_get, retries=_HTTP_RETRIES, backoff_seconds=_BACKOFF_SECONDS)
         # 204 / 404 = "unknown accession" (InterPro's actual signals).
         if response.status_code in (204, 404):
             raise ValueError(f"InterPro has no entries for UniProt accession '{accession}'")
@@ -585,7 +591,11 @@ def _submit_and_poll(
         status_extractor=extract_text_status,
     )
     result_url = f"{_IPRSCAN5_BASE}/result/{job_id}/json"
-    response = session.get(result_url, timeout=_RESULT_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(result_url, timeout=_RESULT_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     try:
         payload = response.json()
@@ -612,7 +622,11 @@ def _submit_iprscan(
     ]
     if config.applications:
         data.extend(("appl", app) for app in config.applications)
-    response = session.post(f"{_IPRSCAN5_BASE}/run/", data=data, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.post(f"{_IPRSCAN5_BASE}/run/", data=data, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     job_id = response.text.strip()
     if not job_id:

--- a/tests/database_retrieval_tests/test_interproscan_fetch.py
+++ b/tests/database_retrieval_tests/test_interproscan_fetch.py
@@ -7,6 +7,7 @@ sequence submit-and-poll paths against EBI's iprscan5 endpoint.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -16,6 +17,7 @@ from proto_tools.tools.database_retrieval import (
     run_interproscan_fetch,
     run_uniprot_fetch,
 )
+from proto_tools.tools.database_retrieval.interproscan import interproscan_fetch
 from proto_tools.tools.database_retrieval.interproscan.interproscan_fetch import (
     _DIRECT_LOOKUP_MAX_PAGES,
     _direct_lookup,
@@ -269,6 +271,43 @@ def test_direct_lookup_wraps_corrupt_json_with_context():
         _direct_lookup("P04637", InterProScanFetchConfig(), session)
 
 
+class _ResetThenOkSession:
+    """A session whose ``get``/``post`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, response):
+        self.failures = failures
+        self.response = response
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        return self._call()
+
+    def post(self, *args, **kwargs):
+        return self._call()
+
+    def _call(self):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return self.response
+
+
+def test_direct_lookup_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against InterPro's REST API."""
+    monkeypatch.setattr(interproscan_fetch, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.text = '{"results": [], "next": null}'
+    response.json.return_value = {"results": [], "next": None}
+    session = _ResetThenOkSession(failures=2, response=response)
+    output = _direct_lookup("P04637", InterProScanFetchConfig(), session)
+    assert output.num_domains == 0
+    assert session.calls == 3
+
+
 # ---------------------------------------------------------------------------
 # iprscan5 submit + parse tests
 # ---------------------------------------------------------------------------
@@ -293,6 +332,18 @@ def test_submit_iprscan_returns_plain_text_job_id():
     posted_data = dict(kwargs["data"]) if isinstance(kwargs["data"], list) else kwargs["data"]
     assert posted_data["email"] == "dev@example.org"
     assert posted_data["sequence"] == "MKTILVAA"
+
+
+def test_submit_iprscan_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against EBI's iprscan5 submit endpoint."""
+    monkeypatch.setattr(interproscan_fetch, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.text = "iprscan5-job-123"
+    response.raise_for_status.return_value = None
+    session = _ResetThenOkSession(failures=2, response=response)
+    job_id = _submit_iprscan("MKT", "dev@example.org", InterProScanFetchConfig(email="dev@example.org"), session)
+    assert job_id == "iprscan5-job-123"
+    assert session.calls == 3
 
 
 def test_submit_iprscan_rejects_empty_body():


### PR DESCRIPTION
## Summary
- Same latent bug as #84: `interproscan-fetch` reuses one session across a paginated direct-lookup GET loop and, on the submit-and-poll path, a submit POST plus a post-poll result GET — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- `poll_until_complete`'s own internal GETs already retry `ConnectionError`/`Timeout` against a wall-clock deadline and are unaffected; only three bare call sites needed the fix: the pagination GET in `_direct_lookup`, the result GET in `_submit_and_poll`, and the submit POST in `_submit_iprscan`.

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/database_retrieval_tests/test_interproscan_fetch.py -q -m "not integration"` — 31 passed, including two new regression tests (pagination GET and submit POST) reproducing the reused-connection failure directly.
- [x] `pytest tests/database_retrieval_tests/test_interproscan_fetch.py -q --integration` (live InterPro REST + iprscan5 API) — 37 passed, 0 failed, 1 skipped (slow test, unrelated).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors (one narrowing fix needed: `next_url: str | None` inside the pagination loop needed an explicit `str` local before use as a default-arg type in the retry wrapper's inner function).
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.