### PR TITLE
Expose ESM-IF1 scoring logits

### DIFF
--- a/proto_tools/tools/inverse_folding/esm_if1/README.md
+++ b/proto_tools/tools/inverse_folding/esm_if1/README.md
@@ -50,6 +50,7 @@ Use this to rank candidate sequences or assess point mutations by structural com
 
 #### Usage Tips
 - **Lower perplexity is better, and it tracks the log-likelihood directly.** Perplexity is `exp(-avg_log_likelihood)`, so the two metrics rank candidates identically. Treat the score as compatibility under the model, not a guarantee the sequence folds, and confirm shortlisted candidates with a structure predictor.
+- **`return_logits` (default `False`) enables one-pass variant analysis.** When enabled, scoring also returns a `(target chain length x 20)` logit array and its canonical amino-acid vocabulary. The logits come from the same teacher-forced forward pass as the scalar score; leave them disabled when only aggregate metrics are needed to reduce response size.
 
 ## Toolkit Notes
 

--- a/proto_tools/tools/inverse_folding/esm_if1/esm_if1_score.py
+++ b/proto_tools/tools/inverse_folding/esm_if1/esm_if1_score.py
@@ -129,6 +129,7 @@ class ESMIF1ScoringConfig(BaseConfig):
     Attributes:
         weights_variant (Literal['esmif', 'protein_dpo']): Which model weights to use. 'esmif' loads vanilla ESM-IF1,
             'protein_dpo' loads DPO-aligned weights optimized for protein stability.
+        return_logits (bool): Whether to include per-position amino-acid logits.
         device (str): Device to run the model on.
     """
 
@@ -138,6 +139,12 @@ class ESMIF1ScoringConfig(BaseConfig):
         description="'esmif' for vanilla ESM-IF1, 'protein_dpo' for DPO-aligned weights",
         reload_on_change=True,
         examples=["esmif", "protein_dpo"],
+    )
+
+    return_logits: bool = ConfigField(
+        title="Return Logits",
+        default=False,
+        description="Whether to include per-position amino-acid logits in the output.",
     )
 
     device: str = ConfigField(
@@ -235,6 +242,7 @@ def run_esm_if1_score(
                 "seed": config.seed,
                 "device": config.device,
                 "weights_variant": config.weights_variant,
+                "return_logits": config.return_logits,
                 "verbose": config.verbose,
             }
             result = ToolInstance.dispatch(
@@ -243,7 +251,13 @@ def run_esm_if1_score(
                 instance=instance,
                 config=config,
             )
-        scores.append(InverseFoldingScoringMetrics(**result["metrics"]))
+        scores.append(
+            InverseFoldingScoringMetrics(
+                **result["metrics"],
+                logits=result["logits"],
+                vocab=result["vocab"],
+            )
+        )
 
     return ESMIF1ScoringOutput(scores=scores)
 

--- a/proto_tools/tools/inverse_folding/esm_if1/standalone/inference.py
+++ b/proto_tools/tools/inverse_folding/esm_if1/standalone/inference.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import torch
 from standalone_helpers import (
+    AMINO_ACIDS_LIST,
     get_logger,
     log_likelihood_metrics,
     move_model_to_device,
@@ -223,6 +224,7 @@ class ESMIF1Model:
         seed: int | None = None,
         device: str = "cuda",
         weights_variant: str = "protein_dpo",
+        return_logits: bool = False,
         verbose: bool = False,
     ) -> dict[str, Any]:
         """Score a sequence against a structure using the score_complex approach.
@@ -240,31 +242,67 @@ class ESMIF1Model:
             seed: Random seed.
             device: Device to run on.
             weights_variant: 'esmif' for vanilla or 'protein_dpo' for DPO weights.
+            return_logits: Whether to return canonical amino-acid logits for each position.
             verbose: Whether to print status messages.
 
         Returns:
-            Dictionary with keys: metrics (dict of scalar metrics)
+            Dictionary with keys: metrics, logits, and vocab. ``logits`` has
+            shape ``(sequence_length, 20)`` when requested and is otherwise
+            ``None``; ``vocab`` gives its canonical amino-acid column order.
         """
         if not self._loaded or self._weights_variant != weights_variant:
             self.load(device, weights_variant, verbose)
         elif self.device != device:
             self.to_device(device)
 
-        import esm.inverse_folding.multichain_util
+        import torch.nn.functional as F
+        from esm.inverse_folding.multichain_util import _concatenate_coords
+        from esm.inverse_folding.util import CoordBatchConverter
 
         all_coords, _all_native_seqs, target_chain = self._load_structure(pdb_path, chain_ids, target_chain)
 
         set_torch_seed(seed)
-        # Score the sequence in the complex context
-        avg_ll, _ = esm.inverse_folding.multichain_util.score_sequence_in_complex(
-            self.model,
-            self.alphabet,
-            all_coords,
-            target_chain,
-            sequence,
+        # ESM-IF1 places the target chain first and appends the remaining chains
+        # as encoder-only structural context.  Run the same teacher-forced
+        # forward pass used by fair-esm's score_sequence_in_complex(), retaining
+        # its logits rather than discarding them after cross-entropy.
+        coords = _concatenate_coords(all_coords, target_chain)
+        batch_converter = CoordBatchConverter(self.alphabet)
+        coords_tensor, confidence, _strs, tokens, padding_mask = batch_converter(
+            [(coords, None, sequence)],
+            device=self.device,
         )
+        prev_output_tokens = tokens[:, :-1]
+        target = tokens[:, 1:]
+        target_padding_mask = target == self.alphabet.padding_idx
 
-        return {"metrics": log_likelihood_metrics(float(avg_ll), len(sequence))}
+        with torch.no_grad():
+            raw_logits, _ = self.model.forward(
+                coords_tensor,
+                padding_mask,
+                confidence,
+                prev_output_tokens,
+            )
+            losses = F.cross_entropy(raw_logits, target, reduction="none")[0]
+            valid_positions = ~target_padding_mask[0]
+            avg_ll = -losses[valid_positions].mean().item()
+
+            logits = None
+            if return_logits:
+                # Model output is (batch, vocab, position).  Expose only the
+                # canonical amino-acid columns, matching the other ESM tools.
+                aa_token_ids = torch.tensor(
+                    [self.alphabet.get_idx(aa) for aa in AMINO_ACIDS_LIST],
+                    device=raw_logits.device,
+                )
+                position_logits = raw_logits[0, :, : len(sequence)].transpose(0, 1)
+                logits = position_logits.index_select(1, aa_token_ids).float().cpu().tolist()
+
+        return {
+            "metrics": log_likelihood_metrics(avg_ll, len(sequence)),
+            "logits": logits,
+            "vocab": AMINO_ACIDS_LIST if return_logits else None,
+        }
 
     def load(
         self,
@@ -371,6 +409,7 @@ def dispatch(input_dict: dict[str, Any]) -> dict[str, Any]:
             seed=input_dict["seed"],
             device=input_dict["device"],
             weights_variant=input_dict["weights_variant"],
+            return_logits=input_dict.get("return_logits", False),
             verbose=input_dict["verbose"],
         )
     raise ValueError(f"esm-if1: unknown operation {operation!r}; valid: ['sample', 'score']")

--- a/tests/inverse_folding_tests/test_esm_if1.py
+++ b/tests/inverse_folding_tests/test_esm_if1.py
@@ -28,6 +28,7 @@ from proto_tools.tools.inverse_folding.shared_data_models import (
     InverseFoldingScoringMetrics,
     InverseFoldingStructureInput,
 )
+from proto_tools.utils.sequence import PROTEIN_AMINO_ACIDS
 from tests.conftest import benchmark_twice, make_persistent_fixture, random_protein_sequences
 from tests.tool_infra_tests._metric_helpers import assert_metrics_in_spec
 from tests.tool_infra_tests.test_export_functionality import validate_output
@@ -244,6 +245,48 @@ def test_esm_if1_score(pdb_structure: Structure):
     assert output.tool_id == "esm-if1-score"
     assert len(output.scores) == 1
     assert isinstance(output.scores[0], InverseFoldingScoringMetrics)
+    assert output.scores[0].logits is None
+    assert output.vocab is None
+
+
+def test_esm_if1_score_logits_dispatch_contract(monkeypatch, pdb_structure: Structure):
+    """The wrapper requests and preserves one-pass canonical amino-acid logits."""
+    sequence = pdb_structure.get_chain_sequence("A")
+    captured = {}
+    vocab = list(PROTEIN_AMINO_ACIDS)
+
+    def fake_dispatch(toolkit, payload, *, instance=None, config=None):
+        captured["toolkit"] = toolkit
+        captured["payload"] = payload
+        return {
+            "metrics": {
+                "log_likelihood": -float(len(sequence)),
+                "avg_log_likelihood": -1.0,
+                "perplexity": float(np.e),
+            },
+            "logits": [[0.0] * len(vocab) for _ in sequence],
+            "vocab": vocab,
+        }
+
+    monkeypatch.setattr(
+        "proto_tools.tools.inverse_folding.esm_if1.esm_if1_score.ToolInstance.dispatch",
+        fake_dispatch,
+    )
+
+    output = run_esm_if1_score(
+        ESMIF1ScoringInput(
+            sequence_structure_pairs=[
+                ESMIF1ScoringPair(sequence=sequence, structure=pdb_structure),
+            ]
+        ),
+        ESMIF1ScoringConfig(device="cpu", return_logits=True),
+    )
+
+    assert captured["toolkit"] == "esm_if1"
+    assert captured["payload"]["return_logits"] is True
+    assert output.vocab == vocab
+    assert output.scores[0].logits is not None
+    assert np.asarray(output.scores[0].logits).shape == (len(sequence), len(vocab))
 
 
 @pytest.mark.uses_gpu
@@ -256,12 +299,17 @@ def test_esm_if1_score_fields(pdb_structure: Structure):
             ESMIF1ScoringPair(sequence=original_sequence, structure=pdb_structure),
         ]
     )
-    config = ESMIF1ScoringConfig()
+    config = ESMIF1ScoringConfig(return_logits=True)
     output = run_esm_if1_score(inp, config)
     assert output.success
     assert_metrics_in_spec(output)
 
     score = output.scores[0]
+
+    # Canonical amino-acid logits come from the same teacher-forced pass.
+    assert output.vocab == list(PROTEIN_AMINO_ACIDS)
+    assert score.logits is not None
+    assert np.asarray(score.logits).shape == (len(original_sequence), len(PROTEIN_AMINO_ACIDS))
 
     # Value range checks
     assert score.avg_log_likelihood <= 0


### PR DESCRIPTION
## Summary
- expose an opt-in `return_logits` config for ESM-IF1/ProteinDPO scoring
- retain canonical 20-amino-acid logits from the existing teacher-forced forward pass
- return an L x 20 matrix and vocabulary only when requested
- document and test default/null and enabled behavior

## Correctness
- CPU comparison on a 340-residue structure matched fair-esm's reference average log-likelihood within 2.7e-7
- verified a 340 x 20 output with canonical vocabulary
- uses `torch.no_grad()` so persistent model caches remain reusable across mixed operations

## Tests
- 751 targeted config/schema/unit tests passed; 1 unrelated platform skip
- real ProteinDPO logits integration test passed on GPU
- ruff and format checks passed