### PR TITLE
Superseded: caller-owned Modal deployment for BLAST

### DIFF
--- a/proto_tools/mcp/tools.py
+++ b/proto_tools/mcp/tools.py
@@ -640,6 +640,7 @@ def _dispatch(
     client: Any | None = None,
     progress_partition: str | None = None,
     on_record: Callable[[dict[str, Any]], None] | None = None,
+    force_remote: bool = False,
 ) -> tuple[Any, Device]:
     """Route one call to the backend ``device`` names, and report where it ran.
 
@@ -666,7 +667,7 @@ def _dispatch(
         return spec.function(payload, cfg), ran_on
     # A search mode whose implementation is an HTTP call is answered from here. Otherwise the
     # server would look for a deployment that such a tool has no reason to have.
-    if (reason := cfg.local_execution_reason(device)) is not None:
+    if not force_remote and (reason := cfg.local_execution_reason(device)) is not None:
         logger.info("Tool %s: %s Running in this process instead.", tool_key, reason)
         cfg.device = "cpu"
         return spec.function(payload, cfg), "local"
@@ -732,6 +733,7 @@ def run_tool(
     client: Any | None = None,
     progress_partition: str | None = None,
     on_record: Callable[[dict[str, Any]], None] | None = None,
+    force_remote: bool = False,
 ) -> dict[str, Any]:
     """Run a tool and return its result, with large fields written to disk.
 
@@ -749,6 +751,10 @@ def run_tool(
     ``on_record`` receives the worker's progress records as they arrive, for a caller that has
     somewhere to put them. Without one the call is silent until it returns, which is what a
     terminal-less caller would otherwise get for a fold that takes minutes.
+
+    ``force_remote`` is an internal hosted-gateway control. It bypasses a config's advisory
+    in-process preference, but not intrinsically inline CPU tools or hard remote-capability checks
+    such as a caller-local database path.
     """
     from proto_tools.tools import ToolRegistry
 
@@ -796,6 +802,7 @@ def run_tool(
             client=client,
             progress_partition=progress_partition,
             on_record=on_record,
+            force_remote=force_remote,
         )
     except _setup_errors(device) as exc:
         return {"ok": False, **_unavailable(device, tool_key, str(exc))}

--- a/proto_tools/modal/manifest.py
+++ b/proto_tools/modal/manifest.py
@@ -45,6 +45,7 @@ APP_BUCKETS: dict[str, list[str]] = {
     "proto-tools-splice-transformer": ["SpliceTransformerService"],
     "proto-tools-spliceai": ["SpliceAIService"],
     # CPU services — one app each, so deploying one does not build the others.
+    "proto-tools-blast": ["BlastService"],
     "proto-tools-ccd-lookup": ["CcdLookupService"],
     "proto-tools-crispr-tracr-rna": ["CrisprTracrRNAService"],
     "proto-tools-dssp": ["DSSPService"],
@@ -114,6 +115,7 @@ SERVICE_TIERS: dict[str, str] = {
     "AlphaFold2Service": "long",
     "AlphaGenomeService": "long",
     "BioEmuService": "extended",
+    "BlastService": "medium",
     "Boltz2Service": "long",
     "BorzoiService": "long",
     "CcdLookupService": "fast",
@@ -285,6 +287,7 @@ SERVICE_TO_MODULE: dict[str, str] = {
     "AlphaFold2Service": "proto_tools.modal.structure_prediction.alphafold2_deployment.alphafold2_service",
     "AlphaGenomeService": "proto_tools.modal.sequence_scoring.alphagenome_deployment.alphagenome_service",
     "BioEmuService": "proto_tools.modal.structure_dynamics.bioemu_deployment.bioemu_service",
+    "BlastService": "proto_tools.modal.sequence_alignment.blast_deployment.blast_service",
     "Boltz2Service": "proto_tools.modal.structure_prediction.boltz2_deployment.boltz2_service",
     "BorzoiService": "proto_tools.modal.sequence_scoring.borzoi_deployment.borzoi_service",
     "CcdLookupService": "proto_tools.modal.database_retrieval.ccd_lookup_deployment.ccd_lookup_service",

--- a/proto_tools/modal/sequence_alignment/blast_deployment/blast_service.py
+++ b/proto_tools/modal/sequence_alignment/blast_deployment/blast_service.py
@@ -1,0 +1,86 @@
+"""Portable BLAST Modal service for caller-owned workspaces.
+
+Only online NCBI QBLAST searches are remotely portable. Local database searches are rejected by
+``BlastSearchConfig.remote_unsupported_reason`` before dispatch because the database path belongs
+to the caller's machine. Proto's hosted backend may override this service with its own deployment
+that mounts managed databases; this definition deliberately has no Proto volumes or secrets.
+"""
+
+from typing import Any
+
+import modal
+
+from proto_tools.modal.app import HF_TOKEN_SECRET, SERVICE_RETRIES, get_app_for_service
+from proto_tools.modal.base_images import CPU_BASE, with_proto_tools
+from proto_tools.modal.manifest import SERVICE_MODAL_TIMEOUTS
+from proto_tools.modal.registry import register_tools
+from proto_tools.modal.utils import RUNTIME_ENV, env_for, run_tool_call
+
+
+def _warmup() -> None:
+    """Validate the online-only runtime without submitting a request to NCBI during deployment."""
+    from Bio.Blast import NCBIWWW, NCBIXML  # noqa: F401
+
+    from proto_tools.tools.sequence_alignment.blast.blast_search import BlastSearchConfig, BlastSearchInput
+
+    BlastSearchInput(query="ATGC")
+    BlastSearchConfig(search_mode="online")
+
+
+image = (
+    with_proto_tools(CPU_BASE)
+    .env(env_for())
+    .run_function(
+        _warmup,
+        secrets=[HF_TOKEN_SECRET],
+        include_source=False,
+    )
+    .env(RUNTIME_ENV)
+)
+
+
+app = get_app_for_service("BlastService")
+
+
+@app.cls(
+    include_source=False,
+    image=image,
+    cpu=2,
+    timeout=SERVICE_MODAL_TIMEOUTS["BlastService"],
+    retries=SERVICE_RETRIES,
+    secrets=[HF_TOKEN_SECRET],
+)
+@register_tools({"blast-search": "search"})
+class BlastService:
+    """Modal service for online NCBI BLAST searches."""
+
+    @modal.method()
+    def search(self, input_dict: dict[str, Any], config_dict: dict[str, Any]) -> dict[str, Any]:
+        """Search an NCBI BLAST database through QBLAST.
+
+        Args:
+            input_dict (dict[str, Any]): Serialized BLAST query input.
+            config_dict (dict[str, Any]): Serialized online-search configuration.
+
+        Returns:
+            dict[str, Any]: Structured BLAST hits and query metadata.
+
+        Raises:
+            ValueError: If a caller bypasses dispatch validation and requests local database mode.
+        """
+        from proto_tools.tools.sequence_alignment.blast.blast_search import (
+            BlastSearchConfig,
+            BlastSearchInput,
+            run_blast_search,
+        )
+
+        config = BlastSearchConfig(**config_dict)
+        if config.search_mode != "online":
+            raise ValueError("BlastService only supports search_mode='online'; local databases are not portable.")
+        return run_tool_call(
+            run_blast_search,
+            BlastSearchInput,
+            BlastSearchConfig,
+            input_dict,
+            config_dict,
+        )

--- a/proto_tools/modal/tool_map.py
+++ b/proto_tools/modal/tool_map.py
@@ -27,6 +27,7 @@ TOOL_MAP: dict[str, ToolEntry] = {
     "alphagenome-score-ism-variants-batch": ToolEntry("proto-tools-alphagenome", "AlphaGenomeService", "score_ism_variants", True),
     "alphagenome-score-variants": ToolEntry("proto-tools-alphagenome", "AlphaGenomeService", "score_variants", True),
     "bioemu-sample": ToolEntry("proto-tools-bioemu", "BioEmuService", "sample", True),
+    "blast-search": ToolEntry("proto-tools-blast", "BlastService", "search", False),
     "boltz2-affinity": ToolEntry("proto-tools-boltz2", "Boltz2Service", "affinity", True),
     "boltz2-prediction": ToolEntry("proto-tools-boltz2", "Boltz2Service", "predict", True),
     "borzoi-ensemble": ToolEntry("proto-tools-borzoi", "BorzoiService", "predict_ensemble", True),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,6 +417,7 @@ exclude = ["*.standalone.standalone_helpers", "*.standalone.standalone_helpers.*
 "proto_tools.modal.rna_splicing.pangolin_deployment" = ["README.md"]
 "proto_tools.modal.rna_splicing.splice_transformer_deployment" = ["README.md"]
 "proto_tools.modal.rna_splicing.spliceai_deployment" = ["README.md"]
+"proto_tools.modal.sequence_alignment.blast_deployment" = ["README.md"]
 "proto_tools.modal.sequence_alignment.mafft_deployment" = ["README.md"]
 "proto_tools.modal.sequence_scoring.alphagenome_deployment" = ["README.md"]
 "proto_tools.modal.sequence_scoring.borzoi_deployment" = ["README.md"]

--- a/tests/modal_tests/test_mcp_local_device.py
+++ b/tests/modal_tests/test_mcp_local_device.py
@@ -103,6 +103,92 @@ def test_a_deployed_tool_is_still_dispatched(monkeypatch) -> None:
     assert result["ok"] is False
 
 
+def test_online_blast_stays_local_unless_the_host_forces_remote(monkeypatch) -> None:
+    """Hosted MCP can require caller-owned compute without changing ordinary SDK behavior."""
+    from proto_tools.mcp import tools as impl
+    from proto_tools.modal import client
+
+    local_calls: list[str] = []
+    remote_calls: list[str] = []
+
+    spec = ToolRegistry.get("blast-search")
+
+    def fake_local(payload, cfg):
+        local_calls.append(cfg.device)
+        raise RuntimeError("ran locally")
+
+    def fake_remote(tool_key, payload, cfg, **_kwargs):
+        remote_calls.append(tool_key)
+        raise RuntimeError("ran remotely")
+
+    monkeypatch.setattr(spec, "function", fake_local)
+    monkeypatch.setattr(client, "dispatch_to_modal", fake_remote)
+    example = ToolRegistry.get_example_input("blast-search")
+    inputs = example.model_dump(mode="json")
+
+    ordinary = impl.run_tool("blast-search", inputs=inputs, device="modal")
+    forced = impl.run_tool("blast-search", inputs=inputs, device="modal", force_remote=True)
+
+    assert local_calls == ["cpu"]
+    assert "ran locally" in ordinary["error"]
+    assert remote_calls == ["blast-search"]
+    assert "ran remotely" in forced["error"]
+
+
+def test_forced_remote_blast_still_rejects_a_local_database(monkeypatch) -> None:
+    """The hosted override skips a preference, never a hard capability boundary."""
+    from proto_tools.mcp import tools as impl
+    from proto_tools.modal import client
+
+    monkeypatch.setattr(
+        client,
+        "dispatch_to_modal",
+        lambda *_args, **_kwargs: pytest.fail("a local database must never be dispatched"),
+    )
+    result = impl.run_tool(
+        "blast-search",
+        inputs={"query": "ATGC"},
+        config={"search_mode": "local", "local_db": "/blast/db"},
+        device="modal",
+        force_remote=True,
+    )
+
+    assert result["ok"] is False
+    assert result["not_supported_on"] == "modal"
+    assert "local BLAST database" in result["error"]
+
+
+def test_forced_remote_keeps_intrinsically_inline_cpu_tools_in_process(monkeypatch) -> None:
+    """The hosted override is config-specific; it must not require deployments for simple lookups."""
+    from proto_tools.mcp import tools as impl
+    from proto_tools.modal import client
+
+    tool_key = "pdb-fetch-entry"
+    called: list[str] = []
+    spec = ToolRegistry.get(tool_key)
+
+    def fake_local(payload, cfg):
+        called.append(cfg.device)
+        raise RuntimeError("ran inline")
+
+    monkeypatch.setattr(spec, "function", fake_local)
+    monkeypatch.setattr(
+        client,
+        "dispatch_to_modal",
+        lambda *_args, **_kwargs: pytest.fail("an intrinsically inline tool must not be dispatched"),
+    )
+    example = ToolRegistry.get_example_input(tool_key)
+    result = impl.run_tool(
+        tool_key,
+        inputs=example.model_dump(mode="json"),
+        device="modal",
+        force_remote=True,
+    )
+
+    assert called == ["modal"]
+    assert "ran inline" in result["error"]
+
+
 def test_a_deployed_local_cpu_tool_is_not_flagged_as_running_here() -> None:
     """local_cpu means a deployment is optional, not absent — two of them have one.
 


### PR DESCRIPTION
## Motivation

Hosted MCP calls must run on compute owned by the caller. BLAST online mode normally stays in the local process because submitting to NCBI over HTTP does not benefit from another hop. That is correct for the local SDK, but it left a hosted MCP process with no safe way to dispatch BLAST into the caller's Modal workspace.

## What changed

- Add a portable `proto-tools-blast` Modal app and `BlastService` for online NCBI QBLAST searches.
- Register `blast-search` in the generated Modal tool map.
- Add an internal `force_remote` option to the MCP implementation. It skips only configuration-driven local-execution preferences.
- Preserve intrinsically inline CPU behavior, so database and API lookup tools still run in-process without requiring deployments.
- Preserve `remote_unsupported_reason`, so `search_mode="local"` and caller-local BLAST database paths are rejected before dispatch.
- Validate Biopython and the BLAST models at image build time without submitting a real NCBI request.
- Add the deployment package to wheel benchmark-report exclusions.

## Behavior

Before:

- A normal online BLAST call correctly ran locally.
- A hosted MCP call also tried to run locally, rather than in caller-owned Modal compute.
- Users had no portable BLAST app they could deploy.

After:

- Normal SDK and local MCP calls retain the existing local behavior.
- A hosted caller can explicitly force the online mode through `proto-tools-blast` in their own Modal workspace.
- Local-database BLAST remains local-only and is never staged or dispatched implicitly.
- Other simple CPU utilities remain inline and do not acquire a deployment requirement.

Proto-owned compute can continue overriding this portable service with its managed-database BLAST deployment.

## Coordinated rollout

The dependent API changes are in proto-bio/proto-tools-api#708. Merge this PR first so its pinned submodule commit is available upstream, then merge the API PR.

## Test plan

```bash
uv run ruff check proto_tools/modal/manifest.py proto_tools/mcp/tools.py proto_tools/modal/sequence_alignment/blast_deployment/blast_service.py tests/modal_tests/test_mcp_local_device.py
uv run pytest tests/modal_tests/test_mcp_local_device.py tests/modal_tests/test_entrypoints.py -q
uv run pytest tests/modal_tests tests/tool_infra_tests/test_proto.py tests/sequence_alignment_tests/test_blast.py -q
```

Results: 446 passed, 12 integration/slow tests skipped in the broad suite; 30 passed in the focused routing and manifest suite.