### PR TITLE
Retry FoldMason MSA fetches through a reset connection

### DIFF
--- a/proto_tools/tools/structure_alignment/foldmason/foldmason_msa.py
+++ b/proto_tools/tools/structure_alignment/foldmason/foldmason_msa.py
@@ -27,6 +27,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -287,7 +288,11 @@ def _remote_msa(inputs: FoldmasonMSAInput, config: FoldmasonMSAConfig) -> Foldma
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDMASON_BASE}/api/result/foldmason/{ticket_id}"
-        result_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        result_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         result_response.raise_for_status()
         aa_fasta, three_di_fasta, newick, num_sequences, alignment_length = _parse_msa_response_json(
             result_response.json()
@@ -361,10 +366,14 @@ def _submit_foldmason(
     for sid, text in zip(structure_ids, structures, strict=True):
         files.append(("fileNames[]", (None, sid, "text/plain")))
         files.append(("queries[]", (sid, text, "chemical/x-pdb")))
-    response = session.post(
-        f"{_FOLDMASON_BASE}/api/ticket/foldmason",
-        files=files,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.post(
+            f"{_FOLDMASON_BASE}/api/ticket/foldmason",
+            files=files,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     response.raise_for_status()
     payload = response.json()

--- a/tests/structure_alignment_tests/test_foldmason_msa.py
+++ b/tests/structure_alignment_tests/test_foldmason_msa.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.structure_alignment import (
@@ -14,6 +15,7 @@ from proto_tools.tools.structure_alignment import (
     FoldmasonMSAInput,
     run_foldmason_msa,
 )
+from proto_tools.tools.structure_alignment.foldmason import foldmason_msa
 from proto_tools.tools.structure_alignment.foldmason.foldmason_msa import (
     _msa_dimensions,
     _parse_msa_response_json,
@@ -184,6 +186,73 @@ def test_remote_mode_submits_polls_and_parses_json():
     files = fake_session.post.call_args.kwargs["files"]
     field_names = [name for name, _ in files]
     assert field_names == ["fileNames[]", "queries[]", "fileNames[]", "queries[]"]
+
+
+class _ResetThenOkSession:
+    """A session whose ``post``/``get`` mimic a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, post_response, get_response):
+        self.failures = failures
+        self.post_response = post_response
+        self.get_response = get_response
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        return self._call(self.post_response)
+
+    def get(self, *args, **kwargs):
+        return self._call(self.get_response)
+
+    def close(self):
+        pass
+
+    def _call(self, response):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return response
+
+
+def test_remote_mode_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against search.foldseek.com."""
+    monkeypatch.setattr(foldmason_msa, "_BACKOFF_SECONDS", 0.0)
+    inputs = FoldmasonMSAInput(structures=[_TINY_PDB, _TINY_PDB], structure_ids=["q1", "q2"])
+    config = FoldmasonMSAConfig()
+
+    submit_response = MagicMock()
+    submit_response.status_code = 200
+    submit_response.raise_for_status.return_value = None
+    submit_response.json.return_value = {"id": "tk-123"}
+
+    result_response = MagicMock()
+    result_response.raise_for_status.return_value = None
+    result_response.json.return_value = {
+        "entries": [
+            {"name": "q1", "aa": "MK", "ss": "DD", "ca": ""},
+            {"name": "q2", "aa": "MK", "ss": "DD", "ca": ""},
+        ],
+        "tree": "(q1,q2);",
+        "scores": [0.8, 0.8],
+        "statistics": {"msaLDDT": 0.8},
+    }
+
+    # 2 failures each on submit and result-fetch, sharing one failure counter against one session --
+    # simplest faithful reproduction of a connection reset hitting either call.
+    fake_session = _ResetThenOkSession(failures=2, post_response=submit_response, get_response=result_response)
+
+    with (
+        patch(
+            "proto_tools.tools.structure_alignment.foldmason.foldmason_msa.build_http_session",
+            return_value=fake_session,
+        ),
+        patch("proto_tools.tools.structure_alignment.foldmason.foldmason_msa.poll_until_complete"),
+    ):
+        output = run_foldmason_msa(inputs, config)
+
+    assert output.success
+    assert output.ticket_id == "tk-123"
 
 
 def test_remote_submit_raises_on_missing_ticket_id():


### PR DESCRIPTION
## Summary
- Same latent bug as #84: `foldmason-msa`'s remote mode reuses one session across a submit POST, several `poll_until_complete` GETs, and a post-poll result-download GET against `search.foldseek.com` — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- `poll_until_complete`'s own internal GETs already retry `ConnectionError`/`Timeout` against a wall-clock deadline and are unaffected; only the submit POST (`_submit_foldmason`) and the result-download GET (`_remote_msa`) were bare.

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/structure_alignment_tests/test_foldmason_msa.py -q -m "not integration"` — 18 passed, 1 skipped (unrelated slow test), including a new regression test reproducing the reused-connection failure directly.
- [x] `pytest tests/structure_alignment_tests/test_foldmason_msa.py -q --integration` (live `search.foldseek.com` remote submit-and-poll) — 20 passed, 0 failed, 1 skipped.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.