### PR TITLE
Retry Foldseek search fetches through a reset connection

### DIFF
--- a/proto_tools/tools/structure_alignment/foldseek/foldseek_multimer_search.py
+++ b/proto_tools/tools/structure_alignment/foldseek/foldseek_multimer_search.py
@@ -40,6 +40,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 from proto_tools.utils.device import RemoteDevice
 
@@ -352,7 +353,11 @@ def _remote_multimer_search(
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDSEEK_BASE}/api/result/download/{ticket_id}"
-        archive_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        archive_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         archive_response.raise_for_status()
         hits = _parse_m8_archive(archive_response.content)
         return FoldseekMultimerSearchOutput(

--- a/proto_tools/tools/structure_alignment/foldseek/foldseek_search.py
+++ b/proto_tools/tools/structure_alignment/foldseek/foldseek_search.py
@@ -30,6 +30,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 from proto_tools.utils.device import RemoteDevice
 
@@ -414,7 +415,11 @@ def _remote_search(inputs: FoldseekSearchInput, config: FoldseekSearchConfig) ->
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDSEEK_BASE}/api/result/download/{ticket_id}"
-        archive_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        archive_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         archive_response.raise_for_status()
         hits = _parse_m8_archive(archive_response.content)
         return FoldseekSearchOutput(
@@ -479,11 +484,15 @@ def _submit(
     """Submit a structure to Foldseek; return the job ticket ID."""
     files = {"q": ("query.pdb", structure_text, "chemical/x-pdb")}
     data = [("database[]", db) for db in databases] + [("mode", mode)]
-    response = session.post(
-        f"{_FOLDSEEK_BASE}/api/ticket",
-        files=files,
-        data=data,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.post(
+            f"{_FOLDSEEK_BASE}/api/ticket",
+            files=files,
+            data=data,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     response.raise_for_status()
     payload = response.json()

--- a/tests/structure_alignment_tests/test_foldseek_search.py
+++ b/tests/structure_alignment_tests/test_foldseek_search.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -21,6 +22,7 @@ from proto_tools.tools.structure_alignment import (
     FoldseekSearchInput,
     run_foldseek_search,
 )
+from proto_tools.tools.structure_alignment.foldseek import foldseek_search
 from proto_tools.tools.structure_alignment.foldseek.foldseek_search import (
     FoldseekHit,
     _parse_m8_archive,
@@ -149,6 +151,47 @@ def test_submit_parses_ticket_id_and_encodes_databases():
         ("database[]", "afdb50"),
         ("mode", "tmalign"),
     ]
+
+
+class _ResetThenOkSession:
+    """A session whose ``post``/``get`` mimic a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, response):
+        self.failures = failures
+        self.response = response
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        return self._call()
+
+    def get(self, *args, **kwargs):
+        return self._call()
+
+    def _call(self):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return self.response
+
+
+def test_submit_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against search.foldseek.com.
+
+    _submit is shared by foldseek-search and foldseek-multimer-search, so this covers both.
+    """
+    monkeypatch.setattr(foldseek_search, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"id": "ticket-abc-123", "status": "PENDING"}
+    session = _ResetThenOkSession(failures=2, response=response)
+
+    ticket_id = _submit("PDB...", ["pdb100"], "tmalign", session)
+
+    assert ticket_id == "ticket-abc-123"
+    assert session.calls == 3
 
 
 # ── Local mode (mocked dispatch) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Same latent bug as #84: `foldseek-search` and `foldseek-multimer-search` each reuse one session across a submit POST, several `poll_until_complete` GETs, and a post-poll result-archive GET against `search.foldseek.com` — the same reuse pattern that let a pooled-connection reset go unretried in `uniprot-fetch`.
- `foldseek-multimer-search` imports `_submit` from `foldseek_search.py` rather than defining its own, so fixing it there covers both tools; multimer's own result-archive GET needed its own separate fix.
- `poll_until_complete`'s internal GETs already retry `ConnectionError`/`Timeout` against a wall-clock deadline and are unaffected.

**Depends on #84** (`fix/uniprot-connection-reset-retry`) for the `request_with_retry` helper — this PR is based on that branch and should be reviewed/merged after it (or rebased onto `main` once #84 lands).

## Test plan
- [x] `pytest tests/structure_alignment_tests/test_foldseek_search.py tests/structure_alignment_tests/test_foldseek_multimer_search.py -q -m "not integration"` — 15 passed, 2 skipped (unrelated slow tests), including a new regression test on the shared `_submit` (covers both tools) reproducing the reused-connection failure directly.
- [x] Same suites `--integration` (live `search.foldseek.com` remote submit-and-poll, including a real multimer search finding PDL1 complex neighbors) — 19 passed, 0 failed, 2 skipped.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy` — no new errors.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.

Opened as a draft for review before merging.