### PR TITLE
Reject rfdiffusion3-design specs rfd3 would reject, before dispatch

### DIFF
--- a/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
+++ b/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
@@ -126,7 +126,9 @@ class RFdiffusion3DesignSpec(BaseModel):
 
         select_hotspots (bool | str | dict[str, str] | None): Atom or residue
             hotspots for binder/PPI design (typically <=4.5 Angstroms to any
-            heavy atom in the designed structure).
+            heavy atom in the designed structure). Requires ``contig`` (not
+            just ``length``) to state how the designed binder relates to
+            ``input_structure``, e.g. ``"A1-1366/0,80-120"``.
 
         symmetry (str | dict[str, Any] | None): Symmetry for homo-oligomer design.
             A group-id string (e.g. ``"C3"``) is wrapped as ``{"id": "C3"}``; a
@@ -217,7 +219,7 @@ class RFdiffusion3DesignSpec(BaseModel):
     select_hotspots: bool | str | dict[str, str] | None = Field(
         default=None,
         title="Hotspots",
-        description="Atom/residue-level hotspots for binder design (True/False, contig string, or dict)",
+        description="Atom/residue-level hotspots for binder design; requires 'contig', not just 'length'",
         examples=["A24,A35,A50"],
     )
     symmetry: str | dict[str, Any] | None = Field(
@@ -369,6 +371,26 @@ class RFdiffusion3DesignSpec(BaseModel):
                 "Pass either 'contig' or 'length', not both: a contig already encodes "
                 "its designed-segment lengths, while 'length' is for unconditional "
                 "design with no contig."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_hotspots_require_contig(self) -> Any:
+        """Reject ``select_hotspots`` without ``contig``.
+
+        Hotspots mark contacts for a designed binder chain, but naming them doesn't tell
+        rfd3 how that chain relates to ``input_structure`` -- ``length`` alone leaves the
+        new chain's composition undefined relative to the input, and rfd3 rejects the spec
+        deep in its own validation (past ours) with "Input provided but unused in
+        composition specification". ``contig`` is what actually states the composition,
+        e.g. ``"A1-1366/0,80-120"`` to keep chain A and add a new 80-120 residue chain.
+        """
+        if self.select_hotspots is not None and self.contig is None:
+            raise ValueError(
+                "'select_hotspots' requires 'contig' to define the designed chain's "
+                "composition relative to 'input_structure' (e.g. 'A1-1366/0,80-120' to "
+                "keep chain A and add a new 80-120 residue binder). 'length' alone doesn't "
+                "state that relationship."
             )
         return self
 

--- a/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
+++ b/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
@@ -374,51 +374,42 @@ class RFdiffusion3DesignSpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_composition_spec(self) -> Any:
-        """Mirror rfd3's own composition rules so a bad spec fails here, not after GPU dispatch.
+        """Mirror rfd3's own composition rules so a bad spec fails here, not after GPU dispatch."""
+        # Upstream ``DesignInputSpecification.validate_input_schema`` (rfd3
+        # ``inference/input_parsing.py``) enforces the four rules below; each otherwise
+        # surfaces only inside the subprocess, after weights load and a real dispatch.
 
-        Upstream ``DesignInputSpecification.validate_input_schema`` (rfd3
-        ``inference/input_parsing.py``) enforces four rules, all of which otherwise surface
-        only inside the subprocess -- after weights load and a real dispatch, with no
-        structures produced. ``select_*`` fields are *not* part of any of them: naming
-        hotspots on a target says nothing about how the design composes with that target,
-        so hotspots alongside a bare ``length`` trips rule 2 like any other unused input.
-        """
         # Rule 1: something must establish what to build. Every other typed field
         # (symmetry, ligand, partial_t, plddt_enhanced, ...) only modifies a composition.
         if self.input_structure is None and self.contig is None and self.length is None:
             raise ValueError(
-                "Provide at least one of 'input_structure', 'contig', or 'length': the "
-                "remaining fields (symmetry, ligand, select_*, plddt_enhanced, ...) modify "
-                "a composition but cannot define one."
+                "Provide at least one of 'input_structure', 'contig', or 'length': the other "
+                "fields modify a composition but cannot define one."
             )
 
-        # Rule 2: an input structure has to be consumed by the composition itself. Only
-        # these four fields place input atoms into the design; select_* fields annotate
-        # atoms that some other field already placed.
+        # Rule 2: an input structure must be consumed by the composition itself. Only these
+        # four fields place input atoms into the design; every select_* field, hotspots
+        # included, merely annotates atoms that one of the four already placed -- naming
+        # hotspots on a target says nothing about how the design composes with that target.
         consumers = ("contig", "unindex", "ligand", "partial_t")
         if self.input_structure is not None and all(getattr(self, f) is None for f in consumers):
             raise ValueError(
-                "'input_structure' is unused: pass one of 'contig', 'unindex', 'ligand', or "
-                "'partial_t' to state how the input enters the design. For binder design use "
-                "a contig such as 'A1-100/0,80-120' (keep chain A, add an 80-120 residue "
-                "binder); 'length' alone describes a chain unrelated to the input, and "
-                "'select_*' fields only annotate atoms placed by those four."
+                "'input_structure' is unused: pass 'contig', 'unindex', 'ligand', or 'partial_t' "
+                "to state how it enters the design (e.g. contig 'A1-100/0,80-120' for a binder)."
             )
 
         if self.partial_t is None:
             # Rule 3: unindexed motifs float inside a design of known extent.
             if self.unindex is not None and self.contig is None and self.length is None:
-                raise ValueError(
-                    "'unindex' requires 'contig' or 'length' to size the design its unindexed motifs are placed into."
-                )
+                raise ValueError("'unindex' requires 'contig' or 'length' to size the design it is placed into.")
         elif self.length is not None:
             # Rule 4: partial diffusion re-noises the input, so its extent is already fixed.
             # Upstream's companion check (partial diffusion requires an input) needs no mirror:
             # rule 1 and ``validate_selections_require_input_structure`` already reject every
             # input-free spec that could reach it.
             raise ValueError(
-                "'length' must not be combined with 'partial_t': partial diffusion "
-                "re-noises 'input_structure', so the design's extent comes from the input."
+                "'length' must not be combined with 'partial_t': partial diffusion re-noises "
+                "'input_structure', so the design's extent comes from the input."
             )
         return self
 

--- a/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
+++ b/proto_tools/tools/structure_design/rfdiffusion3/rfdiffusion3_sample.py
@@ -126,9 +126,7 @@ class RFdiffusion3DesignSpec(BaseModel):
 
         select_hotspots (bool | str | dict[str, str] | None): Atom or residue
             hotspots for binder/PPI design (typically <=4.5 Angstroms to any
-            heavy atom in the designed structure). Requires ``contig`` (not
-            just ``length``) to state how the designed binder relates to
-            ``input_structure``, e.g. ``"A1-1366/0,80-120"``.
+            heavy atom in the designed structure).
 
         symmetry (str | dict[str, Any] | None): Symmetry for homo-oligomer design.
             A group-id string (e.g. ``"C3"``) is wrapped as ``{"id": "C3"}``; a
@@ -219,7 +217,7 @@ class RFdiffusion3DesignSpec(BaseModel):
     select_hotspots: bool | str | dict[str, str] | None = Field(
         default=None,
         title="Hotspots",
-        description="Atom/residue-level hotspots for binder design; requires 'contig', not just 'length'",
+        description="Atom/residue-level hotspots for binder design (True/False, contig string, or dict)",
         examples=["A24,A35,A50"],
     )
     symmetry: str | dict[str, Any] | None = Field(
@@ -375,22 +373,52 @@ class RFdiffusion3DesignSpec(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_hotspots_require_contig(self) -> Any:
-        """Reject ``select_hotspots`` without ``contig``.
+    def validate_composition_spec(self) -> Any:
+        """Mirror rfd3's own composition rules so a bad spec fails here, not after GPU dispatch.
 
-        Hotspots mark contacts for a designed binder chain, but naming them doesn't tell
-        rfd3 how that chain relates to ``input_structure`` -- ``length`` alone leaves the
-        new chain's composition undefined relative to the input, and rfd3 rejects the spec
-        deep in its own validation (past ours) with "Input provided but unused in
-        composition specification". ``contig`` is what actually states the composition,
-        e.g. ``"A1-1366/0,80-120"`` to keep chain A and add a new 80-120 residue chain.
+        Upstream ``DesignInputSpecification.validate_input_schema`` (rfd3
+        ``inference/input_parsing.py``) enforces four rules, all of which otherwise surface
+        only inside the subprocess -- after weights load and a real dispatch, with no
+        structures produced. ``select_*`` fields are *not* part of any of them: naming
+        hotspots on a target says nothing about how the design composes with that target,
+        so hotspots alongside a bare ``length`` trips rule 2 like any other unused input.
         """
-        if self.select_hotspots is not None and self.contig is None:
+        # Rule 1: something must establish what to build. Every other typed field
+        # (symmetry, ligand, partial_t, plddt_enhanced, ...) only modifies a composition.
+        if self.input_structure is None and self.contig is None and self.length is None:
             raise ValueError(
-                "'select_hotspots' requires 'contig' to define the designed chain's "
-                "composition relative to 'input_structure' (e.g. 'A1-1366/0,80-120' to "
-                "keep chain A and add a new 80-120 residue binder). 'length' alone doesn't "
-                "state that relationship."
+                "Provide at least one of 'input_structure', 'contig', or 'length': the "
+                "remaining fields (symmetry, ligand, select_*, plddt_enhanced, ...) modify "
+                "a composition but cannot define one."
+            )
+
+        # Rule 2: an input structure has to be consumed by the composition itself. Only
+        # these four fields place input atoms into the design; select_* fields annotate
+        # atoms that some other field already placed.
+        consumers = ("contig", "unindex", "ligand", "partial_t")
+        if self.input_structure is not None and all(getattr(self, f) is None for f in consumers):
+            raise ValueError(
+                "'input_structure' is unused: pass one of 'contig', 'unindex', 'ligand', or "
+                "'partial_t' to state how the input enters the design. For binder design use "
+                "a contig such as 'A1-100/0,80-120' (keep chain A, add an 80-120 residue "
+                "binder); 'length' alone describes a chain unrelated to the input, and "
+                "'select_*' fields only annotate atoms placed by those four."
+            )
+
+        if self.partial_t is None:
+            # Rule 3: unindexed motifs float inside a design of known extent.
+            if self.unindex is not None and self.contig is None and self.length is None:
+                raise ValueError(
+                    "'unindex' requires 'contig' or 'length' to size the design its unindexed motifs are placed into."
+                )
+        elif self.length is not None:
+            # Rule 4: partial diffusion re-noises the input, so its extent is already fixed.
+            # Upstream's companion check (partial diffusion requires an input) needs no mirror:
+            # rule 1 and ``validate_selections_require_input_structure`` already reject every
+            # input-free spec that could reach it.
+            raise ValueError(
+                "'length' must not be combined with 'partial_t': partial diffusion "
+                "re-noises 'input_structure', so the design's extent comes from the input."
             )
         return self
 

--- a/tests/structure_design_tests/test_rfdiffusion3.py
+++ b/tests/structure_design_tests/test_rfdiffusion3.py
@@ -65,9 +65,10 @@ def test_rfdiffusion3_design_spec_selections_require_input_structure():
     with pytest.raises(ValueError, match=pattern):
         RFdiffusion3DesignSpec(unindex="A244,A274")
 
-    # Happy path 1: input_structure alone with select_*
-    spec = RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), select_hotspots="A24,A35,A50")
-    assert spec.select_hotspots == "A24,A35,A50"
+    # Happy path 1: input_structure alone with a select_* field other than select_hotspots
+    # (select_hotspots additionally requires contig -- see test_rfdiffusion3_hotspots_require_contig).
+    spec = RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), select_buried="A24,A35,A50")
+    assert spec.select_buried == "A24,A35,A50"
 
     # Happy path 2: input_structure + contig + select_* (full motif scaffolding shape)
     spec = RFdiffusion3DesignSpec(
@@ -87,6 +88,31 @@ def test_rfdiffusion3_design_spec_rejects_contig_with_length():
     """Contig and length are mutually exclusive; a contig already encodes its lengths."""
     with pytest.raises(ValueError, match=r"Pass either 'contig' or 'length'"):
         RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), contig="A1-100", length="100")
+
+
+def test_rfdiffusion3_hotspots_require_contig():
+    """select_hotspots + input_structure + length (no contig) is rejected before dispatch.
+
+    Regression: this combination used to pass our validators and reach the rfd3 subprocess,
+    which rejected it deep in its own validation ("Input provided but unused in composition
+    specification") -- a binder-design attempt (hotspots on a fixed target, a free length for
+    the new chain) with no contig stating how the new chain composes with the target.
+    """
+    with pytest.raises(ValueError, match=r"'select_hotspots' requires 'contig'"):
+        RFdiffusion3DesignSpec(
+            input_structure=synthetic_cif(["A"]),
+            length="80-120",
+            select_hotspots="A24,A35,A50",
+        )
+
+    # The fix: a contig stating the composition (keep chain A, add a new binder chain).
+    spec = RFdiffusion3DesignSpec(
+        input_structure=synthetic_cif(["A"]),
+        contig="A1-100/0,80-120",
+        select_hotspots="A24,A35,A50",
+    )
+    assert spec.contig == "A1-100/0,80-120"
+    assert spec.select_hotspots == "A24,A35,A50"
 
 
 def test_rfdiffusion3_config_gamma_0_symmetry_constraint():

--- a/tests/structure_design_tests/test_rfdiffusion3.py
+++ b/tests/structure_design_tests/test_rfdiffusion3.py
@@ -93,12 +93,10 @@ def test_rfdiffusion3_design_spec_rejects_contig_with_length():
 def test_rfdiffusion3_rejects_unused_input():
     """An input_structure no composition field consumes is rejected before dispatch.
 
-    Regression: a live binder-design run (hotspots on a fixed target + a free ``length`` for
-    the new chain, no contig) passed our validators and reached the rfd3 subprocess, which
-    rejected it after a real GPU dispatch with "Input provided but unused in composition
-    specification". Upstream's rule keys on the four fields that consume the input, not on
-    hotspots, so the identical failure occurred for any select_* field -- both shapes below
-    reach the same upstream error and must be caught here.
+    Regression: a live binder-design run (hotspots + a free ``length``, no contig) reached the
+    rfd3 subprocess and failed there with "Input provided but unused in composition
+    specification". Upstream keys that rule on the four consuming fields, not on hotspots, so
+    the select_* variants below hit the identical error and must be caught here too.
     """
     cif = synthetic_cif(["A"])
     pattern = r"'input_structure' is unused"

--- a/tests/structure_design_tests/test_rfdiffusion3.py
+++ b/tests/structure_design_tests/test_rfdiffusion3.py
@@ -93,10 +93,10 @@ def test_rfdiffusion3_design_spec_rejects_contig_with_length():
 def test_rfdiffusion3_rejects_unused_input():
     """An input_structure no composition field consumes is rejected before dispatch.
 
-    Regression: a live binder-design run (hotspots + a free ``length``, no contig) reached the
-    rfd3 subprocess and failed there with "Input provided but unused in composition
-    specification". Upstream keys that rule on the four consuming fields, not on hotspots, so
-    the select_* variants below hit the identical error and must be caught here too.
+    Regression: a live binder-design run (hotspots + a free ``length``, no contig) passed our
+    validators and was rejected by rfd3's own prevalidation instead, after a GPU dispatch that
+    produced nothing. Upstream keys that rule on the four consuming fields rather than on
+    hotspots, so the select_* variants below fail the same way and must be caught here too.
     """
     cif = synthetic_cif(["A"])
     pattern = r"'input_structure' is unused"

--- a/tests/structure_design_tests/test_rfdiffusion3.py
+++ b/tests/structure_design_tests/test_rfdiffusion3.py
@@ -65,9 +65,9 @@ def test_rfdiffusion3_design_spec_selections_require_input_structure():
     with pytest.raises(ValueError, match=pattern):
         RFdiffusion3DesignSpec(unindex="A244,A274")
 
-    # Happy path 1: input_structure alone with a select_* field other than select_hotspots
-    # (select_hotspots additionally requires contig -- see test_rfdiffusion3_hotspots_require_contig).
-    spec = RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), select_buried="A24,A35,A50")
+    # Happy path 1: input_structure + select_* with no contig, using 'ligand' to consume the
+    # input (a select_* field cannot consume it -- see test_rfdiffusion3_rejects_unused_input).
+    spec = RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), ligand="HAX", select_buried="A24,A35,A50")
     assert spec.select_buried == "A24,A35,A50"
 
     # Happy path 2: input_structure + contig + select_* (full motif scaffolding shape)
@@ -90,29 +90,61 @@ def test_rfdiffusion3_design_spec_rejects_contig_with_length():
         RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), contig="A1-100", length="100")
 
 
-def test_rfdiffusion3_hotspots_require_contig():
-    """select_hotspots + input_structure + length (no contig) is rejected before dispatch.
+def test_rfdiffusion3_rejects_unused_input():
+    """An input_structure no composition field consumes is rejected before dispatch.
 
-    Regression: this combination used to pass our validators and reach the rfd3 subprocess,
-    which rejected it deep in its own validation ("Input provided but unused in composition
-    specification") -- a binder-design attempt (hotspots on a fixed target, a free length for
-    the new chain) with no contig stating how the new chain composes with the target.
+    Regression: a live binder-design run (hotspots on a fixed target + a free ``length`` for
+    the new chain, no contig) passed our validators and reached the rfd3 subprocess, which
+    rejected it after a real GPU dispatch with "Input provided but unused in composition
+    specification". Upstream's rule keys on the four fields that consume the input, not on
+    hotspots, so the identical failure occurred for any select_* field -- both shapes below
+    reach the same upstream error and must be caught here.
     """
-    with pytest.raises(ValueError, match=r"'select_hotspots' requires 'contig'"):
-        RFdiffusion3DesignSpec(
-            input_structure=synthetic_cif(["A"]),
-            length="80-120",
-            select_hotspots="A24,A35,A50",
-        )
+    cif = synthetic_cif(["A"])
+    pattern = r"'input_structure' is unused"
 
-    # The fix: a contig stating the composition (keep chain A, add a new binder chain).
-    spec = RFdiffusion3DesignSpec(
-        input_structure=synthetic_cif(["A"]),
-        contig="A1-100/0,80-120",
-        select_hotspots="A24,A35,A50",
-    )
+    with pytest.raises(ValueError, match=pattern):
+        RFdiffusion3DesignSpec(input_structure=cif, length="80-120", select_hotspots="A24,A35,A50")
+    with pytest.raises(ValueError, match=pattern):
+        RFdiffusion3DesignSpec(input_structure=cif, length="80-120", select_buried="A24")
+    with pytest.raises(ValueError, match=pattern):
+        RFdiffusion3DesignSpec(input_structure=cif, select_buried="A24")
+
+    # Each of the four consuming fields makes the same hotspot spec valid.
+    spec = RFdiffusion3DesignSpec(input_structure=cif, contig="A1-100/0,80-120", select_hotspots="A24")
     assert spec.contig == "A1-100/0,80-120"
-    assert spec.select_hotspots == "A24,A35,A50"
+    assert RFdiffusion3DesignSpec(input_structure=cif, partial_t=10.0, select_hotspots="A24").partial_t == 10.0
+    assert RFdiffusion3DesignSpec(input_structure=cif, ligand="HAX", select_hotspots="A24").ligand == "HAX"
+    assert RFdiffusion3DesignSpec(input_structure=cif, unindex="A24", length="80-120").unindex == "A24"
+
+
+def test_rfdiffusion3_rejects_spec_with_no_composition_field():
+    """Modifier-only specs (no input_structure, contig, or length) are rejected."""
+    pattern = r"at least one of 'input_structure', 'contig', or 'length'"
+    with pytest.raises(ValueError, match=pattern):
+        RFdiffusion3DesignSpec(symmetry="C3")
+    with pytest.raises(ValueError, match=pattern):
+        RFdiffusion3DesignSpec(plddt_enhanced=True)
+
+
+def test_rfdiffusion3_unindex_requires_contig_or_length():
+    """Unindexed motifs need a contig or length to size the design they float inside."""
+    with pytest.raises(ValueError, match=r"'unindex' requires 'contig' or 'length'"):
+        RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), unindex="A24", ligand="HAX")
+
+
+def test_rfdiffusion3_partial_diffusion_constraints():
+    """partial_t re-noises the input, so it forbids length."""
+    with pytest.raises(ValueError, match=r"'length' must not be combined with 'partial_t'"):
+        RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), length="100", partial_t=10.0)
+    # partial_t alone never reaches the partial-diffusion branch: it states no composition,
+    # so the first rule rejects it (upstream orders its own checks the same way).
+    with pytest.raises(ValueError, match=r"at least one of 'input_structure', 'contig', or 'length'"):
+        RFdiffusion3DesignSpec(partial_t=10.0)
+
+    # partial_t == 0.0 is a legal noise level, not an absent one.
+    spec = RFdiffusion3DesignSpec(input_structure=synthetic_cif(["A"]), partial_t=0.0)
+    assert spec.partial_t == 0.0
 
 
 def test_rfdiffusion3_config_gamma_0_symmetry_constraint():
@@ -378,7 +410,7 @@ def test_rfdiffusion3_json_spec_generation(tmp_path, monkeypatch):
 def test_rfdiffusion3_input_structure_accepts_structure_object(tmp_path):
     """A Structure object is materialized to a file; "input" is that path (rfd3 needs a path, not content)."""
     structure = Structure(structure=synthetic_cif(["A"]))
-    inputs = RFdiffusion3Input(design_specs=[RFdiffusion3DesignSpec(input_structure=structure, length="40")])
+    inputs = RFdiffusion3Input(design_specs=[RFdiffusion3DesignSpec(input_structure=structure, contig="A1-1/0,40")])
     spec = json.loads(inputs.to_json_spec(input_dir=tmp_path))
     input_path = Path(spec["spec-0"]["input"])
     assert input_path.is_file() and input_path.suffix == ".cif"  # synthetic_cif → cif format


### PR DESCRIPTION
## Summary

Live run failure: `select_hotspots` + `input_structure` + `length` (no `contig`) passed this wrapper's own validators, then reached the rfd3 subprocess and failed there with `Input provided but unused in composition specification` — after a real GPU dispatch, with no structures produced.

That error is not about hotspots. Upstream rfd3 0.2.0 (`DesignInputSpecification.validate_input_schema`, `rfd3/inference/input_parsing.py`) enforces four composition rules, and `select_*` fields appear in none of them:

1. one of `input`/`contig`/`length` must be present;
2. an `input` must be consumed by `contig`, `unindex`, `ligand`, or `partial_t`;
3. outside partial diffusion, `unindex` needs `contig` or `length`;
4. under partial diffusion, `length` is forbidden.

So this PR mirrors all four in `validate_composition_spec` rather than keying on `select_hotspots`. A hotspots-specific rule was wrong in both directions: it rejected valid specs (`hotspots` + `partial_t` — and since rule 4 forbids `length` there, partial-diffusion binder runs were left with no legal spec; also `hotspots` + `ligand`, and an explicit `select_hotspots=False`, which trips an `is not None` check) while still passing to dispatch the identical failure under a different field, e.g. `input_structure` + `length` + `select_buried`.

Two existing tests asserted specs upstream rejects and are corrected to valid compositions: `test_rfdiffusion3_input_structure_accepts_structure_object` (`input_structure` + `length`) and "happy path 1" in `test_rfdiffusion3_design_spec_selections_require_input_structure`.

## Test plan

- [x] **Differential test against the installed rfd3.** All 512 combinations of `input_structure`/`contig`/`length`/`unindex`/`ligand`/`partial_t`/`select_hotspots`/`select_buried`/`symmetry` run through both this wrapper and upstream `validate_input_schema`. Specs accepted here that rfd3 rejects: **0** (75 on `main`, 43 with this PR's first commit). The 124 stricter-than-upstream rejections all come from pre-existing rules (`select_*`/`contig`/`unindex` require `input_structure`; `contig` XOR `length`), and fail fast rather than at dispatch.
- [x] `pytest tests/structure_design_tests/test_rfdiffusion3.py` — 26 passed, 3 failed, 1 skipped. The 3 failures are pre-existing on `main` (local pydantic 2.11.9 lacks `model_dump(exclude_computed_fields=...)`).
- [x] `pytest tests/ -m "not integration"` (full suite) — 12280 passed, 682 failed; the failing set is **identical to `main`** (685 `FAILED` lines, `comm` diff empty in both directions), same pydantic cause.
- [x] `pytest tests/style_consistency_tests` — clean, including the field-description length limit.
- [x] `ruff check` / `ruff format` clean; `mypy` error set identical to `main`, none in the touched files.
- [x] Docstring examples, `examples/example.ipynb` (`length="100"`), and the modal service all remain valid; `select_hotspots` has no other call site.

Still not mirrored (pre-existing, out of scope): the wrapper's `contig` XOR `length` rule is stricter than upstream, which accepts both together.
