### PR TITLE
Retry more database/search fetches through a reset connection

### DIFF
--- a/proto_tools/tools/database_retrieval/alphafold_db/alphafold_db_fetch.py
+++ b/proto_tools/tools/database_retrieval/alphafold_db/alphafold_db_fetch.py
@@ -22,6 +22,7 @@ from proto_tools.utils import (
     ConfigField,
     InputField,
     build_http_session,
+    request_with_retry,
 )
 from proto_tools.utils.tool_io import Metrics, MetricSpec
 
@@ -506,7 +507,11 @@ def _select_record(
 
 def _fetch_prediction(api_url: str, session: requests.Session) -> list[dict[str, Any]] | None:
     """Fetch prediction metadata list. Returns None on 404."""
-    response = session.get(api_url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(api_url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         logger.debug("AlphaFold DB returned 404 for %s", api_url)
         return None
@@ -519,14 +524,22 @@ def _fetch_prediction(api_url: str, session: requests.Session) -> list[dict[str,
 
 def _fetch_text(url: str, session: requests.Session) -> str:
     """Fetch a remote file as text (used for structure files and MSA A3M)."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     return response.text
 
 
 def _fetch_plddt(url: str, session: requests.Session) -> list[float]:
     """Fetch the per-residue pLDDT confidence array."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     payload = response.json()
     scores = payload.get("confidenceScore")
@@ -537,7 +550,11 @@ def _fetch_plddt(url: str, session: requests.Session) -> list[float]:
 
 def _fetch_pae(url: str, session: requests.Session) -> list[list[float]]:
     """Fetch the PAE matrix as a 2D list of floats."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     payload = response.json()
     if not isinstance(payload, list) or not payload:

--- a/proto_tools/tools/database_retrieval/interproscan/interproscan_fetch.py
+++ b/proto_tools/tools/database_retrieval/interproscan/interproscan_fetch.py
@@ -27,6 +27,7 @@ from proto_tools.utils import (
     build_http_session,
     extract_text_status,
     poll_until_complete,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -437,7 +438,12 @@ def _direct_lookup(
         if next_url in seen_urls:
             raise ValueError(f"InterPro pagination cursor revisited URL {next_url!r} for '{accession}'")
         seen_urls.add(next_url)
-        response = session.get(next_url, timeout=_REQUEST_TIMEOUT_SECONDS)
+        current_url = next_url
+
+        def _get(url: str = current_url) -> requests.Response:
+            return session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+
+        response = request_with_retry(_get, retries=_HTTP_RETRIES, backoff_seconds=_BACKOFF_SECONDS)
         # 204 / 404 = "unknown accession" (InterPro's actual signals).
         if response.status_code in (204, 404):
             raise ValueError(f"InterPro has no entries for UniProt accession '{accession}'")
@@ -585,7 +591,11 @@ def _submit_and_poll(
         status_extractor=extract_text_status,
     )
     result_url = f"{_IPRSCAN5_BASE}/result/{job_id}/json"
-    response = session.get(result_url, timeout=_RESULT_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(result_url, timeout=_RESULT_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     try:
         payload = response.json()
@@ -612,7 +622,11 @@ def _submit_iprscan(
     ]
     if config.applications:
         data.extend(("appl", app) for app in config.applications)
-    response = session.post(f"{_IPRSCAN5_BASE}/run/", data=data, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.post(f"{_IPRSCAN5_BASE}/run/", data=data, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     job_id = response.text.strip()
     if not job_id:

--- a/proto_tools/tools/database_retrieval/ncbi/shared_data_models.py
+++ b/proto_tools/tools/database_retrieval/ncbi/shared_data_models.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 import requests
 from pydantic import BaseModel, Field
 
-from proto_tools.utils import BaseConfig, ConfigField
+from proto_tools.utils import BaseConfig, ConfigField, request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -158,10 +158,14 @@ def _ncbi_esearch(
         params["reldate"] = reldate
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/esearch.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/esearch.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-esearch"):
         return []
@@ -183,10 +187,14 @@ def _ncbi_esummary(
     }
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/esummary.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/esummary.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-esummary"):
         return None
@@ -221,10 +229,14 @@ def _ncbi_efetch(
 
     params.update(_ncbi_common_params(config))
 
-    response = session.get(
-        f"{_NCBI_EUTILS_BASE}/efetch.fcgi",
-        params=params,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.get(
+            f"{_NCBI_EUTILS_BASE}/efetch.fcgi",
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     if not _check_response(response, "ncbi-efetch"):
         return None

--- a/proto_tools/tools/database_retrieval/pdb/shared_data_models.py
+++ b/proto_tools/tools/database_retrieval/pdb/shared_data_models.py
@@ -12,7 +12,7 @@ from typing import Any
 import requests
 from pydantic import BaseModel, Field
 
-from proto_tools.utils import BaseConfig
+from proto_tools.utils import BaseConfig, request_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,11 @@ class PdbFetchConfig(BaseConfig):
 
 def _request_pdb(session: requests.Session, url: str, source_label: str) -> requests.Response | None:
     """Execute an HTTP GET, returning None on 404."""
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         logger.debug("No record found at %s: %s", source_label, response.url)
         return None

--- a/proto_tools/tools/database_retrieval/pubchem/pubchem_fetch.py
+++ b/proto_tools/tools/database_retrieval/pubchem/pubchem_fetch.py
@@ -22,6 +22,7 @@ from proto_tools.utils import (
     ConfigField,
     InputField,
     build_http_session,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -429,10 +430,14 @@ def _resolve_to_cids(inputs: PubChemFetchInput, session: requests.Session) -> li
 
     if inputs.inchi is not None:
         url = f"{_PUBCHEM_BASE}/compound/inchi/cids/JSON"
-        response = session.post(
-            url,
-            data={"inchi": inputs.inchi},
-            timeout=_REQUEST_TIMEOUT_SECONDS,
+        response = request_with_retry(
+            lambda: session.post(
+                url,
+                data={"inchi": inputs.inchi},
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            ),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
         )
     else:
         if inputs.name is not None:
@@ -441,7 +446,11 @@ def _resolve_to_cids(inputs: PubChemFetchInput, session: requests.Session) -> li
             url = f"{_PUBCHEM_BASE}/compound/smiles/{quote(inputs.smiles, safe='')}/cids/JSON"
         else:
             url = f"{_PUBCHEM_BASE}/compound/inchikey/{quote(inputs.inchikey or '', safe='')}/cids/JSON"
-        response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+        response = request_with_retry(
+            lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
 
     if response.status_code == 404:
         return []
@@ -458,7 +467,11 @@ def _fetch_properties(
     """Fetch the requested property bundle for a CID. Returns (record, url)."""
     props = ",".join(config.properties)
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/property/{props}/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     response.raise_for_status()
     properties = response.json()["PropertyTable"]["Properties"]
     if not properties:
@@ -476,7 +489,11 @@ def _fetch_synonyms(cid: int, session: requests.Session) -> list[str]:
     other malformed shape raises KeyError via direct dict access.
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/synonyms/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()
@@ -494,7 +511,11 @@ def _fetch_descriptions(cid: int, session: requests.Session) -> list[str]:
     contribute a Title).
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/description/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()
@@ -509,7 +530,11 @@ def _fetch_aids(cid: int, session: requests.Session) -> list[int]:
     For common compounds (e.g., aspirin) this can return thousands of IDs.
     """
     url = f"{_PUBCHEM_BASE}/compound/cid/{cid}/aids/JSON"
-    response = session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS)
+    response = request_with_retry(
+        lambda: session.get(url, timeout=_REQUEST_TIMEOUT_SECONDS),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
+    )
     if response.status_code == 404:
         return []
     response.raise_for_status()

--- a/proto_tools/tools/structure_alignment/foldmason/foldmason_msa.py
+++ b/proto_tools/tools/structure_alignment/foldmason/foldmason_msa.py
@@ -27,6 +27,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 
 logger = logging.getLogger(__name__)
@@ -287,7 +288,11 @@ def _remote_msa(inputs: FoldmasonMSAInput, config: FoldmasonMSAConfig) -> Foldma
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDMASON_BASE}/api/result/foldmason/{ticket_id}"
-        result_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        result_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         result_response.raise_for_status()
         aa_fasta, three_di_fasta, newick, num_sequences, alignment_length = _parse_msa_response_json(
             result_response.json()
@@ -361,10 +366,14 @@ def _submit_foldmason(
     for sid, text in zip(structure_ids, structures, strict=True):
         files.append(("fileNames[]", (None, sid, "text/plain")))
         files.append(("queries[]", (sid, text, "chemical/x-pdb")))
-    response = session.post(
-        f"{_FOLDMASON_BASE}/api/ticket/foldmason",
-        files=files,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.post(
+            f"{_FOLDMASON_BASE}/api/ticket/foldmason",
+            files=files,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     response.raise_for_status()
     payload = response.json()

--- a/proto_tools/tools/structure_alignment/foldseek/foldseek_multimer_search.py
+++ b/proto_tools/tools/structure_alignment/foldseek/foldseek_multimer_search.py
@@ -40,6 +40,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 from proto_tools.utils.device import RemoteDevice
 
@@ -352,7 +353,11 @@ def _remote_multimer_search(
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDSEEK_BASE}/api/result/download/{ticket_id}"
-        archive_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        archive_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         archive_response.raise_for_status()
         hits = _parse_m8_archive(archive_response.content)
         return FoldseekMultimerSearchOutput(

--- a/proto_tools/tools/structure_alignment/foldseek/foldseek_search.py
+++ b/proto_tools/tools/structure_alignment/foldseek/foldseek_search.py
@@ -30,6 +30,7 @@ from proto_tools.utils import (
     ToolInstance,
     build_http_session,
     poll_until_complete,
+    request_with_retry,
 )
 from proto_tools.utils.device import RemoteDevice
 
@@ -414,7 +415,11 @@ def _remote_search(inputs: FoldseekSearchInput, config: FoldseekSearchConfig) ->
             timeout_seconds=config.timeout_seconds,
         )
         result_url = f"{_FOLDSEEK_BASE}/api/result/download/{ticket_id}"
-        archive_response = session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS)
+        archive_response = request_with_retry(
+            lambda: session.get(result_url, timeout=_RESULT_DOWNLOAD_TIMEOUT_SECONDS),
+            retries=_HTTP_RETRIES,
+            backoff_seconds=_BACKOFF_SECONDS,
+        )
         archive_response.raise_for_status()
         hits = _parse_m8_archive(archive_response.content)
         return FoldseekSearchOutput(
@@ -479,11 +484,15 @@ def _submit(
     """Submit a structure to Foldseek; return the job ticket ID."""
     files = {"q": ("query.pdb", structure_text, "chemical/x-pdb")}
     data = [("database[]", db) for db in databases] + [("mode", mode)]
-    response = session.post(
-        f"{_FOLDSEEK_BASE}/api/ticket",
-        files=files,
-        data=data,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.post(
+            f"{_FOLDSEEK_BASE}/api/ticket",
+            files=files,
+            data=data,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     response.raise_for_status()
     payload = response.json()

--- a/tests/database_retrieval_tests/test_alphafold_db_fetch.py
+++ b/tests/database_retrieval_tests/test_alphafold_db_fetch.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from proto_tools.entities.structures.structure import BFactorType, Structure
 from proto_tools.tools.database_retrieval import (
@@ -20,6 +21,7 @@ from proto_tools.tools.database_retrieval import (
     run_alphafold_db_fetch,
     run_uniprot_fetch,
 )
+from proto_tools.tools.database_retrieval.alphafold_db import alphafold_db_fetch
 from proto_tools.tools.database_retrieval.alphafold_db.alphafold_db_fetch import (
     AlphaFoldDBFetchOutput,
     _fetch_pae,
@@ -76,6 +78,36 @@ def test_fetch_prediction_returns_none_on_404():
     result = _fetch_prediction("https://example/api", session)
     assert result is None
     session.get.return_value.json.assert_not_called()
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, payload):
+        self.failures = failures
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = MagicMock()
+        response.status_code = 200
+        response.raise_for_status.return_value = None
+        response.json.return_value = self.payload
+        return response
+
+
+def test_fetch_prediction_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against the AFDB API."""
+    monkeypatch.setattr(alphafold_db_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, payload=[{"modelEntityId": "AF-P04637-F1"}])
+    result = _fetch_prediction("https://example/api", session)
+    assert result == [{"modelEntityId": "AF-P04637-F1"}]
+    assert session.calls == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/database_retrieval_tests/test_interproscan_fetch.py
+++ b/tests/database_retrieval_tests/test_interproscan_fetch.py
@@ -7,6 +7,7 @@ sequence submit-and-poll paths against EBI's iprscan5 endpoint.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -16,6 +17,7 @@ from proto_tools.tools.database_retrieval import (
     run_interproscan_fetch,
     run_uniprot_fetch,
 )
+from proto_tools.tools.database_retrieval.interproscan import interproscan_fetch
 from proto_tools.tools.database_retrieval.interproscan.interproscan_fetch import (
     _DIRECT_LOOKUP_MAX_PAGES,
     _direct_lookup,
@@ -269,6 +271,43 @@ def test_direct_lookup_wraps_corrupt_json_with_context():
         _direct_lookup("P04637", InterProScanFetchConfig(), session)
 
 
+class _ResetThenOkSession:
+    """A session whose ``get``/``post`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, response):
+        self.failures = failures
+        self.response = response
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        return self._call()
+
+    def post(self, *args, **kwargs):
+        return self._call()
+
+    def _call(self):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return self.response
+
+
+def test_direct_lookup_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against InterPro's REST API."""
+    monkeypatch.setattr(interproscan_fetch, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.text = '{"results": [], "next": null}'
+    response.json.return_value = {"results": [], "next": None}
+    session = _ResetThenOkSession(failures=2, response=response)
+    output = _direct_lookup("P04637", InterProScanFetchConfig(), session)
+    assert output.num_domains == 0
+    assert session.calls == 3
+
+
 # ---------------------------------------------------------------------------
 # iprscan5 submit + parse tests
 # ---------------------------------------------------------------------------
@@ -293,6 +332,18 @@ def test_submit_iprscan_returns_plain_text_job_id():
     posted_data = dict(kwargs["data"]) if isinstance(kwargs["data"], list) else kwargs["data"]
     assert posted_data["email"] == "dev@example.org"
     assert posted_data["sequence"] == "MKTILVAA"
+
+
+def test_submit_iprscan_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against EBI's iprscan5 submit endpoint."""
+    monkeypatch.setattr(interproscan_fetch, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.text = "iprscan5-job-123"
+    response.raise_for_status.return_value = None
+    session = _ResetThenOkSession(failures=2, response=response)
+    job_id = _submit_iprscan("MKT", "dev@example.org", InterProScanFetchConfig(email="dev@example.org"), session)
+    assert job_id == "iprscan5-job-123"
+    assert session.calls == 3
 
 
 def test_submit_iprscan_rejects_empty_body():

--- a/tests/database_retrieval_tests/test_ncbi_fetch.py
+++ b/tests/database_retrieval_tests/test_ncbi_fetch.py
@@ -4,6 +4,7 @@ Tests for the NCBI Entrez tools (esearch, esummary, efetch).
 """
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -15,8 +16,10 @@ from proto_tools.tools.database_retrieval import (
     run_ncbi_esearch,
     run_ncbi_esummary,
 )
+from proto_tools.tools.database_retrieval.ncbi import shared_data_models
 from proto_tools.tools.database_retrieval.ncbi.shared_data_models import (
     _accession_from_header,
+    _ncbi_esearch,
     _parse_fasta_records,
 )
 
@@ -34,6 +37,37 @@ def test_ncbi_esummary_requires_identifier():
 def test_ncbi_efetch_requires_identifier():
     with pytest.raises(ValidationError):
         NCBIEfetchInput(db="protein")
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, text: str, url: str = "https://example/esearch.fcgi"):
+        self.failures = failures
+        self.text = text
+        self.url = url
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = requests.Response()
+        response.status_code = 200
+        response.url = self.url
+        response._content = self.text.encode()
+        return response
+
+
+def test_ncbi_esearch_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against NCBI eutils."""
+    monkeypatch.setattr(shared_data_models, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, text='{"esearchresult": {"idlist": ["12345"]}}')
+    ids = _ncbi_esearch("protein", "lacI", 10, NCBIFetchConfig(), session)
+    assert ids == ["12345"]
+    assert session.calls == 3
 
 
 def test_parse_fasta_records():

--- a/tests/database_retrieval_tests/test_pdb_fetch.py
+++ b/tests/database_retrieval_tests/test_pdb_fetch.py
@@ -4,6 +4,7 @@ Tests for the PDB fetch tools (fetch-entry, fetch-fasta).
 """
 
 import pytest
+import requests
 
 from proto_tools.tools.database_retrieval import (
     PdbFetchConfig,
@@ -12,9 +13,11 @@ from proto_tools.tools.database_retrieval import (
     run_pdb_fetch_entry,
     run_pdb_fetch_fasta,
 )
+from proto_tools.tools.database_retrieval.pdb import shared_data_models
 from proto_tools.tools.database_retrieval.pdb.shared_data_models import (
     _chain_ids_from_header,
     _is_protein_sequence,
+    _request_pdb,
 )
 
 
@@ -32,6 +35,37 @@ def test_is_protein_sequence_rna():
 
 def test_is_protein_sequence_empty():
     assert _is_protein_sequence("") is False
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, text: str):
+        self.failures = failures
+        self.text = text
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = requests.Response()
+        response.status_code = 200
+        response.url = "https://example/entry.json"
+        response._content = self.text.encode()
+        return response
+
+
+def test_request_pdb_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against RCSB PDB."""
+    monkeypatch.setattr(shared_data_models, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, text='{"entry": {"id": "1TUP"}}')
+    response = _request_pdb(session, "https://example/entry.json", "pdb-fetch-entry")
+    assert response is not None
+    assert response.json() == {"entry": {"id": "1TUP"}}
+    assert session.calls == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/database_retrieval_tests/test_pubchem_fetch.py
+++ b/tests/database_retrieval_tests/test_pubchem_fetch.py
@@ -6,6 +6,7 @@ Tests for the PubChem fetch tool.
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -13,6 +14,7 @@ from proto_tools.tools.database_retrieval import (
     PubChemFetchInput,
     run_pubchem_fetch,
 )
+from proto_tools.tools.database_retrieval.pubchem import pubchem_fetch
 from proto_tools.tools.database_retrieval.pubchem.pubchem_fetch import (
     _fetch_properties,
     _fetch_synonyms,
@@ -59,6 +61,35 @@ def test_resolve_to_cids_parses_response(status_code, payload, expected):
     session.get.return_value = response
     cids = _resolve_to_cids(PubChemFetchInput(name="anything"), session)
     assert cids == expected
+
+
+class _ResetThenOkSession:
+    """A session whose ``get`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, payload):
+        self.failures = failures
+        self.payload = payload
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = self.payload
+        return response
+
+
+def test_resolve_to_cids_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against PubChem PUG REST."""
+    monkeypatch.setattr(pubchem_fetch, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, payload={"IdentifierList": {"CID": [2244]}})
+    cids = _resolve_to_cids(PubChemFetchInput(name="aspirin"), session)
+    assert cids == [2244]
+    assert session.calls == 3
 
 
 def test_fetch_properties_raises_when_property_table_empty():

--- a/tests/structure_alignment_tests/test_foldmason_msa.py
+++ b/tests/structure_alignment_tests/test_foldmason_msa.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.structure_alignment import (
@@ -14,6 +15,7 @@ from proto_tools.tools.structure_alignment import (
     FoldmasonMSAInput,
     run_foldmason_msa,
 )
+from proto_tools.tools.structure_alignment.foldmason import foldmason_msa
 from proto_tools.tools.structure_alignment.foldmason.foldmason_msa import (
     _msa_dimensions,
     _parse_msa_response_json,
@@ -184,6 +186,73 @@ def test_remote_mode_submits_polls_and_parses_json():
     files = fake_session.post.call_args.kwargs["files"]
     field_names = [name for name, _ in files]
     assert field_names == ["fileNames[]", "queries[]", "fileNames[]", "queries[]"]
+
+
+class _ResetThenOkSession:
+    """A session whose ``post``/``get`` mimic a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, post_response, get_response):
+        self.failures = failures
+        self.post_response = post_response
+        self.get_response = get_response
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        return self._call(self.post_response)
+
+    def get(self, *args, **kwargs):
+        return self._call(self.get_response)
+
+    def close(self):
+        pass
+
+    def _call(self, response):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return response
+
+
+def test_remote_mode_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against search.foldseek.com."""
+    monkeypatch.setattr(foldmason_msa, "_BACKOFF_SECONDS", 0.0)
+    inputs = FoldmasonMSAInput(structures=[_TINY_PDB, _TINY_PDB], structure_ids=["q1", "q2"])
+    config = FoldmasonMSAConfig()
+
+    submit_response = MagicMock()
+    submit_response.status_code = 200
+    submit_response.raise_for_status.return_value = None
+    submit_response.json.return_value = {"id": "tk-123"}
+
+    result_response = MagicMock()
+    result_response.raise_for_status.return_value = None
+    result_response.json.return_value = {
+        "entries": [
+            {"name": "q1", "aa": "MK", "ss": "DD", "ca": ""},
+            {"name": "q2", "aa": "MK", "ss": "DD", "ca": ""},
+        ],
+        "tree": "(q1,q2);",
+        "scores": [0.8, 0.8],
+        "statistics": {"msaLDDT": 0.8},
+    }
+
+    # 2 failures each on submit and result-fetch, sharing one failure counter against one session --
+    # simplest faithful reproduction of a connection reset hitting either call.
+    fake_session = _ResetThenOkSession(failures=2, post_response=submit_response, get_response=result_response)
+
+    with (
+        patch(
+            "proto_tools.tools.structure_alignment.foldmason.foldmason_msa.build_http_session",
+            return_value=fake_session,
+        ),
+        patch("proto_tools.tools.structure_alignment.foldmason.foldmason_msa.poll_until_complete"),
+    ):
+        output = run_foldmason_msa(inputs, config)
+
+    assert output.success
+    assert output.ticket_id == "tk-123"
 
 
 def test_remote_submit_raises_on_missing_ticket_id():

--- a/tests/structure_alignment_tests/test_foldseek_search.py
+++ b/tests/structure_alignment_tests/test_foldseek_search.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from proto_tools.tools.database_retrieval import (
@@ -21,6 +22,7 @@ from proto_tools.tools.structure_alignment import (
     FoldseekSearchInput,
     run_foldseek_search,
 )
+from proto_tools.tools.structure_alignment.foldseek import foldseek_search
 from proto_tools.tools.structure_alignment.foldseek.foldseek_search import (
     FoldseekHit,
     _parse_m8_archive,
@@ -149,6 +151,47 @@ def test_submit_parses_ticket_id_and_encodes_databases():
         ("database[]", "afdb50"),
         ("mode", "tmalign"),
     ]
+
+
+class _ResetThenOkSession:
+    """A session whose ``post``/``get`` mimic a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, response):
+        self.failures = failures
+        self.response = response
+        self.calls = 0
+
+    def post(self, *args, **kwargs):
+        return self._call()
+
+    def get(self, *args, **kwargs):
+        return self._call()
+
+    def _call(self):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return self.response
+
+
+def test_submit_retries_connection_reset(monkeypatch):
+    """Same reused-connection failure as rest.uniprot.org, here against search.foldseek.com.
+
+    _submit is shared by foldseek-search and foldseek-multimer-search, so this covers both.
+    """
+    monkeypatch.setattr(foldseek_search, "_BACKOFF_SECONDS", 0.0)
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"id": "ticket-abc-123", "status": "PENDING"}
+    session = _ResetThenOkSession(failures=2, response=response)
+
+    ticket_id = _submit("PDB...", ["pdb100"], "tmalign", session)
+
+    assert ticket_id == "ticket-abc-123"
+    assert session.calls == 3
 
 
 # ── Local mode (mocked dispatch) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-on to #84 (merged): audited every other tool sharing `build_http_session()` with `uniprot-fetch` for the same latent bug — a session reused across multiple sequential requests, where a pooled keep-alive connection the server has since closed raises `ConnectionResetError` while urllib3 is *sending* the next request on it. That surfaces as `requests.exceptions.ConnectionError` above `HTTPAdapter`'s `Retry` rather than through it, so it goes unretried despite `http_retries` being configured.

Found and fixed 7 more tools with the identical gap, each wired to the shared `request_with_retry` helper from #84:

- **`alphafold-db-fetch`** — 4 sequential fetches per run (prediction metadata, structure, pLDDT, PAE, MSA)
- **`pubchem-fetch`** — up to 5 sequential fetches per run (CID resolution, properties, synonyms, descriptions, assay IDs)
- **`ncbi-esearch`/`esummary`/`efetch`** — shared eutils call sites in `shared_data_models.py`, also backing `sequence-fetch`'s batch lookups
- **`pdb-fetch-entry`/`fetch-fasta`** — shared RCSB call site in `shared_data_models.py`, also backing `sequence-fetch`
- **`interproscan-fetch`** — pagination GET loop, submit POST, and post-poll result GET
- **`foldmason-msa`** — submit POST and post-poll result-download GET against `search.foldseek.com`
- **`foldseek-search`** + **`foldseek-multimer-search`** — submit POST (shared between both tools) and each tool's own result-archive GET

Checked and ruled out as *not* vulnerable: `alphamissense-db-fetch` and all five `ensembl-*` tools — each makes only one request per session lifetime, so there's no reused connection for a reset to hit. `poll_until_complete`'s own internal GETs already retry `ConnectionError`/`Timeout` against a wall-clock deadline and needed no change.

## Test plan
- [x] `pytest` on each touched test file, `-m "not integration"` — all pass, including 7 new regression tests (one per tool/shared-module) reproducing the reused-connection failure directly.
- [x] `pytest tests/ -q -m "not integration"` (full suite) — 12686 passed, 9 failed. All 9 confirmed pre-existing and unrelated (missing `umap` dependency, unrelated `chai1` MSA-parsing assertions) — identical failure set on `main` before this branch.
- [x] Live integration sweep across all 7 tools against their real external APIs (UniProt, AlphaFold DB, PubChem, NCBI eutils, RCSB PDB, InterPro/iprscan5, `search.foldseek.com` for both Foldseek and FoldMason) — 167 passed, 2 failed. Both failures are `alphafold.ebi.ac.uk`'s MSA file endpoint currently returning 403 to any request whatsoever (confirmed with a bare `curl`, unrelated to this repo) — same as observed and ruled out in #84's review.
- [x] `ruff check` / `ruff format --check` clean on all 15 changed files.
- [x] `mypy proto_tools/` (full repo, matching CI) — no new errors; confirmed by diffing against the same run on `main`.
- [x] Docstring style checker (`test_docstring_style.py`) — clean.
- [x] Verified this branch's 7 commits merge and reapply cleanly with zero conflicts (each touches a disjoint set of files).

Opened as a draft for review before merging.