### PR TITLE
Three Genomic Intelligence fixes that missed the #83 merge

### DIFF
--- a/proto_tools/tools/sequence_scoring/genomic_intelligence/shared_data_models.py
+++ b/proto_tools/tools/sequence_scoring/genomic_intelligence/shared_data_models.py
@@ -34,6 +34,7 @@ from proto_tools.utils import (
     build_http_session,
     get_logger,
     poll_until_complete,
+    request_with_retry,
 )
 
 logger = get_logger(__name__)
@@ -628,11 +629,15 @@ def _post(
             :func:`_job_status` when the job completes.
     """
     headers = {"Prefer": "respond-async"} if config.respond_async else {}
-    response = session.post(
-        f"{resolve_base_url()}/{_API_VERSION}/{path.lstrip('/')}",
-        json=body,
-        headers=headers,
-        timeout=_REQUEST_TIMEOUT_SECONDS,
+    response = request_with_retry(
+        lambda: session.post(
+            f"{resolve_base_url()}/{_API_VERSION}/{path.lstrip('/')}",
+            json=body,
+            headers=headers,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        ),
+        retries=_HTTP_RETRIES,
+        backoff_seconds=_BACKOFF_SECONDS,
     )
     raise_for_gi_error(response)
     payload: dict[str, Any] = require_envelope(response)

--- a/proto_tools/tools/sequence_scoring/genomic_intelligence/shared_data_models.py
+++ b/proto_tools/tools/sequence_scoring/genomic_intelligence/shared_data_models.py
@@ -52,6 +52,9 @@ _DEFAULT_POLL_INTERVAL_SECONDS = 5.0
 _MAX_BP = 500_000
 """Upper bound shared by every endpoint, published as ``maxLength``."""
 
+_GI_ALPHABET = frozenset("ACGNT")
+"""The characters every predict schema's published ``sequence.pattern`` accepts."""
+
 GITask = Literal["promoter", "splice", "enhancer", "chromatin", "annotation", "expression"]
 
 _MISSING_KEY_MESSAGE = (
@@ -369,6 +372,17 @@ def validate_gi_sequence(sequence: str, *, min_bp: int, task: str) -> str:
     # reports it as an invalid nucleotide character and refuses a sequence the
     # service would have scored.
     cleaned = validate_dna_sequence("".join(sequence.split()))
+    # The shared validator allows RNA, so it accepts U. The published request
+    # schemas do not: every predict operation carries
+    # ^\s*(?:[ACGNTacgnt]\s*)+$, and the service rejects a U with a 422 naming
+    # the character. Narrow the shared result to the alphabet this API accepts
+    # so the refusal is local rather than a round trip.
+    outside = sorted({character for character in cleaned if character not in _GI_ALPHABET})
+    if outside:
+        raise ValueError(
+            f"{task}: sequence contains characters the endpoint does not accept: {outside}. "
+            f"The published request schema allows {''.join(sorted(_GI_ALPHABET))} only."
+        )
     length = len(cleaned)
     if length < min_bp:
         raise ValueError(

--- a/tests/sequence_scoring_tests/test_genomic_intelligence.py
+++ b/tests/sequence_scoring_tests/test_genomic_intelligence.py
@@ -567,6 +567,28 @@ class _FakeSession:
         self.closed = True
 
 
+class _ResetThenOkSession:
+    """A session whose ``post`` mimics a reused keep-alive connection the server already closed."""
+
+    def __init__(self, failures: int, post: _FakeResponse) -> None:
+        self.failures = failures
+        self._post = post
+        self.calls = 0
+        self.headers: dict[str, str] = {}
+        self.closed = False
+
+    def post(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "Connection aborted.", ConnectionResetError(104, "Connection reset by peer")
+            )
+        return self._post
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def _install_session(
     monkeypatch: pytest.MonkeyPatch,
     post: _FakeResponse,
@@ -586,6 +608,27 @@ _BAD_SUMMARY_PAYLOAD: dict[str, Any] = {"data": {**_GOOD_DATA, "summary": "all g
 def _predict(config: GIConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     """Issue one promoter predict call through the shared client."""
     return call_predict(config, "promoter", "ATGC" * 100, "demo")
+
+
+def test_predict_submission_retries_a_connection_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The same reused-connection failure the other fetch tools retry, here on the predict submission.
+
+    ``build_http_session``'s adapter does not cover this: a server closing a pooled
+    keep-alive connection raises ``ConnectionResetError`` while urllib3 is *sending*
+    the next request on it, which surfaces above the adapter as a
+    ``requests.exceptions.ConnectionError``. Retrying the submission is safe for the
+    same reason it is safe for the other job-creating POSTs in this repo -- the
+    request never reached the server, so no job was created.
+    """
+    monkeypatch.setattr(shared_data_models, "_BACKOFF_SECONDS", 0.0)
+    session = _ResetThenOkSession(failures=2, post=_FakeResponse(200, {"data": _GOOD_DATA, "meta": _META}))
+    monkeypatch.setattr(shared_data_models, "_build_session", lambda _config: session)
+
+    data, _payload = _predict(GIConfig(gi_api_key="gi_test"))
+
+    assert data == _GOOD_DATA
+    assert session.calls == 3
+    assert session.closed
 
 
 class TestTheEnvelopeIsRequired:

--- a/tests/sequence_scoring_tests/test_genomic_intelligence.py
+++ b/tests/sequence_scoring_tests/test_genomic_intelligence.py
@@ -369,6 +369,25 @@ def test_invalid_nucleotides_are_rejected() -> None:
         validate_gi_sequence("ACGTZZZZ" * 100, min_bp=50, task="enhancer")
 
 
+def test_rna_uracil_is_rejected_locally() -> None:
+    r"""The shared validator allows U; these endpoints do not, so the gate narrows it.
+
+    Every predict schema publishes ``^\s*(?:[ACGNTacgnt]\s*)+$`` and the service
+    answers a U with a 422 naming the character. Refusing it here keeps an RNA paste
+    from costing a round trip.
+    """
+    with pytest.raises(ValueError, match=r"does not accept: \['U'\]"):
+        validate_gi_sequence("ACGU" * 100, min_bp=50, task="enhancer")
+
+
+def test_the_gate_accepts_exactly_the_published_alphabet() -> None:
+    """Case and wrapping are accepted, N is accepted, and nothing else is."""
+    assert validate_gi_sequence("acg tn\nACGTN" * 20, min_bp=50, task="enhancer") == "ACGTNACGTN" * 20
+    for character in "URYKMSWBDHV-":
+        with pytest.raises(ValueError):
+            validate_gi_sequence(("ACGT" * 25) + character, min_bp=50, task="enhancer")
+
+
 def test_bare_string_is_coerced_to_one_sequence() -> None:
     """Every task input accepts a bare DNA string in place of a list."""
     for input_class in (GIPromoterInput, GISpliceInput, GIEnhancerInput, GIChromatinInput, GIAnnotationInput):

--- a/tests/sequence_scoring_tests/test_genomic_intelligence.py
+++ b/tests/sequence_scoring_tests/test_genomic_intelligence.py
@@ -893,8 +893,13 @@ class TestTheCallerSeesTheRefusal:
 
 # ============================================================================
 # Integration — live API, skipped unless pytest runs with --integration
-# (in CI, the run-integration label)
 # ============================================================================
+#
+# The `run-integration` label starts Integration Tests, which runs pytest with
+# --integration, so these two cases are selected there. They still skip: that
+# workflow sets no GI_API_KEY, and a pull request from a fork is not given
+# repository secrets in any case. Running them for real means a local run with
+# a key in the environment.
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Three small fixes to the Genomic Intelligence toolkit that were reviewed on later revisions of #83 but were not on the branch that got merged. The sequence gate now rejects U locally, because the shared DNA validator allows RNA while every Genomic Intelligence predict schema publishes an ACGNT-only pattern and the service answers a U with a 422. The predict submission now goes through request_with_retry, which #84 and #93 applied to every other HTTP call in the repo while #83 was open, so a server closing a pooled keep-alive connection is retried instead of surfacing as a ConnectionError. The last one is a comment fix: the integration header said the two live cases run under the run-integration label, but that workflow sets no GI_API_KEY and a fork PR gets no secrets, so they are selected and then skipped.

All seven tools were run once against the production API from a clean install of this branch's base before opening this, and the module suite is 60 passed, 9 skipped with ruff and mypy clean.