### PR TITLE
fix(dssp): pin compatible libmcfp ABI

### DIFF
--- a/proto_tools/tools/structure_scoring/dssp/standalone/setup.sh
+++ b/proto_tools/tools/structure_scoring/dssp/standalone/setup.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 echo "Setting up DSSP standalone environment..."
 
 echo "Installing DSSP binary from conda-forge..."
-"$MAMBA_BIN" install -y -p "$VENV_PATH" -c conda-forge dssp
+# DSSP 4.6.1 is built against the libmcfp 1.4.2 ABI. libmcfp 2.x is not
+# binary-compatible and makes mkdssp fail at startup with an undefined symbol.
+"$MAMBA_BIN" install -y -p "$VENV_PATH" -c conda-forge "dssp=4.6.1" "libmcfp=1.4.2"
 
 echo "Installing uv package manager..."
 pip install uv
@@ -15,10 +17,14 @@ uv pip install -r requirements.txt
 echo "Verifying DSSP installation..."
 python - <<'PY'
 import shutil
+import subprocess
+
 from Bio.PDB.DSSP import DSSP  # noqa: F401
 
-if not (shutil.which("mkdssp") or shutil.which("dssp")):
+executable = shutil.which("mkdssp") or shutil.which("dssp")
+if not executable:
     raise SystemExit("DSSP binary not found on PATH")
+subprocess.run([executable, "--version"], check=True)
 print("DSSP OK")
 PY
 

--- a/tests/structure_scoring_tests/test_dssp.py
+++ b/tests/structure_scoring_tests/test_dssp.py
@@ -23,6 +23,16 @@ FIXTURE = (
     Path(__file__).resolve().parents[2]
     / "proto_tools/tools/structure_scoring/structure_metrics/example_input_fixture.pdb"
 )
+_SETUP_SH = Path(__file__).resolve().parents[2] / "proto_tools/tools/structure_scoring/dssp/standalone/setup.sh"
+
+
+def test_dssp_setup_pins_abi_compatible_packages_and_executes_binary() -> None:
+    """The standalone env must keep DSSP on its build-time libmcfp ABI."""
+    setup = _SETUP_SH.read_text()
+
+    assert '"dssp=4.6.1"' in setup
+    assert '"libmcfp=1.4.2"' in setup
+    assert 'subprocess.run([executable, "--version"], check=True)' in setup
 
 
 def test_dssp_tool_is_registered() -> None:


### PR DESCRIPTION
## Summary

- pin DSSP 4.6.1 with its build-time-compatible libmcfp 1.4.2 dependency
- execute mkdssp --version during standalone setup so shared-library ABI failures abort at provisioning time
- add a regression test covering both the compatible package pins and executable smoke test

## Problem

The unconstrained conda-forge DSSP install can resolve DSSP 4.6.1 alongside ABI-incompatible libmcfp 2.x. mkdssp then crashes during Modal warmup with an undefined C++ symbol before Biopython can inspect its version.

## Test plan

- [x] pytest -q tests/structure_scoring_tests/test_dssp.py -m "not slow"
- [x] pytest -q tests/style_consistency_tests/ (8,728 passed; 707 skipped)
- [x] bash -n proto_tools/tools/structure_scoring/dssp/standalone/setup.sh
- [x] ruff check and ruff format --check on the changed test